### PR TITLE
BXC-3449 - Update to jena 4.4.0

### DIFF
--- a/deposit-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit-app/src/main/webapp/WEB-INF/service-context.xml
@@ -202,7 +202,6 @@
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />
-        <property name="httpClientConnectionManager" ref="multiThreadedHttpConnectionManager" />
     </bean>
     
     <!-- Initialize access control dependencies -->

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/sparql/FusekiSparqlQueryServiceImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/sparql/FusekiSparqlQueryServiceImpl.java
@@ -25,6 +25,8 @@ import org.apache.jena.query.QueryFactory;
 
 import edu.unc.lib.boxc.model.api.sparql.SparqlQueryService;
 
+import java.lang.reflect.Method;
+
 /**
  * Service for executing sparql queries against a Fuseki backend
  *
@@ -34,24 +36,17 @@ import edu.unc.lib.boxc.model.api.sparql.SparqlQueryService;
 public class FusekiSparqlQueryServiceImpl implements SparqlQueryService {
 
     private String fusekiQueryURL;
-    private CloseableHttpClient httpClient;
-    private HttpClientConnectionManager httpClientConnectionManager;
 
     @Override
     public QueryExecution executeQuery(String queryString) {
         Query query = QueryFactory.create(queryString);
 
-        return QueryExecutionFactory.sparqlService(fusekiQueryURL, query, httpClient);
+        return QueryExecution.service(fusekiQueryURL)
+                .query(query)
+                .build();
     }
 
     public void setFusekiQueryURL(String fusekiQueryURL) {
         this.fusekiQueryURL = fusekiQueryURL;
-    }
-
-    public void setHttpClientConnectionManager(HttpClientConnectionManager manager) {
-        this.httpClientConnectionManager = manager;
-        this.httpClient = HttpClients.custom()
-                .setConnectionManager(httpClientConnectionManager)
-                .build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
         <embedded-redis.version>0.7.3</embedded-redis.version>
         <solr.version>8.10.1</solr.version>
         <metrics.version>5.0.0</metrics.version>
-        <jena.version>3.17.0</jena.version>
-        <jena.fuseki.version>3.17.0</jena.fuseki.version>
+        <jena.version>4.4.0</jena.version>
+        <jena.fuseki.version>4.4.0</jena.fuseki.version>
         
         <fcrepo-camel.version>5.0.0</fcrepo-camel.version>
         <camel.version>2.25.4</camel.version>
@@ -1004,25 +1004,6 @@
                   </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-osgi</artifactId>
-                <version>${jena.version}</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>commons-codec</groupId>
-                    <artifactId>commons-codec</artifactId>
-                  </exclusion>
-                </exclusions>
-            </dependency>
 
             <!-- Logging -->
             <dependency>
@@ -1070,6 +1051,12 @@
                 <artifactId>fcrepo-auth-common</artifactId>
                 <version>${fcrepo4.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.jena</groupId>
+                        <artifactId>jena-arq</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.grizzly</groupId>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -86,6 +86,10 @@
                 <groupId>org.apache.camel</groupId>
                 <artifactId>camel-jackson</artifactId>
             </exclusion>
+            <exclusion>
+                <groupId>org.apache.jena</groupId>
+                <artifactId>jena-osgi</artifactId>
+            </exclusion>
         </exclusions>
     </dependency>
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/OrderedSetAggregationStrategy.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/OrderedSetAggregationStrategy.java
@@ -36,7 +36,7 @@ public class OrderedSetAggregationStrategy implements AggregationStrategy {
     @Override
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         if (oldExchange == null) {
-            log.error("Starting new ordered set batch");
+            log.debug("Starting new ordered set batch");
             var orderedSet = new LinkedHashSet<>();
             orderedSet.add(newExchange.getIn().getBody());
             newExchange.getIn().setBody(orderedSet);
@@ -44,7 +44,7 @@ public class OrderedSetAggregationStrategy implements AggregationStrategy {
         } else {
             var orderedSet = oldExchange.getIn().getBody(Set.class);
             orderedSet.add(newExchange.getIn().getBody());
-            log.error("Added to batch, now contains {}", orderedSet.size());
+            log.debug("Added to batch, now contains {}", orderedSet.size());
             return oldExchange;
         }
     }

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -102,7 +102,6 @@
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
     
     <bean id="contentPathFactory" class="edu.unc.lib.boxc.model.fcrepo.services.ContentPathFactoryImpl"

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -136,8 +136,8 @@ public class TriplesReindexingRouterIT {
 
         final Dataset ds = new DatasetImpl(fusekiModel);
         fusekiServer = FusekiServer.create()
-                .setPort(Integer.parseInt(fusekiPort))
-                .setContextPath("/fuseki")
+                .port(Integer.parseInt(fusekiPort))
+                .contextPath("/fuseki")
                 .add("/test", ds)
                 .build();
         fusekiServer.start();

--- a/services-camel-app/src/test/resources/triples-reindexing-it-context.xml
+++ b/services-camel-app/src/test/resources/triples-reindexing-it-context.xml
@@ -41,7 +41,6 @@
 
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl" >
         <property name="fusekiQueryURL" value="${triplestore.datasetUri}" />
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
     
     <bean id="triplesUpdateJmsTemplate" class="org.springframework.jms.core.JmsTemplate">

--- a/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -59,7 +59,6 @@
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
 
     <!-- Initialize access control dependencies -->

--- a/web-admin-app/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/web-admin-app/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -42,7 +42,6 @@
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
     
     <!-- Initialize access control dependencies -->

--- a/web-services-app/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -14,7 +14,6 @@
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
     
     <!-- Initialize access control dependencies -->


### PR DESCRIPTION
* Update jena to 4.4.0 to address security issue and use java 11 version. Adjustments to address changes in api.