### PR TITLE
BXC-3392 - Fix bug with advanced search collection filter not working

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import edu.unc.lib.boxc.search.solr.facets.GenericFacet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -463,10 +464,9 @@ public class SearchStateFactory {
             searchState.getSearchFields().put(SearchFieldKey.TITLE_INDEX.name(), parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.ANCESTOR_PATH.name()));
+        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.PARENT_COLLECTION.name()));
         if (parameter != null && parameter.length() > 0) {
-            CutoffFacet hierFacet = new CutoffFacetImpl(SearchFieldKey.ANCESTOR_PATH.name(), parameter);
-            searchState.addFacet(hierFacet);
+            searchState.setFacet(new GenericFacet(SearchFieldKey.PARENT_COLLECTION, parameter));
         }
 
         parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.DEPARTMENT.name()));

--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/AdvancedSearchFormController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/AdvancedSearchFormController.java
@@ -95,16 +95,10 @@ public class AdvancedSearchFormController extends AbstractSolrSearchController {
         // If the user has submitted the search form, then generate a search state
         // and forward them to the search servlet.
         SearchState searchState = searchStateFactory.createSearchStateAdvancedSearch(request.getParameterMap());
-        String container = request.getParameter("container");
 
         request.getSession().setAttribute("searchState", searchState);
         model.addAllAttributes(SearchStateUtil.generateStateParameters(searchState));
 
-        String collection = (container != null && container.length() > 0) ? container : null;
-        if (collection == null) {
-            return "redirect:/search";
-        }
-
-        return "redirect:/search?collection=" + collection;
+        return "redirect:/search";
     }
 }

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
@@ -46,7 +46,7 @@
 		<div class="twocol light shadowtop">
 			<div class="contentarea">
 				<h3>Limit By</h3>
-				<select name="container" class="advsearch_select" aria-label="collection">
+				<select name="${searchSettings.searchFieldParams['PARENT_COLLECTION']}" class="advsearch_select" aria-label="collection">
 					<option value="">Collection</option>
 					<c:forEach items="${collectionList}" var="collectionRecord">
 						<option value="<c:out value='${collectionRecord.id}' />"><c:out value="${collectionRecord.title}" /></option>


### PR DESCRIPTION
* Fix bug with advanced search collection filter not working by adding parent collection filter via the standard 'collection' parameter rather than giving it special URL construction behaviors
    * the issue was that the advanced search controller constructs a SearchState which gets passed to the regular search controller via the session, meanwhile the "collection" parameter was only being added to the URL which the advanced search forwards to. So when the regular search controller executes, it sees that a SearchState is already present and uses that rather than parsing the current URL, but the "collection" parameter is only in the URL and not the SearchState.