### PR TITLE
BXC-3314 - FITS failure for .mov file in path containing parentheses

### DIFF
--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -473,6 +473,27 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, 1);
     }
 
+    @Test
+    public void movFileParenthesisTest() throws Exception {
+        setupFitsCommand("src/test/resources/fitsReports/imageReport.xml");
+
+        PID workPid = makePid(RepositoryPathConstants.CONTENT_BASE);
+        Bag workBag = model.createBag(workPid.getRepositoryPath());
+        workBag.addProperty(RDF.type, Cdr.Work);
+        depositBag.add(workBag);
+        String parentFolderName = "paren(goes)here";
+        File parentFolder = tmpFolder.newFolder(parentFolderName);
+        String filename = "commencement.MOV";
+        File sourceFile = new File(parentFolder, "commence.mov");
+        PID filePid = addFileObject(workBag, sourceFile.getAbsolutePath(), IMAGE_MIMETYPE, IMAGE_MD5);
+
+        job.closeModel();
+
+        job.run();
+
+        verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, 1);
+    }
+
     private HttpUriRequest getRequest() throws Exception {
         ArgumentCaptor<HttpUriRequest> requestCaptor = ArgumentCaptor.forClass(HttpUriRequest.class);
         verify(httpClient).execute(requestCaptor.capture());


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3314

* Skip wrapping file path in quotes when running FITS CLI since the FITS script also causes all arguments to be wrapped in quotes, resulting it being double wrapped and therefore not wrapped. 
* Minor refactoring of CLI executing code to improve reporting