### PR TITLE
BXC-3248 - Add check to verify that all of the listed successful jobs are valid

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/work/DepositFailedException.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/work/DepositFailedException.java
@@ -20,10 +20,10 @@ package edu.unc.lib.boxc.deposit.work;
  * @author count0
  *
  */
-public class DepositFailedException extends Throwable {
+public class DepositFailedException extends RuntimeException {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -4818301461775253637L;
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3248

* Add check to verify that all of the listed successful jobs are valid jobs, to force regeneration or modification of deposit jobs in the case of classes being renamed so that jobs don't get run multiple times.
* Make DepositFailedException into a RuntimeException rather than a Throwable so it can be handled more normally.