### PR TITLE
BXC-3256 - Additional Metadata Types in XML Export

### DIFF
--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
@@ -22,9 +22,9 @@ import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.DATA_FILE_FILESET;
 import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.DEPOSIT_MANIFEST_CONTAINER;
-import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.METADATA_CONTAINER;
 
 import edu.unc.lib.boxc.common.util.URIUtil;
+import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 
 /**
@@ -40,33 +40,64 @@ public class DatastreamPids {
     private DatastreamPids() {
     }
 
+    /**
+     * Construct a PID for the provided datastream belonging the given PID.
+     *
+     * Does not include deposit manifests.
+     *
+     * @param pid
+     * @param dsType
+     * @return Constructed datastream PID.
+     */
+    public static PID getDatastreamPid(PID pid, DatastreamType dsType) {
+        switch (dsType) {
+        case MD_DESCRIPTIVE_HISTORY:
+            return getDatastreamHistoryPid(getMdDescriptivePid(pid));
+        case TECHNICAL_METADATA_HISTORY:
+            return getDatastreamHistoryPid(getTechnicalMetadataPid(pid));
+        default:
+            return constructPid(pid, dsType);
+        }
+    }
+
     public static PID getMdDescriptivePid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), METADATA_CONTAINER, MD_DESCRIPTIVE.getId());
-        return PIDs.get(path);
+        return constructPid(pid, MD_DESCRIPTIVE);
     }
 
     public static PID getOriginalFilePid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, ORIGINAL_FILE.getId());
-        return PIDs.get(path);
+        return constructPid(pid, ORIGINAL_FILE);
     }
 
     public static PID getMdEventsPid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), METADATA_CONTAINER, MD_EVENTS.getId());
-        return PIDs.get(path);
+        return constructPid(pid, MD_EVENTS);
     }
 
     public static PID getTechnicalMetadataPid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, TECHNICAL_METADATA.getId());
-        return PIDs.get(path);
+        return constructPid(pid, TECHNICAL_METADATA);
     }
 
+    /**
+     * Construct a PID for a deposit manifest datastream using the provided name.
+     *
+     * @param pid
+     * @param name
+     * @return PID of manifest
+     */
     public static PID getDepositManifestPid(PID pid, String name) {
         String path = URIUtil.join(pid.getRepositoryPath(), DEPOSIT_MANIFEST_CONTAINER, name.toLowerCase());
         return PIDs.get(path);
     }
 
     public static PID getAccessSurrogatePid(PID pid) {
-        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, ACCESS_SURROGATE.getId());
+        return constructPid(pid, ACCESS_SURROGATE);
+    }
+
+    private static PID constructPid(PID pid, DatastreamType dsType) {
+        String container = DATA_FILE_FILESET;
+        if (dsType.getContainer() != null) {
+            container = dsType.getContainer();
+        }
+        String path = URIUtil.join(pid.getRepositoryPath(), container, dsType.getId());
         return PIDs.get(path);
     }
 

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/BulkXMLConstants.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/BulkXMLConstants.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.jms.exportxml;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import edu.unc.lib.boxc.model.api.DatastreamType;
+
+/**
+ * Constants used with bulk metadata import/export documents
+ *
+ * @author bbpennel
+ */
+public class BulkXMLConstants {
+    public final static String BULK_MD_TAG = "bulkMetadata";
+    public final static String OBJECT_TAG = "object";
+    public final static String DATASTREAM_TAG = "datastream";
+    public final static String TYPE_ATTR = "type";
+    public final static String PID_ATTR = "pid";
+    public final static String PARENT_ID_ATTR = "parent";
+    public final static String MIMETYPE_ATTR = "mimetype";
+    public final static String MODIFIED_ATTR = "lastModified";
+    public final static String OPERATION_ATTR = "operation";
+    public final static String OPER_UPDATE_ATTR = "update";
+
+    public final static Set<DatastreamType> DEFAULT_DS_TYPES = EnumSet.of(DatastreamType.MD_DESCRIPTIVE);
+    public final static Set<DatastreamType> EXPORTABLE_DS_TYPES = EnumSet.of(
+            DatastreamType.MD_DESCRIPTIVE, DatastreamType.MD_DESCRIPTIVE_HISTORY, DatastreamType.MD_EVENTS,
+            DatastreamType.TECHNICAL_METADATA, DatastreamType.TECHNICAL_METADATA_HISTORY);
+    public final static Set<DatastreamType> UPDATEABLE_DS_TYPES = EnumSet.of(DatastreamType.MD_DESCRIPTIVE);
+
+    private BulkXMLConstants() {
+    }
+}

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
@@ -16,12 +16,15 @@
 package edu.unc.lib.boxc.operations.jms.exportxml;
 
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.DatastreamType;
 
 /**
  * A request object for a bulk XML export
@@ -36,6 +39,7 @@ public class ExportXMLRequest {
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
     private boolean excludeNoDatastreams;
+    private Set<DatastreamType> datastreams;
 
     public ExportXMLRequest() {
     }
@@ -95,5 +99,20 @@ public class ExportXMLRequest {
 
     public void setExcludeNoDatastreams(boolean excludeNoDatastreams) {
         this.excludeNoDatastreams = excludeNoDatastreams;
+    }
+
+    /**
+     * @return List of datastreams to be exported
+     */
+    public Set<DatastreamType> getDatastreams() {
+        return datastreams;
+    }
+
+    public void setDatastreams(Set<DatastreamType> datastreams) {
+        if (datastreams == null || datastreams instanceof EnumSet) {
+            this.datastreams = datastreams;
+        } else {
+            this.datastreams = EnumSet.copyOf(datastreams);
+        }
     }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/exportxml/ExportXMLRequest.java
@@ -112,7 +112,11 @@ public class ExportXMLRequest {
         if (datastreams == null || datastreams instanceof EnumSet) {
             this.datastreams = datastreams;
         } else {
-            this.datastreams = EnumSet.copyOf(datastreams);
+            if (datastreams.isEmpty()) {
+                this.datastreams = EnumSet.noneOf(DatastreamType.class);
+            } else {
+                this.datastreams = EnumSet.copyOf(datastreams);
+            }
         }
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/test/ModsTestHelper.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/test/ModsTestHelper.java
@@ -27,7 +27,9 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.XMLOutputter;
 
+import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.operations.jms.exportxml.BulkXMLConstants;
 
 /**
  * @author bbpennel
@@ -52,26 +54,27 @@ public class ModsTestHelper {
 
     public static Document makeUpdateDocument() {
         Document doc = new Document();
-        doc.addContent(new Element("bulkMetadata"));
+        doc.addContent(new Element(BulkXMLConstants.BULK_MD_TAG));
         return doc;
     }
 
     public static Element addObjectUpdate(Document doc, PID pid, String lastModified) {
         Element objEl = addObject(doc, pid);
-        Element updateEl = new Element("update");
-        updateEl.setAttribute("type", "MODS");
+        Element dsEl = new Element(BulkXMLConstants.DATASTREAM_TAG);
+        dsEl.setAttribute(BulkXMLConstants.TYPE_ATTR, DatastreamType.MD_DESCRIPTIVE.getId());
+        dsEl.setAttribute(BulkXMLConstants.OPERATION_ATTR, BulkXMLConstants.OPER_UPDATE_ATTR);
         if (lastModified != null) {
-            updateEl.setAttribute("lastModified", lastModified);
+            dsEl.setAttribute(BulkXMLConstants.MODIFIED_ATTR, lastModified);
         }
-        objEl.addContent(updateEl);
+        objEl.addContent(dsEl);
 
-        return updateEl;
+        return dsEl;
     }
 
     public static Element addObject(Document doc, PID pid) {
-        Element objEl = new Element("object");
+        Element objEl = new Element(BulkXMLConstants.OBJECT_TAG);
         if (pid != null) {
-            objEl.setAttribute("pid", pid.getId());
+            objEl.setAttribute(BulkXMLConstants.PID_ATTR, pid.getId());
         }
         doc.getRootElement().addContent(objEl);
         return objEl;

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
@@ -26,15 +26,20 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -51,10 +56,13 @@ import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.common.metrics.TimerFactory;
 import edu.unc.lib.boxc.fcrepo.exceptions.ServiceException;
 import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.impl.utils.EmailHandler;
 import edu.unc.lib.boxc.operations.jms.exportxml.ExportXMLRequest;
@@ -78,6 +86,10 @@ public class ExportXMLProcessor implements Processor {
     private final List<String> resultFieldsParent = Arrays.asList(
             SearchFieldKey.ID.name(), SearchFieldKey.DATASTREAM.name());
     private final List<String> resultFieldsChildren = Arrays.asList(SearchFieldKey.ID.name());
+    private final Set<DatastreamType> DEFAULT_DS_TYPES = EnumSet.of(DatastreamType.MD_DESCRIPTIVE);
+    private final Set<DatastreamType> EXPORTABLE_DS_TYPES = EnumSet.of(
+            DatastreamType.MD_DESCRIPTIVE, DatastreamType.MD_DESCRIPTIVE_HISTORY, DatastreamType.MD_EVENTS,
+            DatastreamType.TECHNICAL_METADATA, DatastreamType.TECHNICAL_METADATA_HISTORY);
 
     private AccessControlService aclService;
     private RepositoryObjectLoader repoObjLoader;
@@ -103,6 +115,7 @@ public class ExportXMLProcessor implements Processor {
         long startTime = System.currentTimeMillis();
         ExportXMLRequest request = requestService.deserializeRequest((String) in.getBody());
         try (Timer.Context context = timer.time()) {
+            initializedIncludedDatastreams(request);
             performExport(request, startTime);
         } catch (IOException e) {
             throw new ServiceException("Unable to write export file", e);
@@ -170,6 +183,7 @@ public class ExportXMLProcessor implements Processor {
      * @throws ServiceException
      */
     private void adjustRequestPids(ExportXMLRequest request) throws ServiceException {
+        String dsField = searchService.solrField(SearchFieldKey.DATASTREAM);
         List<String> pids = new ArrayList<>();
         for (String pid : request.getPids()) {
             SearchState searchState = searchStateFactory.createSearchState();
@@ -180,8 +194,11 @@ public class ExportXMLProcessor implements Processor {
             ContentObjectRecord parent = searchService.addSelectedContainer(
                     PIDs.get(pid), searchState, false, request.getAgent().getPrincipals());
             if (request.getExcludeNoDatastreams()) {
-                if (parent.getDatastreamObject(DatastreamType.MD_DESCRIPTIVE.getId()) != null) {
-                    pids.add(pid);
+                for (DatastreamType includedDs : request.getDatastreams()) {
+                    if (parent.getDatastreamObject(includedDs.getId()) != null) {
+                        pids.add(pid);
+                        break;
+                    }
                 }
             } else {
                 pids.add(pid);
@@ -198,8 +215,10 @@ public class ExportXMLProcessor implements Processor {
             searchRequest.setApplyCutoffs(false);
             SolrQuery solrQuery = searchService.generateSearch(searchRequest);
             if (request.getExcludeNoDatastreams()) {
-                solrQuery.addFilterQuery(searchService.solrField(SearchFieldKey.DATASTREAM) + ":"
-                        + DatastreamType.MD_DESCRIPTIVE.getId() + "|*");
+                String dsIncludeFilter = request.getDatastreams().stream()
+                        .map(ds -> dsField + ":" + ds.getId() + "|*")
+                        .collect(Collectors.joining(" OR ", "(", ")"));
+                solrQuery.addFilterQuery(dsIncludeFilter);
             }
             SearchResultResponse resultResponse = null;
             try {
@@ -230,38 +249,60 @@ public class ExportXMLProcessor implements Processor {
             return;
         }
         ContentObject obj = (ContentObject) repoObjLoader.getRepositoryObject(pid);
-        BinaryObject mods = obj.getDescription();
 
-        try {
-            Document objectDoc = new Document();
-            Element objectEl = new Element("object");
-            objectEl.setAttribute("pid", pid.getQualifiedId());
-            objectEl.setAttribute("type", obj.getResourceType().toString());
-            objectDoc.addContent(objectEl);
+        Document objectDoc = new Document();
+        Element objectEl = new Element("object");
+        objectEl.setAttribute("pid", pid.getQualifiedId());
+        objectEl.setAttribute("type", obj.getResourceType().toString());
+        if (obj instanceof FileObject) {
+            objectEl.setAttribute("parent", obj.getParentPid().getQualifiedId());
+        }
+        objectDoc.addContent(objectEl);
 
-            if (mods != null) {
-                Document dsDoc;
-                try (InputStream modsStream = mods.getBinaryStream()) {
-                    dsDoc = createSAXBuilder().build(modsStream);
+        for (DatastreamType dsType : request.getDatastreams()) {
+            PID dsPid = DatastreamPids.getDatastreamPid(pid, dsType);
+
+            try {
+                BinaryObject dsObj = repoObjLoader.getBinaryObject(dsPid);
+
+                objectEl.addContent(SEPERATOR);
+
+                Element updateDsEl = new Element("update");
+                updateDsEl.setAttribute("type", dsType.getId());
+                updateDsEl.setAttribute("lastModified", dsObj.getLastModified().toString());
+                String mimetype = dsObj.getMimetype();
+                updateDsEl.setAttribute("mimetype", mimetype);
+                updateDsEl.addContent(SEPERATOR);
+
+                if ("text/xml".equals(mimetype)) {
+                    try (InputStream modsStream = dsObj.getBinaryStream()) {
+                        Document dsDoc = createSAXBuilder().build(modsStream);
+                        updateDsEl.addContent(dsDoc.detachRootElement());
+                    }
+                } else {
+                    updateDsEl.addContent(IOUtils.toString(dsObj.getBinaryStream(), StandardCharsets.UTF_8));
                 }
-
+                updateDsEl.addContent(SEPERATOR);
+                objectEl.addContent(updateDsEl);
                 objectEl.addContent(SEPERATOR);
-
-                Element modsUpdateEl = new Element("update");
-                modsUpdateEl.setAttribute("type", "MODS");
-                modsUpdateEl.setAttribute("lastModified", mods.getLastModified().toString());
-                modsUpdateEl.addContent(SEPERATOR);
-                modsUpdateEl.addContent(dsDoc.detachRootElement());
-                modsUpdateEl.addContent(SEPERATOR);
-                objectEl.addContent(modsUpdateEl);
-                objectEl.addContent(SEPERATOR);
+            } catch (NotFoundException e) {
+                log.debug("Object {} has no {} datastream for export", pid.getId(), dsType.getId());
+            } catch (JDOMException e) {
+                log.error("Failed to parse XML document for {}", dsPid, e);
             }
+        }
 
-            xmlOutput.output(objectEl, xfop);
+        xmlOutput.output(objectEl, xfop);
 
-            xfop.write(SEPERATOR_BYTES);
-        } catch (JDOMException e) {
-            log.error("Failed to parse MODS document for {}", pid, e);
+        xfop.write(SEPERATOR_BYTES);
+    }
+
+    private void initializedIncludedDatastreams(ExportXMLRequest request) {
+        Set<DatastreamType> dses = request.getDatastreams();
+        if (dses == null) {
+            request.setDatastreams(DEFAULT_DS_TYPES);
+        } else {
+            dses.retainAll(EXPORTABLE_DS_TYPES);
         }
     }
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
@@ -70,6 +70,7 @@ import edu.unc.lib.boxc.operations.jms.exportxml.ExportXMLRequest;
 import edu.unc.lib.boxc.operations.jms.exportxml.ExportXMLRequestService;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
+import edu.unc.lib.boxc.search.api.models.Datastream;
 import edu.unc.lib.boxc.search.api.requests.SearchRequest;
 import edu.unc.lib.boxc.search.api.requests.SearchState;
 import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
@@ -192,7 +193,8 @@ public class ExportXMLProcessor implements Processor {
                     PIDs.get(pid), searchState, false, request.getAgent().getPrincipals());
             if (request.getExcludeNoDatastreams()) {
                 for (DatastreamType includedDs : request.getDatastreams()) {
-                    if (parent.getDatastreamObject(includedDs.getId()) != null) {
+                    Datastream ds = parent.getDatastreamObject(includedDs.getId());
+                    if (ds != null && ds.getOwner() == null) {
                         pids.add(pid);
                         break;
                     }
@@ -213,7 +215,8 @@ public class ExportXMLProcessor implements Processor {
             SolrQuery solrQuery = searchService.generateSearch(searchRequest);
             if (request.getExcludeNoDatastreams()) {
                 String dsIncludeFilter = request.getDatastreams().stream()
-                        .map(ds -> dsField + ":" + ds.getId() + "|*")
+                        // Filtering datastreams to exclude those owned by other objects
+                        .map(ds -> dsField + ":" + ds.getId() + "|*||")
                         .collect(Collectors.joining(" OR ", "(", ")"));
                 solrQuery.addFilterQuery(dsIncludeFilter);
             }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
@@ -194,7 +194,7 @@ public class ExportXMLProcessor implements Processor {
             if (request.getExcludeNoDatastreams()) {
                 for (DatastreamType includedDs : request.getDatastreams()) {
                     Datastream ds = parent.getDatastreamObject(includedDs.getId());
-                    if (ds != null && ds.getOwner() == null) {
+                    if (ds != null && StringUtils.isEmpty(ds.getOwner())) {
                         pids.add(pid);
                         break;
                     }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
@@ -15,8 +15,12 @@
  */
 package edu.unc.lib.boxc.services.camel.exportxml;
 
+import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.boxc.model.api.xml.NamespaceConstants.FITS_URI;
+import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getTechnicalMetadataPid;
 import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.getContentRootPid;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -30,11 +34,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -42,10 +48,14 @@ import java.util.stream.Collectors;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,21 +71,28 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
 import edu.unc.lib.boxc.common.util.ZipFileUtil;
 import edu.unc.lib.boxc.indexing.solr.test.RepositoryObjectSolrIndexer;
+import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDMinter;
 import edu.unc.lib.boxc.model.api.objects.AdminUnit;
+import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.CollectionObject;
 import edu.unc.lib.boxc.model.api.objects.ContentRootObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.rdf.IanaRelation;
+import edu.unc.lib.boxc.model.api.rdf.Premis;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil;
+import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.services.RepositoryInitializer;
 import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.operations.api.events.PremisLogger;
+import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.boxc.operations.impl.utils.EmailHandler;
@@ -121,6 +138,8 @@ public class ExportXMLRouteIT {
     private EmailHandler emailHandler;
     @Autowired
     private ExportXMLProcessor exportXmlProcessor;
+    @Autowired
+    private PremisLoggerFactory premisLoggerFactory;
 
     @Captor
     private ArgumentCaptor<String> toCaptor;
@@ -161,7 +180,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(false, false, workObj1.getPid(), workObj2.getPid());
+        sendRequest(createRequest(false, false, workObj1.getPid(), workObj2.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -184,7 +203,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(false, false, collObj1.getPid());
+        sendRequest(createRequest(false, false, collObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -206,7 +225,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(true, false, collObj1.getPid());
+        sendRequest(createRequest(true, false, collObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -232,7 +251,7 @@ public class ExportXMLRouteIT {
                 .whenDone(1)
                 .create();
 
-        sendRequest(false, false, workObj1.getPid());
+        sendRequest(createRequest(false, false, workObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -253,7 +272,7 @@ public class ExportXMLRouteIT {
                 .whenDone(1)
                 .create();
 
-        sendRequest(false, false, collObj1.getPid());
+        sendRequest(createRequest(false, false, collObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -274,7 +293,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(true, false, unitObj.getPid());
+        sendRequest(createRequest(true, false, unitObj.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -307,7 +326,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(true, true, unitObj.getPid());
+        sendRequest(createRequest(true, true, unitObj.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -331,7 +350,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(false, true, collObj1.getPid());
+        sendRequest(createRequest(false, true, collObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -351,7 +370,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(true, true, workObj2.getPid());
+        sendRequest(createRequest(true, true, workObj2.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -371,7 +390,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(true, true, workObj1.getPid());
+        sendRequest(createRequest(true, true, workObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -393,7 +412,7 @@ public class ExportXMLRouteIT {
                 .whenCompleted(1)
                 .create();
 
-        sendRequest(false, true, workObj1.getPid());
+        sendRequest(createRequest(false, true, workObj1.getPid()));
 
         boolean result = notify.matches(5l, TimeUnit.SECONDS);
         assertTrue("Processing message did not match expectations", result);
@@ -403,6 +422,107 @@ public class ExportXMLRouteIT {
         Element rootEl = getExportedDocumentRootEl();
 
         assertHasObjectWithMods(rootEl, ResourceType.Work, workObj1.getPid());
+
+        assertExportDocumentCount(rootEl, 1);
+    }
+
+    @Test
+    public void exportWorkModsAndFitsTest() throws Exception {
+        String fitsContent = "<fits>content</fits>";
+        URI fitsUri = makeContentUri(fitsContent);
+        PID fitsPid = getTechnicalMetadataPid(fileObj1.getPid());
+        fileObj1.addBinary(fitsPid, fitsUri, TECHNICAL_METADATA.getDefaultFilename(), TECHNICAL_METADATA.getMimetype(),
+                null, null, IanaRelation.derivedfrom, DCTerms.conformsTo, createResource(FITS_URI));
+
+        indexAll();
+
+        NotifyBuilder notify = new NotifyBuilder(cdrExportXML)
+                .whenCompleted(1)
+                .create();
+
+        ExportXMLRequest request = createRequest(true, true, workObj1.getPid());
+        request.setDatastreams(EnumSet.of(DatastreamType.MD_DESCRIPTIVE, DatastreamType.TECHNICAL_METADATA));
+        sendRequest(request);
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Processing message did not match expectations", result);
+
+        assertEmailSent();
+
+        Element rootEl = getExportedDocumentRootEl();
+
+        assertHasObjectWithMods(rootEl, ResourceType.Work, workObj1.getPid());
+        assertHasObjectWithDatastream(rootEl, ResourceType.File, fileObj1.getPid(), DatastreamType.TECHNICAL_METADATA,
+                "text/xml", fitsContent);
+
+        // The FITS belongs to the FileObject, so it will be returned as a separate object
+        assertExportDocumentCount(rootEl, 2);
+    }
+
+    @Test
+    public void exportWorkModsAndPremisTest() throws Exception {
+        PremisLogger logger = premisLoggerFactory.createPremisLogger(workObj1);
+        logger.buildEvent(Premis.Ingestion)
+                .addEventDetail("Ingested this thing")
+                .writeAndClose();
+        BinaryObject premisDs = repositoryObjectLoader.getBinaryObject(
+                DatastreamPids.getMdEventsPid(workObj1.getPid()));
+        String logContent = IOUtils.toString(premisDs.getBinaryStream(), StandardCharsets.UTF_8);
+
+        indexAll();
+
+        NotifyBuilder notify = new NotifyBuilder(cdrExportXML)
+                .whenCompleted(1)
+                .create();
+
+        ExportXMLRequest request = createRequest(true, true, workObj1.getPid());
+        request.setDatastreams(EnumSet.of(DatastreamType.MD_DESCRIPTIVE, DatastreamType.MD_EVENTS));
+        sendRequest(request);
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Processing message did not match expectations", result);
+
+        assertEmailSent();
+
+        Element rootEl = getExportedDocumentRootEl();
+
+        assertHasObjectWithMods(rootEl, ResourceType.Work, workObj1.getPid());
+        assertHasObjectWithDatastream(rootEl, ResourceType.Work, workObj1.getPid(), DatastreamType.MD_EVENTS,
+                "application/n-triples", logContent);
+
+        assertExportDocumentCount(rootEl, 1);
+    }
+
+    @Test
+    public void exportWorkModsAndPremisNoModsTest() throws Exception {
+        PremisLogger logger = premisLoggerFactory.createPremisLogger(workObj2);
+        logger.buildEvent(Premis.Ingestion)
+                .addEventDetail("Ingested this other thing")
+                .writeAndClose();
+        BinaryObject premisDs = repositoryObjectLoader.getBinaryObject(
+                DatastreamPids.getMdEventsPid(workObj2.getPid()));
+        String logContent = IOUtils.toString(premisDs.getBinaryStream(), StandardCharsets.UTF_8);
+
+        indexAll();
+
+        NotifyBuilder notify = new NotifyBuilder(cdrExportXML)
+                .whenCompleted(1)
+                .create();
+
+        ExportXMLRequest request = createRequest(true, true, workObj2.getPid());
+        request.setDatastreams(EnumSet.of(DatastreamType.MD_DESCRIPTIVE, DatastreamType.MD_EVENTS));
+        sendRequest(request);
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Processing message did not match expectations", result);
+
+        assertEmailSent();
+
+        Element rootEl = getExportedDocumentRootEl();
+
+        assertHasObjectWithoutMods(rootEl, ResourceType.Work, workObj2.getPid());
+        assertHasObjectWithDatastream(rootEl, ResourceType.Work, workObj2.getPid(), DatastreamType.MD_EVENTS,
+                "application/n-triples", logContent);
 
         assertExportDocumentCount(rootEl, 1);
     }
@@ -422,7 +542,7 @@ public class ExportXMLRouteIT {
                 bodyCaptor.capture(), filenameCaptor.capture(), attachmentCaptor.capture());
     }
 
-    private ExportXMLRequest sendRequest(boolean exportChildren, boolean excludeNoDs, PID... pids) throws IOException {
+    private ExportXMLRequest createRequest(boolean exportChildren, boolean excludeNoDs, PID... pids) {
         ExportXMLRequest request = new ExportXMLRequest();
         request.setAgent(agent);
         request.setExportChildren(exportChildren);
@@ -430,6 +550,10 @@ public class ExportXMLRouteIT {
         request.setPids(Arrays.stream(pids).map(PID::getId).collect(Collectors.toList()));
         request.setEmail(EMAIL);
         request.setRequestedTimestamp(Instant.now());
+        return request;
+    }
+
+    private ExportXMLRequest sendRequest(ExportXMLRequest request) throws IOException {
         requestService.sendRequest(request);
         return request;
     }
@@ -472,18 +596,45 @@ public class ExportXMLRouteIT {
         Element objEl = getObjectElByPid(rootEl, pid);
         assertNotNull("Did not contain expected child object " + pid, objEl);
         assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
-        assertNull(objEl.getChild("update"));
+        Element updateEl = getUpdateElByDatastream(objEl, DatastreamType.MD_DESCRIPTIVE);
+        assertNull(updateEl);
     }
 
     private void assertHasObjectWithMods(Element rootEl, ResourceType expectedType, PID pid) {
         Element objEl = getObjectElByPid(rootEl, pid);
         assertNotNull("Did not contain expected child object " + pid, objEl);
         assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
-        Element updateEl = objEl.getChild("update");
+        Element updateEl = getUpdateElByDatastream(objEl, DatastreamType.MD_DESCRIPTIVE);
         assertNotNull(updateEl);
         assertNotNull(updateEl.getAttributeValue("lastModified"));
         Element modsEl = updateEl.getChild("mods", JDOMNamespaceUtil.MODS_V3_NS);
         assertNotNull(modsEl);
+    }
+
+    private void assertHasObjectWithDatastream(Element rootEl, ResourceType expectedType, PID pid,
+            DatastreamType expectedDsType, String expectedMimetype, String expectedContent) {
+        Element objEl = getObjectElByPid(rootEl, pid);
+        assertNotNull("Did not contain expected child object " + pid, objEl);
+        assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
+        Element updateEl = getUpdateElByDatastream(objEl, expectedDsType);
+        assertNotNull(updateEl);
+        assertNotNull(updateEl.getAttributeValue("lastModified"));
+        assertEquals(expectedMimetype, updateEl.getAttributeValue("mimetype"));
+
+        String content;
+        if (expectedMimetype.equals("text/xml")) {
+            Element contentEl = updateEl.getChildren().get(0);
+            content = new XMLOutputter(Format.getRawFormat()).outputString(contentEl);
+        } else {
+            content = updateEl.getTextTrim();
+        }
+        assertEquals(expectedContent.trim(), content);
+    }
+
+    private Element getUpdateElByDatastream(Element objEl, DatastreamType dsType) {
+        return objEl.getChildren("update").stream()
+                .filter(e -> e.getAttributeValue("type").equals(dsType.getId()))
+                .findFirst().orElse(null);
     }
 
     private Element getObjectElByPid(Element rootEl, PID pid) {

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
@@ -596,18 +596,19 @@ public class ExportXMLRouteIT {
         Element objEl = getObjectElByPid(rootEl, pid);
         assertNotNull("Did not contain expected child object " + pid, objEl);
         assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
-        Element updateEl = getUpdateElByDatastream(objEl, DatastreamType.MD_DESCRIPTIVE);
-        assertNull(updateEl);
+        Element dsEl = getDatastreamElByType(objEl, DatastreamType.MD_DESCRIPTIVE);
+        assertNull(dsEl);
     }
 
     private void assertHasObjectWithMods(Element rootEl, ResourceType expectedType, PID pid) {
         Element objEl = getObjectElByPid(rootEl, pid);
         assertNotNull("Did not contain expected child object " + pid, objEl);
         assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
-        Element updateEl = getUpdateElByDatastream(objEl, DatastreamType.MD_DESCRIPTIVE);
-        assertNotNull(updateEl);
-        assertNotNull(updateEl.getAttributeValue("lastModified"));
-        Element modsEl = updateEl.getChild("mods", JDOMNamespaceUtil.MODS_V3_NS);
+        Element dsEl = getDatastreamElByType(objEl, DatastreamType.MD_DESCRIPTIVE);
+        assertNotNull(dsEl);
+        assertNotNull(dsEl.getAttributeValue("lastModified"));
+        assertEquals("update", dsEl.getAttributeValue("operation"));
+        Element modsEl = dsEl.getChild("mods", JDOMNamespaceUtil.MODS_V3_NS);
         assertNotNull(modsEl);
     }
 
@@ -616,23 +617,23 @@ public class ExportXMLRouteIT {
         Element objEl = getObjectElByPid(rootEl, pid);
         assertNotNull("Did not contain expected child object " + pid, objEl);
         assertEquals(expectedType.name(), objEl.getAttributeValue("type"));
-        Element updateEl = getUpdateElByDatastream(objEl, expectedDsType);
-        assertNotNull(updateEl);
-        assertNotNull(updateEl.getAttributeValue("lastModified"));
-        assertEquals(expectedMimetype, updateEl.getAttributeValue("mimetype"));
+        Element dsEl = getDatastreamElByType(objEl, expectedDsType);
+        assertNotNull(dsEl);
+        assertNotNull(dsEl.getAttributeValue("lastModified"));
+        assertEquals(expectedMimetype, dsEl.getAttributeValue("mimetype"));
 
         String content;
         if (expectedMimetype.equals("text/xml")) {
-            Element contentEl = updateEl.getChildren().get(0);
+            Element contentEl = dsEl.getChildren().get(0);
             content = new XMLOutputter(Format.getRawFormat()).outputString(contentEl);
         } else {
-            content = updateEl.getTextTrim();
+            content = dsEl.getTextTrim();
         }
         assertEquals(expectedContent.trim(), content);
     }
 
-    private Element getUpdateElByDatastream(Element objEl, DatastreamType dsType) {
-        return objEl.getChildren("update").stream()
+    private Element getDatastreamElByType(Element objEl, DatastreamType dsType) {
+        return objEl.getChildren("datastream").stream()
                 .filter(e -> e.getAttributeValue("type").equals(dsType.getId()))
                 .findFirst().orElse(null);
     }

--- a/static/js/admin/src/ResultObjectActionMenu.js
+++ b/static/js/admin/src/ResultObjectActionMenu.js
@@ -195,7 +195,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 			}
 
 			if ($.inArray('editDescription', metadata.permissions) != -1) {
-				items["exportXML"] = {name : 'Export MODS'};
+				items["exportXML"] = {name : 'Export Metadata'};
 			}
 		}
 

--- a/static/js/admin/src/ResultView.js
+++ b/static/js/admin/src/ResultView.js
@@ -21,7 +21,7 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 			resultActions : [
 						{
 							actions : [
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export Metadata', joiner : ' for'}
 							]
 						},
 						{

--- a/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
+++ b/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
@@ -58,11 +58,19 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 			var email = $("#xml_recipient_email", self.$form).val();
 			var includeChildren = $("#export_xml_include_children", self.$form).prop("checked");
 			var excludeNoDs = $("#export_xml_exclude_no_datastreams", self.$form).prop("checked");
+			var datastreamTypes = $.map($("input[name='export_xml_metadata_types']:checkbox:checked"), function(e,i) {
+			    return e.value;
+			});
 			
 			if (!email || !$.trim(email)) {
 				return false;
 			}
 			localStorage.setItem("send_to_address_" + onyen, email);
+
+			if (datastreamTypes.length == 0 && excludeNoDs) {
+				self.context.view.$alertHandler.alertHandler("error", "Must select at least one metadata type for export, or include objects with no returned datastreams.");
+				return false;
+			}
 
 			var pids = [];
 			for (var index in self.targets) {
@@ -78,7 +86,8 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 					email : email,
 					pids : pids,
 					exportChildren: includeChildren || false,
-					excludeNoDatastreams: excludeNoDs || false
+					excludeNoDatastreams: excludeNoDs || false,
+					datastreams: datastreamTypes || []
 				})
 			}).done(function(response) {
 				self.context.view.$alertHandler.alertHandler("message", response.message);

--- a/static/templates/admin/exportMetadataForm.html
+++ b/static/templates/admin/exportMetadataForm.html
@@ -11,6 +11,15 @@
 
 	<label class="form_inline"><input type="checkbox" id="export_xml_exclude_no_datastreams"> Exclude objects with no returned datastreams.</label>
 
+	<p style="margin-top: 1em;">Select metadata datastream types for export:</p>
+	<div style="padding-left: 2em;">
+		<label class="form_inline"><input type="checkbox" name="export_xml_metadata_types" value="MD_DESCRIPTIVE" checked="checked"> MODS Description</label>
+		<label class="form_inline"><input type="checkbox" name="export_xml_metadata_types" value="MD_EVENTS"> PREMIS Event Log</label>
+		<label class="form_inline"><input type="checkbox" name="export_xml_metadata_types" value="TECHNICAL_METADATA"> Technical Metadata (FITS)</label>
+		<label class="form_inline"><input type="checkbox" name="export_xml_metadata_types" value="MD_DESCRIPTIVE_HISTORY"> MODS Description History</label>
+		<label class="form_inline"><input type="checkbox" name="export_xml_metadata_types" value="TECHNICAL_METADATA_HISTORY"> Technical Metadata History</label>
+	</div>
+
 	<div class="update_field">
 		<input type="submit" id="export_xml_submit_button" class="update_button" value="Export" />
 	</div>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3256

* Allows for FITS, FITS History, MODS History, and PREMIS Event Logs to be included in the XML export
* Renames the `object/update` tag to `object/datastream`, with an optional `operation="update"` attribute
* Refactored out constants for xml import and export operations
* Updates to DatastreamPids helper methods
* Renamed "Export MODS" to "Export Metadata". Still named "Import MODS" since that is the only importable datastream at present.