### PR TITLE
BXC-3205 - Index contentType of all children files onto work

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPackage.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPackage.java
@@ -62,6 +62,10 @@ public class DocumentIndexingPackage {
         return contentObject;
     }
 
+    public void setContentObject(ContentObject contentObject) {
+        this.contentObject = contentObject;
+    }
+
     public IndexDocumentBean getDocument() {
         return document;
     }

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -23,9 +23,11 @@ import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.FolderObject;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.facets.CutoffFacet;
 import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.solr.facets.CutoffFacetImpl;
 import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
@@ -39,6 +41,7 @@ import org.mockito.Mock;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -58,7 +61,6 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class SetContentTypeFilterTest {
 
     private DocumentIndexingPackage dip;
-    @Mock
     private PID pid;
     @Mock
     private FileObject fileObj;
@@ -75,7 +77,6 @@ public class SetContentTypeFilterTest {
     private SolrSearchService solrSearchService;
     @Mock
     private DocumentIndexingPackageDataLoader documentIndexingPackageDataLoader;
-    @Mock
     private CutoffFacet ancestorPath;
     @Mock
     private SearchResultResponse searchResultResponse;
@@ -86,12 +87,14 @@ public class SetContentTypeFilterTest {
     public void setup() throws Exception {
         initMocks(this);
 
+        pid = PIDs.get(UUID.randomUUID().toString());
         dip = new DocumentIndexingPackage(pid, null, documentIndexingPackageDataLoader);
         dip.setPid(pid);
         idb = dip.getDocument();
 
         when(fileObj.getOriginalFile()).thenReturn(binObj);
-        when(ancestorPath.getFieldName()).thenReturn(SearchFieldKey.ANCESTOR_PATH.name());
+        ancestorPath = new CutoffFacetImpl(SearchFieldKey.ANCESTOR_PATH.name(), Arrays.asList(
+                "1,1ed05130-d25f-4890-9086-02d98625275f", "2,5aa1ad67-c494-48dc-839e-241826559abb"), 0);
         when(solrSearchService.getSearchResults(any(SearchRequest.class))).thenReturn(searchResultResponse);
         when(solrSearchService.getAncestorPath(pid.getId(), null)).thenReturn(ancestorPath);
 

--- a/integration/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/integration/src/test/resources/spring-test/solr-indexing-context.xml
@@ -203,6 +203,7 @@
     </bean>
 
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
+        <property name="solrSearchService" ref="solrSearchService" />
     </bean>
 
     <bean id="setDatastreamFilter"

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
@@ -29,6 +29,7 @@ public enum IndexingActionType {
     ADD("Add/Update", "Adds or updates the entry for the specified object"),
     UPDATE_DESCRIPTION("Update description", "Updates the descriptive metadata for the specified object"),
     UPDATE_DATASTREAMS("Update datastreams", "Updates datastream metadata for the specified object"),
+    UPDATE_WORK_FILES("Update work files", "Set of files within a work has been updated."),
     UPDATE_FULL_TEXT("Update full text", "Updates the full text data for the specified object"),
     DELETE("Remove from Index", "Removes the index entry for the specified object"),
     COMMIT("Commit", "Causes an immediate upload and commit of pending updates"),

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecord.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecord.java
@@ -117,7 +117,7 @@ public class ContentObjectSolrRecord extends IndexDocumentBean implements Conten
     }
 
     @Field
-    public void setContentType(ArrayList<String> contentTypes) {
+    public void setContentType(List<String> contentTypes) {
         super.setContentType(contentTypes);
         this.contentTypeFacet = MultivaluedHierarchicalFacet.createMultivaluedHierarchicalFacets(
                 SearchFieldKey.CONTENT_TYPE.name(), contentTypes);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.services.camel.solrUpdate;
+
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+
+import java.util.Collection;
+
+/**
+ * Sends individual indexing operations from aggregated collections of object identifiers
+ *
+ * @author bbpennel
+ */
+public class AggregateUpdateProcessor implements Processor {
+    private IndexingMessageSender messageSender;
+    private IndexingActionType actionType;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+        var idCollection = in.getBody(Collection.class);
+        for (Object idObj : idCollection) {
+            PID pid = PIDs.get(idObj.toString());
+            messageSender.sendIndexingOperation(null, pid, actionType);
+        }
+    }
+
+    public void setIndexingMessageSender(IndexingMessageSender messageSender) {
+        this.messageSender = messageSender;
+    }
+
+    public void setActionType(IndexingActionType actionType) {
+        this.actionType = actionType;
+    }
+}

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdatePreprocessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdatePreprocessor.java
@@ -95,6 +95,7 @@ public class SolrUpdatePreprocessor implements Processor {
                     IndexingActionType.UPDATE_ACCESS,
                     IndexingActionType.UPDATE_PATH,
                     IndexingActionType.UPDATE_DATASTREAMS,
+                    IndexingActionType.UPDATE_WORK_FILES,
                     IndexingActionType.UPDATE_FULL_TEXT,
                     IndexingActionType.COMMIT,
                     IndexingActionType.DELETE);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessor.java
@@ -15,23 +15,17 @@
  */
 package edu.unc.lib.boxc.services.camel.solrUpdate;
 
-import static edu.unc.lib.boxc.common.metrics.TimerFactory.createTimerForClass;
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
-import static java.util.stream.Collectors.toMap;
-
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import edu.unc.lib.boxc.indexing.solr.ChildSetRequest;
+import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
+import edu.unc.lib.boxc.indexing.solr.action.IndexingAction;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
+import io.dropwizard.metrics5.Timer;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -40,12 +34,16 @@ import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.unc.lib.boxc.indexing.solr.ChildSetRequest;
-import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
-import edu.unc.lib.boxc.indexing.solr.action.IndexingAction;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
-import edu.unc.lib.boxc.services.camel.util.MessageUtil;
-import io.dropwizard.metrics5.Timer;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static edu.unc.lib.boxc.common.metrics.TimerFactory.createTimerForClass;
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * Processes solr update messages, triggering the requested solr update action.

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessor.java
@@ -59,13 +59,11 @@ public class SolrUpdateProcessor implements Processor {
     private MessageSender updateWorkSender;
     private Map<IndexingActionType, IndexingAction> solrIndexingActionMap;
     private Set<IndexingActionType> NEED_UPDATE_PARENT_WORK = EnumSet.of(
-            IndexingActionType.DELETE, IndexingActionType.ADD,
-            IndexingActionType.UPDATE_DATASTREAMS, IndexingActionType.UPDATE_FULL_TEXT);
+            IndexingActionType.DELETE, IndexingActionType.ADD);
 
     @Override
     public void process(Exchange exchange) throws Exception {
         try (Timer.Context context = timer.time()) {
-            log.debug("Processing solr update");
             final Message in = exchange.getIn();
 
             Document msgBody = MessageUtil.getDocumentBody(in);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/OrderedSetAggregationStrategy.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/OrderedSetAggregationStrategy.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.services.camel.util;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.processor.aggregate.AggregationStrategy;
+import org.slf4j.Logger;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Message aggregation strategy which puts the bodies of messages into an ordered set.
+ * So contents will be in insertion order, and deduplicated.
+ *
+ * @author bbpennel
+ */
+public class OrderedSetAggregationStrategy implements AggregationStrategy {
+    private final static Logger log = getLogger(OrderedSetAggregationStrategy.class);
+
+    @Override
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        if (oldExchange == null) {
+            log.error("Starting new ordered set batch");
+            var orderedSet = new LinkedHashSet<>();
+            orderedSet.add(newExchange.getIn().getBody());
+            newExchange.getIn().setBody(orderedSet);
+            return newExchange;
+        } else {
+            var orderedSet = oldExchange.getIn().getBody(Set.class);
+            orderedSet.add(newExchange.getIn().getBody());
+            log.error("Added to batch, now contains {}", orderedSet.size());
+            return oldExchange;
+        }
+    }
+}

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -83,6 +83,17 @@
             </list>
         </property>
     </bean>
+
+    <bean id="solrUpdateWorkFilesPipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setContentTypeFilter" />
+                <ref bean="setDatastreamFilter" />
+            </list>
+        </property>
+    </bean>
     
     <bean id="solrFullTextUpdatePipeline"
         class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
@@ -192,6 +203,7 @@
     </bean>
     
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
+        <property name="solrSearchService" ref="queryLayer" />
     </bean>
     
     <bean id="setDatastreamFilter"
@@ -238,6 +250,12 @@
     <bean id="updateDatastreamsAction"
         class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
         <property name="pipeline" ref="solrDatastreamUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
+
+    <bean id="updateWorkFilesAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrUpdateWorkFilesPipeline" />
         <property name="addDocumentMode" value="false" />
     </bean>
     
@@ -352,6 +370,7 @@
         <entry key="ADD" value-ref="updateObjectAction" />
         <entry key="UPDATE_DESCRIPTION" value-ref="updateDescriptionAction" />
         <entry key="UPDATE_DATASTREAMS" value-ref="updateDatastreamsAction" />
+        <entry key="UPDATE_WORK_FILES" value-ref="updateWorkFilesAction" />
         <entry key="UPDATE_FULL_TEXT" value-ref="updateFullTextAction" />
         <entry key="RECURSIVE_REINDEX" value-ref="indexTreeInplaceAction" />
         <entry key="RECURSIVE_ADD" value-ref="updateTreeAction" />
@@ -408,12 +427,12 @@
 
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
-        <property name="actionType" value="UPDATE_DATASTREAMS" />
+        <property name="actionType" value="UPDATE_WORK_FILES" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
         <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
-        <property name="defaultDestinationName" value="${cdr.solrupdate.workObject.fileUpdated}" />
+        <property name="defaultDestinationName" value="activemq:queue:solr.update.workObject.fileUpdated" />
         <property name="pubSubDomain" value="false" />
     </bean>
 

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -385,6 +385,7 @@
         <constructor-arg ref="solrFullUpdatePipeline" />
         <constructor-arg ref="solrUpdateDriver" />
         <constructor-arg ref="repositoryObjectLoader" />
+        <property name="updateWorkSender" ref="updateWorkSender" />
     </bean>
     
     <bean id="cdrEventToSolrUpdateProcessor" class="edu.unc.lib.boxc.services.camel.solr.CdrEventToSolrUpdateProcessor">
@@ -393,16 +394,34 @@
     
     <bean id="solrLargeUpdateProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="solrSmallUpdateProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+        <property name="updateWorkSender" ref="updateWorkSender" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
-    
-    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.BodyListAggregationStrategy"/>
+
+    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="actionType" value="UPDATE_DATASTREAMS" />
+    </bean>
+
+    <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
+        <property name="defaultDestinationName" value="${cdr.solrupdate.workObject.fileUpdated}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+
+    <bean id="updateWorkSender" class="edu.unc.lib.boxc.operations.jms.MessageSender">
+        <property name="jmsTemplate" ref="updateWorkJmsTemplate" />
+    </bean>
+
+    <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>
     
     <camel:camelContext id="CdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.boxc.services.camel.solrUpdate</camel:package>

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import edu.unc.lib.boxc.operations.jms.MessageSender;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -86,6 +87,8 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
     private DerivativeService derivativeService;
     @Mock
     private AgentPrincipals agent;
+    @Autowired
+    private MessageSender updateWorkSender;
 
     @Before
     public void setUp() throws Exception {
@@ -94,6 +97,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
         TestHelper.setContentBase(baseAddress);
 
         processor = new SolrIngestProcessor(dipFactory, solrFullUpdatePipeline, driver, repositoryObjectLoader);
+        processor.setUpdateWorkSender(updateWorkSender);
 
         when(exchange.getIn()).thenReturn(message);
 

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
@@ -117,6 +117,11 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
         indexObjectsInTripleStore();
 
+        setMessageTarget(fileObj);
+        when(message.getHeader(RESOURCE_TYPE)).thenReturn(Cdr.FileObject.getURI());
+        processor.process(exchange);
+        server.commit();
+
         setMessageTarget(workObj);
         processor.process(exchange);
         server.commit();
@@ -243,6 +248,11 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
         setMessageTarget(binObj);
         when(message.getHeader(RESOURCE_TYPE)).thenReturn(Fcrepo4Repository.Binary.getURI());
+        processor.process(exchange);
+        server.commit();
+
+        setMessageTarget(workObj);
+        when(message.getHeader(RESOURCE_TYPE)).thenReturn(Cdr.Work.getURI());
         processor.process(exchange);
         server.commit();
 

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -42,6 +42,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Resource;
 
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.operations.jms.MessageSender;
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.commons.io.FileUtils;
@@ -107,6 +109,10 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
     private SetCollectionSupplementalInformationFilter setCollectionSupplementalInformationFilter;
     @Autowired
     private SolrClient solrClient;
+    @Autowired
+    private RepositoryObjectLoader repositoryObjectLoader;
+    @Autowired
+    private MessageSender updateWorkSender;
 
     @Resource(name = "solrIndexingActionMap")
     private Map<IndexingActionType, IndexingAction> solrIndexingActionMap;
@@ -119,6 +125,8 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
         processor = new SolrUpdateProcessor();
         processor.setSolrIndexingActionMap(solrIndexingActionMap);
+        processor.setRepositoryObjectLoader(repositoryObjectLoader);
+        processor.setUpdateWorkSender(updateWorkSender);
 
         when(exchange.getIn()).thenReturn(message);
 

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -15,21 +15,14 @@
  */
 package edu.unc.lib.boxc.services.camel.solrUpdate;
 
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
-import static edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageHelper.makeIndexingOperationBody;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.ids.PIDMinter;
+import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPIDMinter;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingPriority;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
@@ -50,15 +43,19 @@ import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 
-import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.ids.PIDMinter;
-import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPIDMinter;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingPriority;
-import edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor;
-import edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdateProcessor;
-import edu.unc.lib.boxc.services.camel.util.MessageUtil;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
+import static edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageHelper.makeIndexingOperationBody;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  *
@@ -265,8 +262,8 @@ public class SolrUpdateRouterTest {
 
         notify.matches(3l, TimeUnit.SECONDS);
 
-        verify(indexingMessageSender).sendIndexingOperation(null, targetPid1, IndexingActionType.UPDATE_DATASTREAMS);
-        verify(indexingMessageSender).sendIndexingOperation(null, targetPid2, IndexingActionType.UPDATE_DATASTREAMS);
+        verify(indexingMessageSender).sendIndexingOperation(null, targetPid1, IndexingActionType.UPDATE_WORK_FILES);
+        verify(indexingMessageSender).sendIndexingOperation(null, targetPid2, IndexingActionType.UPDATE_WORK_FILES);
     }
 
     private void assertMessage(List<Exchange> exchanges, PID expectedPid, IndexingActionType expectedAction)

--- a/services-camel-app/src/test/resources/cdr-event-routing-it-config.properties
+++ b/services-camel-app/src/test/resources/cdr-event-routing-it-config.properties
@@ -45,6 +45,8 @@ cdr.solrupdate.stream.camel=activemq://activemq:queue:repository.solrupdate
 
 cdr.solrupdate.large.camel=direct:solr.update.large
 cdr.solrupdate.priority.low.camel=direct:solr.update.priority.low
+cdr.solrupdate.workObject.fileUpdated=sjms:solr.update.workObject.fileUpdated?transacted=true
+cdr.solrupdate.workObject.fileUpdated.consumer=sjms-batch:solr.update.workObject.fileUpdated?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#orderedSetAggregationStrategy&connectionFactory=jmsFactory
 
 # The base URL of the triplestore being used.
 triplestore.baseUrl=http://localhost:8080/fuseki/test/update

--- a/services-camel-app/src/test/resources/cdr-event-routing-it-context.xml
+++ b/services-camel-app/src/test/resources/cdr-event-routing-it-context.xml
@@ -73,6 +73,13 @@
         <constructor-arg value="edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor" />
     </bean>
 
+    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="actionType" value="UPDATE_WORK_FILES" />
+    </bean>
+
+    <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>
+
     <camel:camelContext id="cdrServiceCdrEvents">
         <camel:package>edu.unc.lib.boxc.services.camel.cdrEvents</camel:package>
     </camel:camelContext>

--- a/services-camel-app/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-indexing-it-context.xml
@@ -88,6 +88,17 @@
             </list>
         </property>
     </bean>
+
+    <bean id="solrUpdateWorkFilesPipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setContentTypeFilter" />
+                <ref bean="setDatastreamFilter" />
+            </list>
+        </property>
+    </bean>
     
     <bean id="solrFullTextUpdatePipeline"
         class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
@@ -127,6 +138,12 @@
     <bean id="updateDatastreamsAction"
         class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
         <property name="pipeline" ref="solrDatastreamUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
+
+    <bean id="updateWorkFilesAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrUpdateWorkFilesPipeline" />
         <property name="addDocumentMode" value="false" />
     </bean>
     

--- a/services-camel-app/src/test/resources/solr-update-config.properties
+++ b/services-camel-app/src/test/resources/solr-update-config.properties
@@ -11,3 +11,5 @@ cdr.solrupdate.stream.camel=direct:start
 
 cdr.solrupdate.large.camel=direct:solr.update.large
 cdr.solrupdate.priority.low.camel=direct:solr.update.priority.low
+cdr.solrupdate.workObject.fileUpdated=sjms:solr.update.workObject.fileUpdated?transacted=true
+cdr.solrupdate.workObject.fileUpdated.consumer=sjms-batch:solr.update.workObject.fileUpdated?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#orderedSetAggregationStrategy&connectionFactory=jmsFactory

--- a/services-camel-app/src/test/resources/solr-update-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-context.xml
@@ -33,8 +33,17 @@
     
     <bean id="solrUpdatePreprocessorReal" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
-    
-    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.BodyListAggregationStrategy"/>
+
+    <bean id="mockIndexingMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender" />
+    </bean>
+
+    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
+        <property name="indexingMessageSender" ref="mockIndexingMessageSender" />
+        <property name="actionType" value="UPDATE_DATASTREAMS" />
+    </bean>
+
+    <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>
 
     <camel:camelContext id="cdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.boxc.services.camel.solrUpdate</camel:package>

--- a/services-camel-app/src/test/resources/solr-update-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-context.xml
@@ -40,7 +40,7 @@
 
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="mockIndexingMessageSender" />
-        <property name="actionType" value="UPDATE_DATASTREAMS" />
+        <property name="actionType" value="UPDATE_WORK_FILES" />
     </bean>
 
     <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -161,10 +161,13 @@
     
     <bean id="solrSmallUpdateProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+        <property name="updateWorkSender" ref="updateWorkSender" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="solrLargeUpdateProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor">
@@ -174,8 +177,23 @@
     
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
-    
-    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.BodyListAggregationStrategy"/>
+
+    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="actionType" value="UPDATE_DATASTREAMS" />
+    </bean>
+
+    <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="${cdr.solrupdate.workObject.fileUpdated}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+
+    <bean id="updateWorkSender" class="edu.unc.lib.boxc.operations.jms.MessageSender">
+        <property name="jmsTemplate" ref="updateWorkJmsTemplate" />
+    </bean>
+
+    <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>
         
     <camel:camelContext id="cdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.boxc.services.camel.solrUpdate</camel:package>

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -128,6 +128,7 @@
         <entry key="ADD" value-ref="updateObjectAction" />
         <entry key="UPDATE_DESCRIPTION" value-ref="updateDescriptionAction" />
         <entry key="UPDATE_DATASTREAMS" value-ref="updateDatastreamsAction" />
+        <entry key="UPDATE_WORK_FILES" value-ref="updateWorkFilesAction" />
         <entry key="UPDATE_FULL_TEXT" value-ref="updateFullTextAction" />
         <entry key="RECURSIVE_REINDEX" value-ref="indexTreeInplaceAction" />
         <entry key="RECURSIVE_ADD" value-ref="updateTreeAction" />
@@ -180,7 +181,7 @@
 
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
-        <property name="actionType" value="UPDATE_DATASTREAMS" />
+        <property name="actionType" value="UPDATE_WORK_FILES" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">

--- a/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -189,6 +189,7 @@
     </bean>
 
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
+        <property name="solrSearchService" ref="solrSearchService" />
     </bean>
 
     <bean id="setDatastreamFilter"

--- a/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -204,6 +204,7 @@
     </bean>
 
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
+        <property name="solrSearchService" ref="solrSearchService" />
     </bean>
 
     <bean id="setDatastreamFilter"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3205

* Work object contentType field populated with contentType of all children file objects.
	* Children contentType info is retrieved from solr records for the files (which should be more performant than using fedora or the triple store for large works)
	* This approach should set us up for other similar aggregate info being added to works
* Refactored triggering indexing of works based on files:
    * Now both ingest and a few update operations will trigger a partial reindex of the work. 
    * The work indexing operations now go through a separate queue which gets deduplicated to reduce redundant indexing. 
    * Previously the work was fully reindexed, and would be reindexed for every file added.
* Adds an "UPDATE_WORK_FILES" indexing operation, which performs actions specifically needed when a file is added to a work, or updated in ways that would impact that work.
* Some refactoring of indexing tests to use real objects instead of unnecessary mocks, which were proving problematic in new tests
