### PR TITLE
BXC-3313 - Java 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout submodules
       run: git submodule update --init --recursive
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:
@@ -35,7 +35,7 @@ jobs:
     - name: Build with Maven
       run: mvn -B -U clean install -DskipTests
     - name: Verify DCR modules
-      run: mvn verify -pl auth-api,auth-fcrepo,common-utils,deposit-app,deposit-utils,fcrepo-utils,indexing-solr,integration,model-api,model-fcrepo,operations-jms,operations,persistence-api,persistence,search-api,search-solr,services-camel-app,web-access-app,web-admin-app,web-common,web-services-app,web-sword
+      run: mvn -pl '!clamav-java' verify 
 
     - name: Set up nodejs
       uses: actions/setup-node@v2

--- a/deposit-app/pom.xml
+++ b/deposit-app/pom.xml
@@ -194,6 +194,18 @@
             <artifactId>fcrepo-http-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>

--- a/fcrepo-utils/pom.xml
+++ b/fcrepo-utils/pom.xml
@@ -116,11 +116,6 @@
             <artifactId>fcrepo-auth-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-http-servlet</artifactId>
         </dependency>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -127,6 +127,18 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>

--- a/operations/pom.xml
+++ b/operations/pom.xml
@@ -130,5 +130,17 @@
             <groupId>org.fcrepo</groupId>
             <artifactId>fcrepo-http-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -131,6 +131,18 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,13 +114,11 @@
         <xerces.version>2.12.0</xerces.version>
         <xml-apis.version>1.4.01</xml-apis.version>
         <xom.version>1.2.5</xom.version>
-        
-        <jetty.version>9.4.12.v20180830</jetty.version>
-        <taglibs.version>1.1.2</taglibs.version>
-        <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
-        <javax.servlet.jsp.version>2.3.3</javax.servlet.jsp.version>
-        <jstl.version>1.2</jstl.version>
-        <jsp-api.version>2.2</jsp-api.version>
+
+        <taglibs.version>1.2.5</taglibs.version>
+        <jakarta.servlet.api.version>4.0.4</jakarta.servlet.api.version>
+        <jstl.version>1.2.7</jstl.version>
+        <jsp-api.version>2.3.6</jsp-api.version>
         
         <jedis.version>2.9.3</jedis.version>
         <embedded-redis.version>0.7.3</embedded-redis.version>
@@ -149,28 +147,6 @@
         
         <build-tools.path>common-utils/src/main/resources/</build-tools.path>
     </properties>
-
-    <distributionManagement>
-        <repository>
-            <id>dlbuild.libint.unc.edu</id>
-            <name>dlbuild.libint.unc.edu-releases</name>
-            <url>http://dlbuild.libint.unc.edu:8080/artifactory/libs-release-local</url>
-        </repository>
-        <snapshotRepository>
-            <id>dlbuild.libint.unc.edu</id>
-            <name>dlbuild.libint.unc.edu-snapshots</name>
-            <url>http://dlbuild.libint.unc.edu:8080/artifactory/libs-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
-
-    <issueManagement>
-        <system>trac</system>
-        <url>https://intranet.lib.unc.edu:82/trac/cdr/</url>
-    </issueManagement>
-    <scm>
-        <connection>scm:javasvn:svn://intranet.lib.unc.edu/cdr/cdr-master/trunk</connection>
-        <developerConnection>scm:javasvn:svn://intranet.lib.unc.edu/cdr/cdr-master/trunk</developerConnection>
-    </scm>
 
     <modules>
         <module>auth-api</module>
@@ -210,48 +186,6 @@
     </reporting>
 
     <profiles>
-        <profile>
-            <id>example-settings</id>
-            <!-- supplies test properties to src/test/resources/server.properties -->
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <repositoryProtocol>https</repositoryProtocol>
-                <repositoryHost>localhost</repositoryHost>
-                <repositoryPort/>
-                <repositoryContext/>
-
-                <fedoraProtocol>https</fedoraProtocol>
-                <fedoraHost>localhost</fedoraHost>
-                <fedoraPort/>
-                <fedoraContext>fedora/</fedoraContext>
-                <fedoraAdminUsername>fedoraAdmin</fedoraAdminUsername>
-                <fedoraAdminPassword>fedoraPassword</fedoraAdminPassword>
-
-                <mulgaraProtocol>http</mulgaraProtocol>
-                <mulgaraHost>localhost</mulgaraHost>
-                <mulgaraPort>:8080</mulgaraPort>
-                <mulgaraContext/>
-
-                <solrProtocol>https</solrProtocol>
-                <solrHost>localhost</solrHost>
-                <solrPort/>
-                <solrContext>solr</solrContext>
-
-                <externalBaseUrl>http://localhost/static/</externalBaseUrl>
-
-                <jmsHost>localhost</jmsHost>
-                <jmsPort>:61616</jmsPort>
-
-                <!-- note: no colon on this port -->
-                <smtpHost>localhost</smtpHost>
-                <smtpPort>25</smtpPort>
-
-                <administratorEmail>somebody@example.com</administratorEmail>
-                <repositoryFromEmail>services@example.com</repositoryFromEmail>
-            </properties>
-        </profile>
         <profile>
             <id>release</id>
             <build>
@@ -451,15 +385,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <scanIntervalSeconds>2</scanIntervalSeconds>
-                    <stopKey>STOP</stopKey>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${maven-war-plugin.version}</version>
@@ -523,40 +448,6 @@
             </plugin>
         </plugins>
     </build>
-    
-    <repositories>
-        <repository>
-            <id>maven.restlet.org</id>
-            <name>maven.restlet.org</name>
-            <url>https://maven.restlet.talend.com/</url>
-        </repository> 
-    </repositories>
-    
-    <pluginRepositories>
-        <pluginRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    
-        <pluginRepository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <dependencyManagement>
         <dependencies>
@@ -1030,30 +921,26 @@
             
             <!-- Servlets -->
             <dependency>
-                <groupId>taglibs</groupId>
-                <artifactId>standard</artifactId>
+                <groupId>org.apache.taglibs</groupId>
+                <artifactId>taglibs-standard-impl</artifactId>
                 <version>${taglibs.version}</version>
+                <scope>runtime</scope>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>jstl</artifactId>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
                 <version>${jstl.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>jsp-api</artifactId>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
                 <version>${jsp-api.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.servlet</groupId>
-                <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet.api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.servlet.jsp</groupId>
-                <artifactId>javax.servlet.jsp-api</artifactId>
-                <version>${javax.servlet.jsp.version}</version>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.api.version}</version>
                 <scope>provided</scope>
             </dependency>
             

--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,13 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.copyrightYear>2008</project.copyrightYear>
         
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
         <javax.annotation.version>1.3.2</javax.annotation.version>
         <javax.jaxb.version>2.3.1</javax.jaxb.version>
         <javax.jaxb-core.version>2.3.0.1</javax.jaxb-core.version>
+        <jakarta.xml.bind.version>3.0.1</jakarta.xml.bind.version>
+        <glassfish-jaxb.version>3.0.1</glassfish-jaxb.version>
         <javax.activation.version>1.1.1</javax.activation.version>
         
         <cdr.version>5.0-SNAPSHOT</cdr.version>
@@ -708,20 +710,35 @@
                 <artifactId>javax.annotation-api</artifactId>
                 <version>${javax.annotation.version}</version>
             </dependency>
+            <!-- old jaxb versions for integration tests with fedora 5.x, can remove once on fedora 6 -->
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
                 <version>${javax.jaxb.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-core</artifactId>
                 <version>${javax.jaxb-core.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
                 <version>${javax.jaxb.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- Java 9+ jaxb versions -->
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${glassfish-jaxb.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.activation</groupId>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -272,6 +272,18 @@
         <artifactId>fcrepo-http-api</artifactId>
     </dependency>
     <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
     </dependency>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -197,6 +197,23 @@
         <artifactId>operations</artifactId>
     </dependency>
 
+    <!-- Jaxb 2.x dependencies, until camel-core no longer requires them -->
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <scope>compile</scope>
+    </dependency>
+    <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <scope>compile</scope>
+    </dependency>
+
     <!-- Testing -->
     <dependency>
         <groupId>org.apache.camel</groupId>
@@ -270,18 +287,6 @@
     <dependency>
         <groupId>org.fcrepo</groupId>
         <artifactId>fcrepo-http-api</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-core</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>com.sun.xml.bind</groupId>
-        <artifactId>jaxb-impl</artifactId>
     </dependency>
     <dependency>
         <groupId>org.springframework</groupId>

--- a/web-access-app/pom.xml
+++ b/web-access-app/pom.xml
@@ -47,21 +47,12 @@
 
         <!-- Servlet -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/web-access-app/pom.xml
+++ b/web-access-app/pom.xml
@@ -63,6 +63,14 @@
             <artifactId>javax.servlet.jsp-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <!-- Spring -->
         <dependency>
@@ -185,6 +193,18 @@
         <dependency>
             <groupId>org.fcrepo</groupId>
             <artifactId>fcrepo-http-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/web-admin-app/pom.xml
+++ b/web-admin-app/pom.xml
@@ -42,21 +42,12 @@
 
         <!-- Servlet -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>javax.servlet.jsp-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/web-admin-app/pom.xml
+++ b/web-admin-app/pom.xml
@@ -58,6 +58,14 @@
             <artifactId>javax.servlet.jsp-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -27,21 +27,20 @@
         
         <!-- Servlets -->
         <dependency>
-            <groupId>taglibs</groupId>
-            <artifactId>standard</artifactId>
+            <groupId>org.apache.taglibs</groupId>
+            <artifactId>taglibs-standard-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>jstl</artifactId>
+          <groupId>jakarta.servlet.jsp.jstl</groupId>
+          <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet.jsp</groupId>
-            <artifactId>jsp-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         
         <!-- Spring -->

--- a/web-services-app/pom.xml
+++ b/web-services-app/pom.xml
@@ -153,6 +153,14 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.ws</groupId>
             <artifactId>spring-ws-core</artifactId>
         </dependency>
@@ -211,6 +219,18 @@
             <artifactId>fcrepo-http-commons</artifactId>
             <scope>test</scope>
             <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
         </dependency>
         <dependency>
             <groupId>it.ozimov</groupId>

--- a/web-services-app/pom.xml
+++ b/web-services-app/pom.xml
@@ -147,10 +147,10 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <!-- Servlets -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>

--- a/web-sword/pom.xml
+++ b/web-sword/pom.xml
@@ -148,8 +148,8 @@
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3313

* Updates compiler version to java 11
* Servlet version updated to 4
* Explicitly added jaxb dependencies, which are no longer built into java. Retaining older version of jaxb in a test scope for integration tests that involve fedora.