### PR TITLE
BXC-3295 - Optimistic locking for bulk metadata imports

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionService.java
@@ -25,6 +25,7 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Instant;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.vocabulary.RDF;
@@ -129,6 +130,7 @@ public class UpdateDescriptionService {
             newVersion.setContentType(MD_DESCRIPTIVE.getMimetype());
             newVersion.setFilename(MD_DESCRIPTIVE.getDefaultFilename());
             newVersion.setTransferSession(request.getTransferSession());
+            newVersion.setUnmodifiedSince(request.getUnmodifiedSince());
 
             BinaryObject descBinary;
             if (repoObjFactory.objectExists(modsDsPid.getRepositoryUri())) {
@@ -215,6 +217,7 @@ public class UpdateDescriptionService {
         private AgentPrincipals agent;
         private InputStream modsStream;
         private IndexingPriority priority;
+        private Instant unmodifiedSince;
 
         public UpdateDescriptionRequest(AgentPrincipals agent, PID pid, InputStream modsStream) {
             this.agent = agent;
@@ -276,6 +279,15 @@ public class UpdateDescriptionService {
 
         public UpdateDescriptionRequest withPriority(IndexingPriority priority) {
             this.priority = priority;
+            return this;
+        }
+
+        public Instant getUnmodifiedSince() {
+            return unmodifiedSince;
+        }
+
+        public UpdateDescriptionRequest withUnmodifiedSince(Instant unmodifiedSince) {
+            this.unmodifiedSince = unmodifiedSince;
             return this;
         }
     }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
@@ -409,7 +409,6 @@ public class ImportXMLJob implements Runnable {
         if (operation == null || !BulkXMLConstants.OPER_UPDATE_ATTR.equals(operation.getValue())) {
             return null;
         }
-        DatastreamOperationDetails details = new DatastreamOperationDetails();
         Attribute typeAttr = element.getAttributeByName(typeAttribute);
         if (typeAttr == null) {
             failed.put(currentPid.getQualifiedId(),
@@ -420,6 +419,7 @@ public class ImportXMLJob implements Runnable {
                     "Invalid import data, unsupported type in update tag");
             return null;
         }
+        DatastreamOperationDetails details = new DatastreamOperationDetails();
         details.dsType = typeAttr.getValue();
         Attribute modifiedAttr = element.getAttributeByName(modifiedAttribute);
         if (modifiedAttr != null) {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.nio.file.Files;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -98,6 +100,7 @@ public class ImportXMLJob implements Runnable {
     private final static QName pidAttribute = new QName(BulkXMLConstants.PID_ATTR);
     private final static QName typeAttribute = new QName(BulkXMLConstants.TYPE_ATTR);
     private final static QName operationAttribute = new QName(BulkXMLConstants.OPERATION_ATTR);
+    private final static QName modifiedAttribute = new QName(BulkXMLConstants.MODIFIED_ATTR);
 
     private PID currentPid;
     private int objectCount = 0;
@@ -105,6 +108,7 @@ public class ImportXMLJob implements Runnable {
     private XMLEventReader xmlReader;
     private final XMLOutputFactory xmlOutput = XMLOutputFactory.newInstance();
     private DocumentState state = DocumentState.ROOT;
+    private Instant currentLastModified;
 
     private final String userEmail;
     private AgentPrincipals agent;
@@ -148,7 +152,7 @@ public class ImportXMLJob implements Runnable {
                 MultiDestinationTransferSession session = transferService.getSession();
         ) {
             initializeXMLReader(importStream);
-            processUpdates(session, null, null);
+            processUpdates(session);
             log.info("Finished metadata import for {} objects in {}ms for user {}",
                     objectCount, System.currentTimeMillis() - startTime, username);
             sendCompletedEmail(updated, failed);
@@ -257,18 +261,14 @@ public class ImportXMLJob implements Runnable {
         xmlReader = createXMLInputFactory().createXMLEventReader(importStream);
     }
 
-    private void processUpdates(MultiDestinationTransferSession session, PID resumePid, String resumeDs)
+    private void processUpdates(MultiDestinationTransferSession session)
             throws XMLStreamException, ServiceException {
         QName contentOpening = null;
         long countOpenings = 0;
         XMLEventWriter xmlWriter = null;
         StringWriter contentWriter = null;
 
-        String currentDs = null;
-
-        boolean resumeMode = (resumePid != null);
-        boolean foundResumptionPoint = false;
-        boolean updateOperation = false;
+        DatastreamDetails dsOpDetails = null;
 
         try {
             while (xmlReader.hasNext()) {
@@ -311,32 +311,13 @@ public class ImportXMLJob implements Runnable {
                         break;
                     case IN_OBJECT:
                         if (e.isStartElement()) {
-                            updateOperation = false;
                             StartElement element = e.asStartElement();
                             // Found start of update, extract the datastream
                             if (element.getName().getLocalPart().equals(DATASTREAM_TAG)) {
-                                Attribute operation = element.getAttributeByName(operationAttribute);
-                                Attribute typeAttr = element.getAttributeByName(typeAttribute);
-                                if (typeAttr == null) {
-                                    failed.put(currentPid.getQualifiedId(),
-                                            "Invalid import data, missing type attribute on update");
-                                } else if (MODS_TYPE.equals(typeAttr.getValue())) {
-                                    updateOperation = operation != null && BulkXMLConstants.OPER_UPDATE_ATTR
-                                            .equals(operation.getValue());
-                                    if (updateOperation) {
-                                        currentDs = MODS_TYPE;
-                                        log.debug("Starting MODS element for object {}", currentPid.getQualifiedId());
-                                    }
-                                } else {
-                                    failed.put(currentPid.getQualifiedId(),
-                                            "Invalid import data, unsupported type in update tag");
-                                }
-
-                                foundResumptionPoint = resumeMode
-                                        && currentPid.equals(resumePid) && currentDs.equals(resumeDs);
+                                dsOpDetails = startDatastreamOperation(element);
 
                                 state = DocumentState.IN_CONTENT;
-                                if (!resumeMode && updateOperation) {
+                                if (dsOpDetails != null) {
                                     contentWriter = new StringWriter();
                                     xmlWriter = xmlOutput.createXMLEventWriter(contentWriter);
                                 }
@@ -367,7 +348,7 @@ public class ImportXMLJob implements Runnable {
                                 e.asEndElement().getName().getLocalPart())) {
                             state = DocumentState.IN_OBJECT;
 
-                            if (!resumeMode && updateOperation) {
+                            if (dsOpDetails != null) {
                                 xmlWriter.close();
                                 xmlWriter = null;
                                 InputStream modsStream = new ByteArrayInputStream(contentWriter.toString().getBytes());
@@ -379,7 +360,8 @@ public class ImportXMLJob implements Runnable {
                                     updateService.updateDescription(
                                             new UpdateDescriptionRequest(agent, currentPid, modsStream)
                                                 .withTransferSession(transferSession)
-                                                .withPriority(IndexingPriority.low));
+                                                .withPriority(IndexingPriority.low)
+                                                .withUnmodifiedSince(dsOpDetails.lastModified));
                                     updated.add(currentPid.getQualifiedId());
                                     log.debug("Finished updating object {} with id {}", objectCount, currentPid);
                                 } catch (AccessRestrictionException ex) {
@@ -398,11 +380,9 @@ public class ImportXMLJob implements Runnable {
                                     failed.put(currentPid.getQualifiedId(),
                                             "Error retrieving object from Fedora: " + ex.getMessage());
                                 }
-                            } else if (foundResumptionPoint) {
-                                return;
                             }
                         } else {
-                            if (!resumeMode && updateOperation) {
+                            if (dsOpDetails != null) {
                                 // Store all of the content from the incoming document
                                 xmlWriter.add(e);
                             }
@@ -416,6 +396,51 @@ public class ImportXMLJob implements Runnable {
             }
         }
 
+    }
+
+    /**
+     * Start a datastream operation, if it passes preconditions:
+     *     * Has a valid type attribute (currently only MODS)
+     *     * Either has no last modified attribute, or has one in ISO 8601 format
+     *     * Is a valid operation (currently only updates)
+     * @param element
+     * @return Details about the operation, or null if it is not a valid operation
+     */
+    private DatastreamDetails startDatastreamOperation(StartElement element) {
+        Attribute operation = element.getAttributeByName(operationAttribute);
+        if (operation == null || !BulkXMLConstants.OPER_UPDATE_ATTR.equals(operation.getValue())) {
+            return null;
+        }
+        DatastreamDetails details = new DatastreamDetails();
+        Attribute typeAttr = element.getAttributeByName(typeAttribute);
+        if (typeAttr == null) {
+            failed.put(currentPid.getQualifiedId(),
+                    "Invalid import data, missing type attribute on update");
+            return null;
+        } else if (!MODS_TYPE.equals(typeAttr.getValue())) {
+            failed.put(currentPid.getQualifiedId(),
+                    "Invalid import data, unsupported type in update tag");
+            return null;
+        }
+        details.dsType = typeAttr.getValue();
+        Attribute modifiedAttr = element.getAttributeByName(modifiedAttribute);
+        if (modifiedAttr != null) {
+            try {
+                details.lastModified = Instant.parse(modifiedAttr.getValue());
+            } catch (DateTimeParseException e) {
+                failed.put(currentPid.getQualifiedId(), "Invalid last modified timestamp," +
+                        " must be in ISO 8601 format");
+                return null;
+            }
+        }
+        log.debug("Starting MODS element for object {}", currentPid.getQualifiedId());
+        return details;
+    }
+
+    private class DatastreamDetails {
+        private String dsType;
+        private Instant lastModified;
+        private boolean updateOperation;
     }
 
     private void close() {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
@@ -45,6 +45,7 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import edu.unc.lib.boxc.fcrepo.exceptions.OptimisticLockException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -371,6 +372,8 @@ public class ImportXMLJob implements Runnable {
                                             "Error reading or converting MODS stream: " + ex.getMessage());
                                 } catch (NotFoundException ex) {
                                     failed.put(currentPid.getQualifiedId(), "Object not found");
+                                } catch (OptimisticLockException ex) {
+                                    failed.put(currentPid.getQualifiedId(), ex.getMessage());
                                 } catch (FedoraException ex) {
                                     failed.put(currentPid.getQualifiedId(),
                                             "Error retrieving object from Fedora: " + ex.getMessage());

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -77,8 +77,9 @@ public class VersionedDatastreamService {
             Instant fcrepoModified = dsObj.getLastModified().toInstant();
             if (newVersion.getUnmodifiedSince().isBefore(fcrepoModified)) {
                 throw new OptimisticLockException("Rejecting update to datastream " + dsPid.getQualifiedId()
-                        + ", must not have been modified since " + newVersion.getUnmodifiedSince()
-                        + " but was last updated " + fcrepoModified);
+                        + ", update specifies datastream must not have been modified since "
+                        + newVersion.getUnmodifiedSince()
+                        + " but version in the repository was last updated " + fcrepoModified);
             }
         }
 

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -76,9 +76,9 @@ public class VersionedDatastreamService {
         if (dsObj != null && newVersion.getUnmodifiedSince() != null) {
             Date lastModified = dsObj.getLastModified();
             if (dsObj.getLastModified().toInstant().isAfter(newVersion.getUnmodifiedSince())) {
-                throw new OptimisticLockException("Rejecting update to datastream " + dsPid
-                        + ", last updated " + lastModified + " but required to have not been modified since "
-                        + newVersion.getUnmodifiedSince());
+                throw new OptimisticLockException("Rejecting update to datastream " + dsPid.getQualifiedId()
+                        + ", last updated " + lastModified.toInstant()
+                        + " but is required to have not been modified since " + newVersion.getUnmodifiedSince());
             }
         }
 

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -74,11 +74,11 @@ public class VersionedDatastreamService {
         Lock dsLock = lockManager.awaitWriteLock(dsPid);
         BinaryObject dsObj = getBinaryObject(dsPid);
         if (dsObj != null && newVersion.getUnmodifiedSince() != null) {
-            Date lastModified = dsObj.getLastModified();
-            if (dsObj.getLastModified().toInstant().isAfter(newVersion.getUnmodifiedSince())) {
+            Instant fcrepoModified = dsObj.getLastModified().toInstant();
+            if (newVersion.getUnmodifiedSince().isBefore(fcrepoModified)) {
                 throw new OptimisticLockException("Rejecting update to datastream " + dsPid.getQualifiedId()
-                        + ", last updated " + lastModified.toInstant()
-                        + " but is required to have not been modified since " + newVersion.getUnmodifiedSince());
+                        + ", must not have been modified since " + newVersion.getUnmodifiedSince()
+                        + " but was last updated " + fcrepoModified);
             }
         }
 

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -21,9 +21,11 @@ import static org.slf4j.LoggerFactory.getLogger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.locks.Lock;
 
+import edu.unc.lib.boxc.fcrepo.exceptions.OptimisticLockException;
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
 
@@ -71,6 +73,14 @@ public class VersionedDatastreamService {
 
         Lock dsLock = lockManager.awaitWriteLock(dsPid);
         BinaryObject dsObj = getBinaryObject(dsPid);
+        if (dsObj != null && newVersion.getUnmodifiedSince() != null) {
+            Date lastModified = dsObj.getLastModified();
+            if (dsObj.getLastModified().toInstant().isAfter(newVersion.getUnmodifiedSince())) {
+                throw new OptimisticLockException("Rejecting update to datastream " + dsPid
+                        + ", last updated " + lastModified + " but required to have not been modified since "
+                        + newVersion.getUnmodifiedSince());
+            }
+        }
 
         // Get a session for transferring the binary and its history
         BinaryTransferSession session = null;
@@ -249,6 +259,8 @@ public class VersionedDatastreamService {
         private String sha1;
         private String filename;
         private Model properties;
+        // Date after which the datastream must not have been modified, for optimistic locking
+        private Instant unmodifiedSince;
 
         public DatastreamVersion(PID dsPid) {
             this.dsPid = dsPid;
@@ -320,6 +332,14 @@ public class VersionedDatastreamService {
 
         public void setProperties(Model properties) {
             this.properties = properties;
+        }
+
+        public Instant getUnmodifiedSince() {
+            return unmodifiedSince;
+        }
+
+        public void setUnmodifiedSince(Instant unmodifiedSince) {
+            this.unmodifiedSince = unmodifiedSince;
         }
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLProcessor.java
@@ -269,7 +269,8 @@ public class ExportXMLProcessor implements Processor {
 
                 Element datastreamEl = new Element(BulkXMLConstants.DATASTREAM_TAG);
                 datastreamEl.setAttribute(BulkXMLConstants.TYPE_ATTR, dsType.getId());
-                datastreamEl.setAttribute(BulkXMLConstants.MODIFIED_ATTR, dsObj.getLastModified().toString());
+                datastreamEl.setAttribute(BulkXMLConstants.MODIFIED_ATTR,
+                        dsObj.getLastModified().toInstant().toString());
                 String mimetype = dsObj.getMimetype();
                 datastreamEl.setAttribute(BulkXMLConstants.MIMETYPE_ATTR, mimetype);
                 datastreamEl.addContent(SEPERATOR);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3295

* Implements support for optimistic locking for bulk MODS imports
    * This means that if a "lastModified" timestamp is present for a datastream in the import document and the timestamp listed is older than the timestamp of the MODS datastream in fedora, then the update will be rejected. See an example document below which contains the lastModified attributes
    * To support this, the EditDescription and VersionedDatastreamService were updated to support optimistic locking
* XML Exports now return the lastModified attribute in ISO8601 format (previously it was using default java Date format)
* Some refactoring of import document parsing, since all the additions to the original structure were getting unweildy
* Some fixes to tests which had hardcoded timestamps that would have caused them to unintentionally fail

```
<?xml version="1.0" encoding="utf-8"?>
<bulkMetadata>
<object pid="content/00b9b91c-833e-46c6-ac45-410d4f278aa0" type="Work">
<datastream type="md_descriptive" lastModified="2021-12-22T14:41:23.339Z" mimetype="text/xml" operation="update">
<mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
  <mods:titleInfo>
    <mods:title>Test Publication!</mods:title>
  </mods:titleInfo>
  <mods:language>
    <mods:languageTerm authority="iso639-2b" type="code">eng</mods:languageTerm>
  </mods:language>
  <mods:originInfo>
    <mods:issuance>continuing</mods:issuance>
  </mods:originInfo>
</mods:mods>
</datastream>
</object>
<object pid="content/9b65434e-e94e-4682-946a-db88cbff06a1" type="File" parent="content/00b9b91c-833e-46c6-ac45-410d4f278aa0" />
<object pid="content/4847f854-04be-4d32-9b68-361ff5fc0bf8" type="Work">
<datastream type="md_descriptive" lastModified="2021-12-03T14:29:47.003Z" mimetype="text/xml" operation="update">
<mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
  <mods:titleInfo>
    <mods:title>Another Publication</mods:title>
  </mods:titleInfo>
  <mods:typeOfResource>still image</mods:typeOfResource>
  <mods:genre authority="gmgpc">digital images</mods:genre>
</mods:mods>
</datastream>
</object>
<object pid="content/3a508f4a-c36e-4f5a-9daf-8a4b2364559c" type="File" parent="content/4847f854-04be-4d32-9b68-361ff5fc0bf8" />
<object pid="content/03b431d1-b254-4369-8f2c-f161e6b39b6d" type="File" parent="content/4847f854-04be-4d32-9b68-361ff5fc0bf8" />
<object pid="content/b265df25-fe69-40f1-b438-f28cbf2d1892" type="Work">
<datastream type="md_descriptive" lastModified="2021-12-03T14:29:47.003Z" mimetype="text/xml" operation="update">
<mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
  <mods:titleInfo>
    <mods:title>Boxy image</mods:title>
  </mods:titleInfo>
  <mods:typeOfResource>still image</mods:typeOfResource>
  <mods:genre authority="gmgpc">digital images</mods:genre>
</mods:mods>
</datastream>
</object>
<object pid="content/f3216a1f-d6cb-479b-8700-295df19f1b5e" type="File" parent="content/b265df25-fe69-40f1-b438-f28cbf2d1892" />
</bulkMetadata>
```