### PR TITLE
BXC-3426 - Prevent full record page error when illegal characters in collection id

### DIFF
--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/FindingAidUrlServiceTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/FindingAidUrlServiceTest.java
@@ -90,4 +90,26 @@ public class FindingAidUrlServiceTest {
         String collId = "50000";
         assertNull(service.getFindingAidUrl(collId));
     }
+
+    @Test
+    public void unencodedCollectionIdTest() {
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        String collId = "55555 oh+no";
+        assertEquals(BASE_URL + "55555%20oh+no/", service.getFindingAidUrl(collId));
+    }
+
+    @Test
+    public void blankCollectionIdTest() {
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
+
+        String collId = "";
+        assertNull(service.getFindingAidUrl(collId));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void noBaseUrlTest() {
+        service.setFindingAidBaseUrl(null);
+        service.init();
+    }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3426

* Encode collection id in finding aid urls. 
* Add check to ensure that base url set