### PR TITLE
BXC-3203 - Access surrogates support

### DIFF
--- a/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/services/DatastreamPermissionUtil.java
+++ b/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/services/DatastreamPermissionUtil.java
@@ -38,7 +38,7 @@ public class DatastreamPermissionUtil {
         DS_PERMISSION_MAP = new EnumMap<>(DatastreamType.class);
         DS_PERMISSION_MAP.put(DatastreamType.FULLTEXT_EXTRACTION, Permission.viewHidden);
         DS_PERMISSION_MAP.put(DatastreamType.JP2_ACCESS_COPY, Permission.viewAccessCopies);
-        DS_PERMISSION_MAP.put(DatastreamType.ACCESS_COPY, Permission.viewAccessCopies);
+        DS_PERMISSION_MAP.put(DatastreamType.ACCESS_SURROGATE, Permission.viewAccessCopies);
         DS_PERMISSION_MAP.put(DatastreamType.MD_DESCRIPTIVE, Permission.viewMetadata);
         DS_PERMISSION_MAP.put(DatastreamType.MD_DESCRIPTIVE_HISTORY, Permission.viewHidden);
         DS_PERMISSION_MAP.put(DatastreamType.MD_EVENTS, Permission.viewHidden);

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJob.java
@@ -26,14 +26,17 @@ import static java.util.stream.Collectors.toSet;
 import static org.apache.jena.rdf.model.ResourceFactory.createStringLiteral;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResIterator;
@@ -54,6 +57,7 @@ import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 import edu.unc.lib.boxc.persist.api.exceptions.InvalidChecksumException;
 import edu.unc.lib.boxc.persist.api.storage.BinaryDetails;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryAlreadyExistsException;
@@ -76,6 +80,8 @@ public class TransferBinariesToStorageJob extends AbstractConcurrentDepositJob {
 
     @Autowired
     private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private DerivativeService derivativeService;
 
     private Model model;
 
@@ -199,6 +205,7 @@ public class TransferBinariesToStorageJob extends AbstractConcurrentDepositJob {
                 transferOriginalFile();
                 transferFitsExtract();
                 transferFitsHistoryFile();
+                transferAccessSurrogate();
             } else if (objPid.getQualifier().equals(DEPOSIT_RECORD_BASE)) {
                 transferDepositManifests();
             }
@@ -256,6 +263,25 @@ public class TransferBinariesToStorageJob extends AbstractConcurrentDepositJob {
                 URI stagingUri = getTechMdPath(objPid, false).toUri();
                 transferFile(fitsPid, stagingUri, CdrDeposit.hasDatastreamFits);
                 log.debug("Finished transferring techmd file {}", fitsPid.getQualifiedId());
+            }
+        }
+
+        private void transferAccessSurrogate() {
+            // add storageUri if doesn't already exist. It will exist in a resume scenario.
+            if (datastreamNotTransferred(CdrDeposit.hasDatastreamAccessCopy)) {
+                Resource dsResc = DepositModelHelpers.getDatastream(resc, DatastreamType.ACCESS_COPY);
+
+                URI stagingUri = URI.create(dsResc.getProperty(CdrDeposit.stagingLocation).getString());
+                Path stagingPath = Paths.get(stagingUri);
+                Path destPath = derivativeService.getDerivativePath(objPid, DatastreamType.ACCESS_COPY);
+                try {
+                    FileUtils.copyFile(stagingPath.toFile(), destPath.toFile());
+                } catch (IOException e) {
+                    failJob(e, "Failed to copy access surrogate from {0} to {1}", stagingPath, destPath);
+                }
+                result.statements.add(ResourceFactory.createStatement(
+                        dsResc, CdrDeposit.storageUri, createStringLiteral(destPath.toUri().toString())));
+                log.debug("Finished transferring access surrogate for {}", objPid.getQualifiedId());
             }
         }
 

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJob.java
@@ -268,12 +268,12 @@ public class TransferBinariesToStorageJob extends AbstractConcurrentDepositJob {
 
         private void transferAccessSurrogate() {
             // add storageUri if doesn't already exist. It will exist in a resume scenario.
-            if (datastreamNotTransferred(CdrDeposit.hasDatastreamAccessCopy)) {
-                Resource dsResc = DepositModelHelpers.getDatastream(resc, DatastreamType.ACCESS_COPY);
+            if (datastreamNotTransferred(CdrDeposit.hasDatastreamAccessSurrogate)) {
+                Resource dsResc = DepositModelHelpers.getDatastream(resc, DatastreamType.ACCESS_SURROGATE);
 
                 URI stagingUri = URI.create(dsResc.getProperty(CdrDeposit.stagingLocation).getString());
                 Path stagingPath = Paths.get(stagingUri);
-                Path destPath = derivativeService.getDerivativePath(objPid, DatastreamType.ACCESS_COPY);
+                Path destPath = derivativeService.getDerivativePath(objPid, DatastreamType.ACCESS_SURROGATE);
                 try {
                     FileUtils.copyFile(stagingPath.toFile(), destPath.toFile());
                 } catch (IOException e) {

--- a/deposit-app/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit-app/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -281,6 +281,10 @@
         scope="prototype">
     </bean>
     
+    <bean id="derivativeService" class="edu.unc.lib.boxc.model.fcrepo.services.DerivativeService">
+        <property name="derivativeDir" value="${derivative.dir}" />
+    </bean>
+    
     <bean id="transferBinariesExecutor" class="java.util.concurrent.Executors"
             factory-method="newFixedThreadPool" destroy-method="shutdownNow">
         <constructor-arg value="${job.transferBinaries.workers:5}"/>

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJobTest.java
@@ -290,9 +290,9 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         workBag.addProperty(Cdr.primaryObject, fileResc);
 
         Path surrogateFile = derivStagingPath.resolve("myderiv.png");
-        PID surrogatePid = DatastreamPids.getAccessCopyPid(filePid);
+        PID surrogatePid = DatastreamPids.getAccessSurrogatePid(filePid);
         Resource surrogateResc = depositModel.getResource(surrogatePid.getRepositoryPath());
-        fileResc.addProperty(CdrDeposit.hasDatastreamAccessCopy, surrogateResc);
+        fileResc.addProperty(CdrDeposit.hasDatastreamAccessSurrogate, surrogateResc);
         Files.write(surrogateFile, "derived".getBytes());
         surrogateResc.addProperty(CdrDeposit.stagingLocation, surrogateFile.toUri().toString());
 
@@ -306,7 +306,7 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         assertOriginalFileTransferred(postFileResc, FILE_CONTENT1);
         assertFitsFileTransferred(postFileResc);
 
-        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_COPY);
+        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_SURROGATE);
         URI surrogateUri = URI.create(dsResc.getProperty(CdrDeposit.storageUri).getString());
         Path surrogatePath = Paths.get(surrogateUri);
         assertTrue("Surrogate file should exist at storage uri", Files.exists(surrogatePath));
@@ -324,9 +324,9 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         workBag.addProperty(Cdr.primaryObject, fileResc);
 
         Path surrogateFile = derivStagingPath.resolve("myderiv.png");
-        PID surrogatePid = DatastreamPids.getAccessCopyPid(filePid);
+        PID surrogatePid = DatastreamPids.getAccessSurrogatePid(filePid);
         Resource surrogateResc = depositModel.getResource(surrogatePid.getRepositoryPath());
-        fileResc.addProperty(CdrDeposit.hasDatastreamAccessCopy, surrogateResc);
+        fileResc.addProperty(CdrDeposit.hasDatastreamAccessSurrogate, surrogateResc);
         // never creates surrogate file
         surrogateResc.addProperty(CdrDeposit.stagingLocation, surrogateFile.toUri().toString());
 
@@ -342,7 +342,7 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         Model model = job.getReadOnlyModel();
         Resource postFileResc = model.getResource(fileResc.getURI());
 
-        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_COPY);
+        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_SURROGATE);
         assertFalse(dsResc.hasProperty(CdrDeposit.storageUri));
     }
 

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/transfer/TransferBinariesToStorageJobTest.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -38,6 +39,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -70,7 +72,6 @@ import org.slf4j.Logger;
 import edu.unc.lib.boxc.deposit.impl.model.DepositDirectoryManager;
 import edu.unc.lib.boxc.deposit.impl.model.DepositModelHelpers;
 import edu.unc.lib.boxc.deposit.normalize.AbstractNormalizationJobTest;
-import edu.unc.lib.boxc.deposit.transfer.TransferBinariesToStorageJob;
 import edu.unc.lib.boxc.deposit.work.JobFailedException;
 import edu.unc.lib.boxc.deposit.work.JobInterruptedException;
 import edu.unc.lib.boxc.model.api.DatastreamType;
@@ -80,6 +81,7 @@ import edu.unc.lib.boxc.model.api.rdf.CdrDeposit;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 import edu.unc.lib.boxc.persist.api.exceptions.InvalidChecksumException;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocation;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
@@ -119,6 +121,8 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
 
     private DepositDirectoryManager depositDirManager;
 
+    private DerivativeService derivativeService;
+
     private Model depositModel;
     private Bag depBag;
 
@@ -126,6 +130,8 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
     private Path loc2Path;
     private Path sourcePath;
     private Path candidatePath;
+    private Path derivStoragePath;
+    private Path derivStagingPath;
 
     private final static ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -136,6 +142,8 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
     public void init() throws Exception {
         loc1Path = tmpFolder.newFolder("loc1").toPath();
         loc2Path = tmpFolder.newFolder("loc2").toPath();
+        derivStoragePath = tmpFolder.newFolder("derivs").toPath();
+        derivStagingPath = tmpFolder.newFolder("derivStaging").toPath();
 
         locTestHelper = new StorageLocationTestHelper();
         locTestHelper.addStorageLocation(LOC1_ID, "Location 1", loc1Path.toString());
@@ -159,6 +167,9 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         transferService = new BinaryTransferServiceImpl();
         transferService.setIngestSourceManager(sourceManager);
 
+        derivativeService = new DerivativeService();
+        derivativeService.setDerivativeDir(derivStoragePath.toString());
+
         initializeJob();
 
         depositModel = job.getWritableModel();
@@ -176,6 +187,7 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         setField(job, "jobStatusFactory", jobStatusFactory);
         setField(job, "repoObjFactory", repoObjFactory);
         setField(job, "executorService", executorService);
+        setField(job, "derivativeService", derivativeService);
         job.setFlushRate(FLUSH_RATE);
         job.init();
     }
@@ -268,6 +280,70 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
         job.closeModel();
 
         job.run();
+    }
+
+    @Test
+    public void depositWithWorkContainingFileAndAccessSurrogate() throws Exception {
+        Bag workBag = addContainerObject(depBag, Cdr.Work);
+        Resource fileResc = addFileObject(workBag, FILE_CONTENT1, true);
+        PID filePid = PIDs.get(fileResc.getURI());
+        workBag.addProperty(Cdr.primaryObject, fileResc);
+
+        Path surrogateFile = derivStagingPath.resolve("myderiv.png");
+        PID surrogatePid = DatastreamPids.getAccessCopyPid(filePid);
+        Resource surrogateResc = depositModel.getResource(surrogatePid.getRepositoryPath());
+        fileResc.addProperty(CdrDeposit.hasDatastreamAccessCopy, surrogateResc);
+        Files.write(surrogateFile, "derived".getBytes());
+        surrogateResc.addProperty(CdrDeposit.stagingLocation, surrogateFile.toUri().toString());
+
+        job.closeModel();
+
+        job.run();
+
+        Model model = job.getReadOnlyModel();
+        Resource postFileResc = model.getResource(fileResc.getURI());
+
+        assertOriginalFileTransferred(postFileResc, FILE_CONTENT1);
+        assertFitsFileTransferred(postFileResc);
+
+        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_COPY);
+        URI surrogateUri = URI.create(dsResc.getProperty(CdrDeposit.storageUri).getString());
+        Path surrogatePath = Paths.get(surrogateUri);
+        assertTrue("Surrogate file should exist at storage uri", Files.exists(surrogatePath));
+        assertEquals("derived", FileUtils.readFileToString(surrogatePath.toFile(), StandardCharsets.UTF_8));
+
+        verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(3));
+        verify(jobStatusFactory, times(3)).incrCompletion(eq(jobUUID), eq(1));
+    }
+
+    @Test
+    public void depositWithWorkContainingFileAndMissingAccessSurrogate() throws Exception {
+        Bag workBag = addContainerObject(depBag, Cdr.Work);
+        Resource fileResc = addFileObject(workBag, FILE_CONTENT1, true);
+        PID filePid = PIDs.get(fileResc.getURI());
+        workBag.addProperty(Cdr.primaryObject, fileResc);
+
+        Path surrogateFile = derivStagingPath.resolve("myderiv.png");
+        PID surrogatePid = DatastreamPids.getAccessCopyPid(filePid);
+        Resource surrogateResc = depositModel.getResource(surrogatePid.getRepositoryPath());
+        fileResc.addProperty(CdrDeposit.hasDatastreamAccessCopy, surrogateResc);
+        // never creates surrogate file
+        surrogateResc.addProperty(CdrDeposit.stagingLocation, surrogateFile.toUri().toString());
+
+        job.closeModel();
+
+        try {
+            job.run();
+            fail("Job expected to fail");
+        } catch (JobFailedException e) {
+            // expected
+        }
+
+        Model model = job.getReadOnlyModel();
+        Resource postFileResc = model.getResource(fileResc.getURI());
+
+        Resource dsResc = DepositModelHelpers.getDatastream(postFileResc, DatastreamType.ACCESS_COPY);
+        assertFalse(dsResc.hasProperty(CdrDeposit.storageUri));
     }
 
     // Ensure that interruptions come through as JobInterruptedExceptions

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelHelpers.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelHelpers.java
@@ -68,8 +68,8 @@ public class DepositModelHelpers {
             PID fitsPid = DatastreamPids.getTechnicalMetadataPid(parentPid);
             dsPid = DatastreamPids.getDatastreamHistoryPid(fitsPid);
             break;
-        case ACCESS_COPY:
-            dsPid = DatastreamPids.getAccessCopyPid(parentPid);
+        case ACCESS_SURROGATE:
+            dsPid = DatastreamPids.getAccessSurrogatePid(parentPid);
             break;
         default:
             throw new RepositoryException("Cannot add datastream of type " + type.name());
@@ -98,8 +98,8 @@ public class DepositModelHelpers {
             return CdrDeposit.hasDatastreamDescriptiveHistory;
         case TECHNICAL_METADATA_HISTORY:
             return CdrDeposit.hasDatastreamFitsHistory;
-        case ACCESS_COPY:
-            return CdrDeposit.hasDatastreamAccessCopy;
+        case ACCESS_SURROGATE:
+            return CdrDeposit.hasDatastreamAccessSurrogate;
         default:
             throw new RepositoryException("Cannot add datastream of type " + type.name());
         }

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/DatastreamType.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/DatastreamType.java
@@ -27,7 +27,7 @@ import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.METADATA_CO
  *
  */
 public enum DatastreamType {
-    ACCESS_COPY("access_copy", "application/octet-stream", ".access", null, EXTERNAL),
+    ACCESS_SURROGATE("access_surrogate", "application/octet-stream", null, null, EXTERNAL),
     FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", null, EXTERNAL),
     JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", null, EXTERNAL),
     MD_DESCRIPTIVE("md_descriptive", "text/xml", "xml", METADATA_CONTAINER, INTERNAL),

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/CdrDeposit.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/CdrDeposit.java
@@ -97,8 +97,8 @@ public class CdrDeposit {
             "http://cdr.unc.edu/definitions/deposit#hasDatastreamOriginal" );
 
     /** Link to access copy binary resource */
-    public static final Property hasDatastreamAccessCopy = createProperty(
-            "http://cdr.unc.edu/definitions/deposit#hasDatastreamAccessCopy" );
+    public static final Property hasDatastreamAccessSurrogate = createProperty(
+            "http://cdr.unc.edu/definitions/deposit#hasDatastreamAccessSurrogate" );
 
     /** Link to FITS binary resource */
     public static final Property hasDatastreamFits = createProperty(

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
@@ -15,7 +15,7 @@
  */
 package edu.unc.lib.boxc.model.fcrepo.ids;
 
-import static edu.unc.lib.boxc.model.api.DatastreamType.ACCESS_COPY;
+import static edu.unc.lib.boxc.model.api.DatastreamType.ACCESS_SURROGATE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.MD_DESCRIPTIVE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.MD_EVENTS;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
@@ -65,8 +65,8 @@ public class DatastreamPids {
         return PIDs.get(path);
     }
 
-    public static PID getAccessCopyPid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, ACCESS_COPY.getId());
+    public static PID getAccessSurrogatePid(PID pid) {
+        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, ACCESS_SURROGATE.getId());
         return PIDs.get(path);
     }
 

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/DerivativeService.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/DerivativeService.java
@@ -81,9 +81,13 @@ public class DerivativeService {
 
         String id = pid.getId();
         String hashedPath = idToPath(id, HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
+        String filename = id;
+        if (dsType.getExtension() != null) {
+            filename += "." + dsType.getExtension();
+        }
 
         // Construct the full path of the derivative
-        return Paths.get(derivativeDir, dsType.getId(), hashedPath, id + "." + dsType.getExtension());
+        return Paths.get(derivativeDir, dsType.getId(), hashedPath, filename);
     }
 
     /**

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessor.java
@@ -20,8 +20,11 @@ import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrBinaryMim
 import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrBinaryPath;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.camel.Exchange;
@@ -30,14 +33,17 @@ import org.apache.camel.Processor;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.tika.Tika;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.exceptions.ObjectTypeMismatchException;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 
 /**
  * Stores information related to identifying binary objects from the repository
@@ -49,6 +55,7 @@ public class BinaryMetadataProcessor implements Processor {
     private static final Logger log = LoggerFactory.getLogger(BinaryMetadataProcessor.class);
 
     private RepositoryObjectLoader repoObjLoader;
+    private DerivativeService derivativeService;
 
     @Override
     public void process(final Exchange exchange) throws Exception {
@@ -56,7 +63,22 @@ public class BinaryMetadataProcessor implements Processor {
 
         String fcrepoBinaryUri = (String) in.getHeader(FCREPO_URI);
         PID binPid = PIDs.get(fcrepoBinaryUri);
+        PID filePid = PIDs.get(binPid.getId());
 
+        // If an access surrogate is present, supply its details instead of that of the original file
+        Path surrogatePath = derivativeService.getDerivativePath(filePid, DatastreamType.ACCESS_SURROGATE);
+        if (Files.exists(surrogatePath)) {
+            String mimetype = getMimetype(surrogatePath);
+            if (mimetype != null) {
+                in.setHeader(CdrBinaryPath, surrogatePath.toString());
+                in.setHeader(CdrBinaryMimeType, mimetype);
+                log.info("Using access surrogate {} with type {} for derivative generation of object {}",
+                        surrogatePath, mimetype, filePid.getId());
+            }
+            return;
+        }
+
+        // No access surrogate, so use the original file for producing derivatives
         BinaryObject binObj;
         try {
             binObj = repoObjLoader.getBinaryObject(binPid);
@@ -87,10 +109,24 @@ public class BinaryMetadataProcessor implements Processor {
         }
     }
 
+    private String getMimetype(Path path) {
+        Tika tika = new Tika();
+        try {
+            return tika.detect(path);
+        } catch (IOException e) {
+            log.warn("Failed to detect mimetype for {}", path, e);
+            return null;
+        }
+    }
+
     /**
      * @param repoObjLoader the repoObjLoader to set
      */
     public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
         this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setDerivativeService(DerivativeService derivativeService) {
+        this.derivativeService = derivativeService;
     }
 }

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -201,6 +201,7 @@
     
     <bean id="binaryMetadataProcessor" class="edu.unc.lib.boxc.services.camel.BinaryMetadataProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="derivativeService" ref="derivativeService" />
     </bean>
     
     <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor">

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessorTest.java
@@ -53,8 +53,8 @@ import edu.unc.lib.boxc.model.api.rdf.Ebucore;
 import edu.unc.lib.boxc.model.api.rdf.Fcrepo4Repository;
 import edu.unc.lib.boxc.model.api.rdf.Premis;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.BinaryMetadataProcessor;
 
 /**
  *
@@ -90,6 +90,7 @@ public class BinaryMetadataProcessorTest {
     private RepositoryObjectLoader repoObjLoader;
     @Mock
     private BinaryObject binaryObject;
+    private DerivativeService derivativeService;
 
     @Before
     public void init() throws Exception {
@@ -99,8 +100,12 @@ public class BinaryMetadataProcessorTest {
 
         binaryBase = tmpFolder.newFolder().getAbsolutePath();
 
+        derivativeService = new DerivativeService();
+        derivativeService.setDerivativeDir(binaryBase);
+
         processor = new BinaryMetadataProcessor();
         processor.setRepositoryObjectLoader(repoObjLoader);
+        processor.setDerivativeService(derivativeService);
 
         when(exchange.getIn()).thenReturn(message);
         when(exchange.getIn().getHeader(FCREPO_URI)).thenReturn(RESC_ID);

--- a/services-camel-app/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel-app/src/test/resources/enhancement-router-it-context.xml
@@ -42,6 +42,7 @@
     
     <bean id="binaryMetadataProcessor" class="edu.unc.lib.boxc.services.camel.BinaryMetadataProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="derivativeService" ref="derivativeService" />
     </bean>
 
     <bean id="binaryEnhancementProcessor" class="edu.unc.lib.boxc.services.camel.BinaryEnhancementProcessor">

--- a/services-camel-app/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel-app/src/test/resources/spring-test/cdr-client-container.xml
@@ -131,4 +131,7 @@
         <property name="versionedDatastreamService" ref="versionedDatastreamService" />
     </bean>
 
+    <bean id="derivativeService" class="edu.unc.lib.boxc.model.fcrepo.services.DerivativeService">
+        <property name="derivativeDir" value="target/" />
+    </bean>
 </beans>

--- a/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -220,10 +220,6 @@
         <property name="dataLoader" ref="dipDataLoader" />
     </bean>
     
-    <bean id="derivativeService" class="edu.unc.lib.boxc.model.fcrepo.services.DerivativeService">
-        <property name="derivativeDir" value="target/" />
-    </bean>
-    
     <bean id="repositoryObjectSolrIndexer" class="edu.unc.lib.boxc.indexing.solr.test.RepositoryObjectSolrIndexer">
     </bean>
 </beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3203

* Access surrogates provided to deposit pipeline will be copied to derivatives directory
* BinaryMetadataProcessor will use the path and mimetype of the access surrogate if one is detected
    * Since there is nowhere to store it, the mimetype of the access surrogate is determined using tika
* Renames access_copy to  access_surrogate in most places for clarity/consistency
* access_surrogate datastream is implicitly indexed to solr, along with all other external datastreams.