### PR TITLE
BXC-3255 - Add option for excluding objects without mods from export

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
@@ -35,6 +35,7 @@ public class ExportXMLRequest {
     private Instant requestedTimestamp;
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
+    private boolean excludeNoDatastreams;
 
     public ExportXMLRequest() {
     }
@@ -83,5 +84,16 @@ public class ExportXMLRequest {
 
     public void setAgent(AgentPrincipals agent) {
         this.agent = agent;
+    }
+
+    /**
+     * @return True if objects which return no datastreams should be excluded from the export
+     */
+    public boolean getExcludeNoDatastreams() {
+        return excludeNoDatastreams;
+    }
+
+    public void setExcludeNoDatastreams(boolean excludeNoDatastreams) {
+        this.excludeNoDatastreams = excludeNoDatastreams;
     }
 }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractQueryService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractQueryService.java
@@ -182,7 +182,7 @@ public abstract class AbstractQueryService {
      * @param fieldKey
      * @return
      */
-    protected String solrField(SearchFieldKey fieldKey) {
+    public String solrField(SearchFieldKey fieldKey) {
         return solrSettings.getFieldName(fieldKey.name());
     }
 

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -279,7 +279,15 @@ public class SolrSearchService extends AbstractQueryService {
 
     public ContentObjectRecord addSelectedContainer(PID containerPid, SearchState searchState,
             boolean applyCutoffs, AccessGroupSet principals) {
-        ContentObjectRecord selectedContainer = getObjectById(new SimpleIdRequest(containerPid, principals));
+        List<String> fields = null;
+        if (searchState.getResultFields() != null) {
+            fields = new ArrayList<>(searchState.getResultFields());
+            if (!fields.contains(SearchFieldKey.ANCESTOR_PATH.name())) {
+                fields.add(SearchFieldKey.ANCESTOR_PATH.name());
+            }
+        }
+
+        ContentObjectRecord selectedContainer = getObjectById(new SimpleIdRequest(containerPid, fields, principals));
         if (selectedContainer == null) {
             return null;
         }
@@ -301,7 +309,7 @@ public class SolrSearchService extends AbstractQueryService {
      * @param isRetrieveFacetsRequest
      * @return
      */
-    protected SolrQuery generateSearch(SearchRequest searchRequest) {
+    public SolrQuery generateSearch(SearchRequest searchRequest) {
         SearchState searchState = searchRequest.getSearchState();
         SolrQuery solrQuery = new SolrQuery();
         StringBuilder termQuery = new StringBuilder();
@@ -577,7 +585,7 @@ public class SolrSearchService extends AbstractQueryService {
      * @throws SolrServerException
      */
     @SuppressWarnings("unchecked")
-    protected SearchResultResponse executeSearch(SolrQuery query, SearchState searchState,
+    public SearchResultResponse executeSearch(SolrQuery query, SearchState searchState,
             boolean isRetrieveFacetsRequest, boolean returnQuery) throws SolrServerException {
         QueryResponse queryResponse = executeQuery(query);
 

--- a/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
+++ b/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
@@ -57,6 +57,7 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 		this.$form.submit(function(e){
 			var email = $("#xml_recipient_email", self.$form).val();
 			var includeChildren = $("#export_xml_include_children", self.$form).prop("checked");
+			var excludeNoDs = $("#export_xml_exclude_no_datastreams", self.$form).prop("checked");
 			
 			if (!email || !$.trim(email)) {
 				return false;
@@ -76,7 +77,8 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 				data : JSON.stringify({
 					email : email,
 					pids : pids,
-					exportChildren: includeChildren || false
+					exportChildren: includeChildren || false,
+					excludeNoDatastreams: excludeNoDs || false
 				})
 			}).done(function(response) {
 				self.context.view.$alertHandler.alertHandler("message", response.message);

--- a/static/templates/admin/exportMetadataForm.html
+++ b/static/templates/admin/exportMetadataForm.html
@@ -9,6 +9,8 @@
 	
 	<label class="form_inline"><input type="checkbox" id="export_xml_include_children" checked="checked"> Include metadata for all items contained within the selected object(s).</label>
 
+	<label class="form_inline"><input type="checkbox" id="export_xml_exclude_no_datastreams"> Exclude objects with no returned datastreams.</label>
+
 	<div class="update_field">
 		<input type="submit" id="export_xml_submit_button" class="update_button" value="Export" />
 	</div>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3255

* Adds an option for excluding objects without mods from XML export
* Adds an email template for when no objects are being exported due to all pids being filtered out
* Exposes some protected methods as public which are useful for constructing and executing custom queries