### PR TITLE
BXC-3451 - Fix indexing of extent for images without dimension data

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.jdom2.Document;
@@ -140,7 +141,16 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
                 if (imgMd != null) {
                     String imgHeight = imgMd.getChildTextTrim("imageHeight", FITS_NS);
                     String imgWidth = imgMd.getChildTextTrim("imageWidth", FITS_NS);
-                    extent = imgHeight + "x" + imgWidth;
+                    if (!StringUtils.isBlank(imgHeight) && !StringUtils.isBlank(imgWidth)) {
+                        try {
+                            Integer.parseInt(imgHeight);
+                            Integer.parseInt(imgWidth);
+                            extent = imgHeight + "x" + imgWidth;
+                        } catch (NumberFormatException e) {
+                            log.warn("Invalid image width or height from FITS {}: {} x {}",
+                                    fits.getPid().getQualifiedId(), imgWidth, imgHeight);
+                        }
+                    }
                 }
             }
             return extent;

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
@@ -223,6 +223,32 @@ public class SetDatastreamFilterTest {
         assertEquals(FILE_SIZE + FILE2_SIZE + (FILE3_SIZE * 2), (long) idb.getFilesizeTotal());
     }
 
+    @Test
+    public void fileObjectImageBinaryNoDimensionsTest() throws Exception {
+        when(binObj.getResource()).thenReturn(
+                fileResource(ORIGINAL_FILE.getId(), FILE_SIZE, FILE3_MIMETYPE, "test.png", FILE_DIGEST));
+
+        BinaryObject binObj2 = mock(BinaryObject.class);
+        when(binObj2.getPid()).thenReturn(DatastreamPids.getTechnicalMetadataPid(pid));
+        when(binObj2.getResource()).thenReturn(
+                fileResource(TECHNICAL_METADATA.getId(), FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST));
+        when(binObj2.getBinaryStream()).thenReturn(getClass().getResourceAsStream("/datastream/techmdImageNoDimensions.xml"));
+
+        when(fileObj.getBinaryObjects()).thenReturn(Arrays.asList(binObj, binObj2));
+        dip.setContentObject(fileObj);
+
+        filter.filter(dip);
+
+        assertContainsDatastream(idb.getDatastream(), ORIGINAL_FILE.getId(),
+                FILE_SIZE, FILE3_MIMETYPE, "test.png", FILE_DIGEST, null, null);
+        assertContainsDatastream(idb.getDatastream(), TECHNICAL_METADATA.getId(),
+                FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST, null, null);
+
+        assertEquals(FILE_SIZE, (long) idb.getFilesizeSort());
+        // JP2 and thumbnail set to same size
+        assertEquals(FILE_SIZE + FILE2_SIZE, (long) idb.getFilesizeTotal());
+    }
+
     @Test(expected = IndexingException.class)
     public void fileObjectNoOriginalTest() throws Exception {
         when(binObj.getResource()).thenReturn(
@@ -358,8 +384,6 @@ public class SetDatastreamFilterTest {
         String joined = components.stream()
                 .map(c -> c == null ? "" : c.toString())
                 .collect(Collectors.joining("|"));
-        System.out.println("Values: " + values);
-        System.out.println("Seeking: " + joined);
         assertTrue("Did not contain datastream " + name, values.contains(joined));
     }
 

--- a/indexing-solr/src/test/resources/datastream/techmdImageNoDimensions.xml
+++ b/indexing-solr/src/test/resources/datastream/techmdImageNoDimensions.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<premis3:premis xmlns:premis3="http://www.loc.gov/premis/v3">
+  <premis3:object xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="premis3:file">
+    <premis3:objectCharacteristics>
+      <premis3:compositionLevel>0</premis3:compositionLevel>
+      <premis3:format>
+        <premis3:formatDesignation>
+          <premis3:formatName>JPEG EXIF</premis3:formatName>
+        </premis3:formatDesignation>
+      </premis3:format>
+      <premis3:size>66500</premis3:size>
+      <premis3:objectCharacteristicsExtension>
+        <fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.6.4-wisc-SNAPSHOT" timestamp="2/4/22, 11:11 AM">
+          <identification status="SINGLE_RESULT">
+            <identity format="JPEG EXIF" mimetype="image/jpeg" toolname="FITS" toolversion="1.6.4-wisc-SNAPSHOT">
+              <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" />
+              <version toolname="NLNZ Metadata Extractor" toolversion="3.6GA">1.1</version>
+            </identity>
+          </identification>
+          <fileinfo>
+            <lastmodified toolname="Exiftool" toolversion="12.29" status="CONFLICT">2012:05:08 14:09:05</lastmodified>
+            <lastmodified toolname="Tika" toolversion="2.0.0" status="CONFLICT">2012-05-08T10:09:05</lastmodified>
+            <created toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="CONFLICT">2012:05:08 14:09:05</created>
+            <created toolname="Tika" toolversion="2.0.0" status="CONFLICT">2012-05-08T10:09:05</created>
+            <filepath toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">/opt/data/test_staging/pyr_dir/therapy-dog-pyr1.jpg</filepath>
+            <filename toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">therapy-dog-pyr1.jpg</filename>
+            <size toolname="OIS File Information" toolversion="1.0">66500</size>
+            <md5checksum toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">c55102ab3c25319a1ff13730532e52a0</md5checksum>
+            <fslastmodified toolname="OIS File Information" toolversion="1.0" status="SINGLE_RESULT">1643991034440</fslastmodified>
+          </fileinfo>
+          <filestatus />
+          <metadata>
+            <image>
+              <lightSource toolname="NLNZ Metadata Extractor" toolversion="3.6GA" status="SINGLE_RESULT">unknown</lightSource>
+              <standard>
+                <mix:mix xmlns:mix="http://www.loc.gov/mix/v20">
+                  <mix:BasicDigitalObjectInformation />
+                  <mix:BasicImageInformation>
+                    <mix:BasicImageCharacteristics>
+                      <mix:PhotometricInterpretation />
+                    </mix:BasicImageCharacteristics>
+                  </mix:BasicImageInformation>
+                  <mix:ImageCaptureMetadata>
+                    <mix:GeneralCaptureInformation>
+                      <mix:dateTimeCreated>2012-05-08T14:09:05</mix:dateTimeCreated>
+                    </mix:GeneralCaptureInformation>
+                    <mix:DigitalCameraCapture>
+                      <mix:DigitalCameraModel />
+                      <mix:CameraCaptureSettings>
+                        <mix:ImageData>
+                          <mix:lightSource>unknown</mix:lightSource>
+                        </mix:ImageData>
+                      </mix:CameraCaptureSettings>
+                    </mix:DigitalCameraCapture>
+                  </mix:ImageCaptureMetadata>
+                  <mix:ImageAssessmentMetadata>
+                    <mix:SpatialMetrics />
+                    <mix:ImageColorEncoding />
+                  </mix:ImageAssessmentMetadata>
+                </mix:mix>
+              </standard>
+            </image>
+          </metadata>
+          <statistics fitsExecutionTime="296">
+            <tool toolname="MediaInfo" toolversion="21.03" status="did not run" />
+            <tool toolname="OIS Audio Information" toolversion="0.1" status="did not run" />
+            <tool toolname="ADL Tool" toolversion="0.1" status="did not run" />
+            <tool toolname="VTT Tool" toolversion="0.1" status="did not run" />
+            <tool toolname="Droid" toolversion="[could not launch tool]" status="failed" />
+            <tool toolname="Exiftool" toolversion="12.29" executionTime="114" />
+            <tool toolname="NLNZ Metadata Extractor" toolversion="3.6GA" executionTime="294" />
+            <tool toolname="OIS File Information" toolversion="1.0" executionTime="1" />
+            <tool toolname="OIS XML Metadata" toolversion="0.2" status="did not run" />
+            <tool toolname="Tika" toolversion="2.0.0" executionTime="5" />
+          </statistics>
+        </fits>
+      </premis3:objectCharacteristicsExtension>
+    </premis3:objectCharacteristics>
+    <premis3:objectIdentifier>
+      <premis3:objectIdentifierType>Fedora Datastream PID</premis3:objectIdentifierType>
+      <premis3:objectIdentifierValue>http://dcr-test-bes.libint.unc.edu:8181/fcrepo/rest/content/38/a6/42/65/38a64265-9bfd-48f2-89f0-6507a33d7df3</premis3:objectIdentifierValue>
+    </premis3:objectIdentifier>
+  </premis3:object>
+</premis3:premis>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3451

This will resolve issues where the datastream extent field gets set to `nullxnull` for images when no height or width field is present in the FITS image tag, for objects that have already been ingested.

* Prevent setting of extent subfield for datastreams if width or height is missing from FITS, or not numbers