### PR TITLE
BXC-3153/3166 - Handling of indexing exceptions

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/exception/RecoverableIndexingException.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/exception/RecoverableIndexingException.java
@@ -16,28 +16,21 @@
 package edu.unc.lib.boxc.indexing.solr.exception;
 
 /**
- * Exception while attempting to index to solr
+ * Indexing exception which it may be possible to recover from
  *
  * @author bbpennel
  */
-public class IndexingException extends RuntimeException {
-    private static final long serialVersionUID = 1L;
-    private String body;
+public class RecoverableIndexingException extends IndexingException {
 
-    public IndexingException(String message, Throwable cause, String body) {
-        super(message, cause);
-        this.body = body;
+    public RecoverableIndexingException(String message, Throwable cause, String body) {
+        super(message, cause, body);
     }
 
-    public IndexingException(String message, Throwable cause) {
+    public RecoverableIndexingException(String message, Throwable cause) {
         super(message, cause);
     }
 
-    public IndexingException(String message) {
+    public RecoverableIndexingException(String message) {
         super(message);
-    }
-
-    public String getBody() {
-        return body;
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solr/SolrRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solr/SolrRouter.java
@@ -16,15 +16,18 @@
 
 package edu.unc.lib.boxc.services.camel.solr;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
+import edu.unc.lib.boxc.indexing.solr.exception.RecoverableIndexingException;
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
+import org.apache.http.HttpException;
+import org.fcrepo.client.FcrepoOperationFailedException;
 import org.slf4j.Logger;
 
-import edu.unc.lib.boxc.indexing.solr.exception.ObjectTombstonedException;
-import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import java.net.ConnectException;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Router which triggers the full indexing of individual objects to Solr.
@@ -44,13 +47,20 @@ public class SolrRouter extends RouteBuilder {
             .routeId("CdrServiceSolr")
             .startupOrder(40)
             .onException(NotFoundException.class)
+                .redeliveryDelay("{{cdr.enhancement.solr.notFound.retryDelay:500}}")
+                .maximumRedeliveries("{{cdr.enhancement.solr.notFound.maxRedeliveries:10}}")
+                .backOffMultiplier("{{cdr.enhancement.solr.notFound.backOffMultiplier:2}}")
+                .retryAttemptedLogLevel(LoggingLevel.DEBUG)
+            .end()
+            .onException(RecoverableIndexingException.class, FcrepoOperationFailedException.class,
+                    ConnectException.class, HttpException.class)
                 .redeliveryDelay("{{cdr.enhancement.solr.error.retryDelay:500}}")
                 .maximumRedeliveries("{{cdr.enhancement.solr.error.maxRedeliveries:10}}")
                 .backOffMultiplier("{{cdr.enhancement.solr.error.backOffMultiplier:2}}")
-                .retryAttemptedLogLevel(LoggingLevel.DEBUG)
+                .retryAttemptedLogLevel(LoggingLevel.WARN)
             .end()
-            .onException(ObjectTombstonedException.class)
-                .retriesExhaustedLogLevel(LoggingLevel.DEBUG)
+            .onException(Exception.class)
+                .retriesExhaustedLogLevel(LoggingLevel.ERROR)
             .end()
             .log(LoggingLevel.DEBUG, log, "Calling solr indexing route for ${headers[org.fcrepo.jms.identifier]}")
             .bean(solrIngestProcessor);

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -271,6 +271,7 @@
         class="edu.unc.lib.boxc.indexing.solr.action.IndexTreeCleanAction">
         <property name="actionType" value="ADD" />
         <property name="deleteAction" ref="deleteSolrTreeAction" />
+        <property name="treeIndexer" ref="recursiveTreeIndexer" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3153
https://jira.lib.unc.edu/browse/BXC-3166

* Adjust error handling during solr indexing so that a smaller subset of potentially recoverable exceptions will get retried. 
* Unexpected or known unrecoverable exceptions would fail after the first try.
* Separate delay config for obj not found vs other recoverable errors
* Adds a RecoverableIndexingException to help differentiate