### PR TITLE
Fix File resource type removal

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/config/SearchSettings.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/config/SearchSettings.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.search.solr.config;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -173,6 +174,7 @@ public class SearchSettings extends AbstractSettings {
         setQueryMaxLength(Integer.parseInt(properties.getProperty("search.query.maxLength", "255")));
         setDefaultOperator(properties.getProperty("search.query.defaultOperator", ""));
         populateCollectionFromProperty("search.query.operators", operators, properties, ",");
+        operators = Collections.unmodifiableSet(operators);
         setDefaultPerPage(Integer.parseInt(properties.getProperty("search.results.defaultPerPage", "0")));
         setDefaultCollectionsPerPage(Integer.parseInt(properties.getProperty("search.results.defaultCollectionsPerPage",
                 "0")));
@@ -200,6 +202,10 @@ public class SearchSettings extends AbstractSettings {
                 ",");
         populateCollectionFromProperty("search.facet.defaultStructureBrowse", facetNamesStructureBrowse,
                 properties, ",");
+        facetNames = Collections.unmodifiableList(facetNames);
+        searchFacetNames = Collections.unmodifiableList(searchFacetNames);
+        collectionBrowseFacetNames = Collections.unmodifiableList(collectionBrowseFacetNames);
+        facetNamesStructureBrowse = Collections.unmodifiableList(facetNamesStructureBrowse);
         try {
             populateClassMapFromProperty("search.facet.class.", "edu.unc.lib.boxc.search.solr.facets.",
                     this.facetClasses, properties);
@@ -213,23 +219,35 @@ public class SearchSettings extends AbstractSettings {
         populateCollectionFromProperty("search.field.searchable", searchableFields, properties, ",");
         populateCollectionFromProperty("search.field.rangeSearchable", rangeSearchableFields, properties, ",");
         populateCollectionFromProperty("search.field.dateSearchable", dateSearchableFields, properties, ",");
+        searchableFields = Collections.unmodifiableSet(searchableFields);
+        rangeSearchableFields = Collections.unmodifiableSet(rangeSearchableFields);
+        dateSearchableFields = Collections.unmodifiableSet(dateSearchableFields);
+
         populateMapFromProperty("search.field.paramName.", searchFieldParams, properties);
         searchFieldKeys = getInvertedHashMap(searchFieldParams);
         populateMapFromProperty("search.field.display.", searchFieldLabels, properties);
         populateMapFromProperty("search.actions.", actions, properties);
         populateMapFromProperty("search.url.param.", searchStateParams, properties);
         populateListMapFromProperty("search.results.fields", resultFields, properties);
+        searchFieldParams = Collections.unmodifiableMap(searchFieldParams);
+        searchFieldLabels = Collections.unmodifiableMap(searchFieldLabels);
+        actions = Collections.unmodifiableMap(actions);
+        searchStateParams = Collections.unmodifiableMap(searchStateParams);
+        resultFields = Collections.unmodifiableMap(resultFields);
 
         // Populate sort types
         setSortReverse(properties.getProperty("search.sort.order.reverse", ""));
         setSortNormal(properties.getProperty("search.sort.order.normal", ""));
         populateMapFromProperty("search.sort.name.", sortDisplayNames, properties);
         populateCollectionFromProperty("search.sort.displayOrder", sortDisplayOrder, properties, "\\|");
+        sortDisplayOrder = Collections.unmodifiableList(sortDisplayOrder);
 
         // Access field names
         this.setAllowPatronAccess(new Boolean(properties.getProperty("search.access.allowPatrons", "true")));
         populateCollectionFromProperty("search.access.fields", accessFields, properties, ",");
         populateCollectionFromProperty("search.access.filterableFields", accessFilterableFields, properties, ",");
+        accessFields = Collections.unmodifiableSet(accessFields);
+        accessFilterableFields = Collections.unmodifiableSet(accessFilterableFields);
 
         // Resource Types
         setResourceTypeFile(properties.getProperty("search.resource.type.file", ""));
@@ -242,6 +260,9 @@ public class SearchSettings extends AbstractSettings {
         populateCollectionFromProperty("search.resource.searchDefault", defaultResourceTypes, properties, ",");
         populateCollectionFromProperty("search.resource.collectionDefault", defaultCollectionResourceTypes,
                 properties, ",");
+        resourceTypes = Collections.unmodifiableSet(resourceTypes);
+        defaultResourceTypes = Collections.unmodifiableList(defaultResourceTypes);
+        defaultCollectionResourceTypes = Collections.unmodifiableList(defaultCollectionResourceTypes);
 
         Iterator<Map.Entry<Object, Object>> propIt = properties.entrySet().iterator();
         while (propIt.hasNext()) {
@@ -258,6 +279,7 @@ public class SearchSettings extends AbstractSettings {
                 this.sortTypes.put(propertyKey.substring(propertyKey.lastIndexOf(".") + 1), sortFields);
             }
         }
+        sortTypes = Collections.unmodifiableMap(sortTypes);
     }
 
     public int getFacetsPerGroup() {

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
@@ -71,7 +71,7 @@ public class SearchStateFactory {
         SearchState searchState = new SearchState();
 
         searchState.setBaseFacetLimit(searchSettings.facetsPerGroup);
-        searchState.setResourceTypes(searchSettings.defaultResourceTypes);
+        searchState.setResourceTypes(new ArrayList<>(searchSettings.defaultResourceTypes));
         searchState.setSearchTermOperator(searchSettings.defaultOperator);
         searchState.setRowsPerPage(searchSettings.defaultPerPage);
         searchState.setFacetsToRetrieve(new ArrayList<>(searchSettings.searchFacetNames));
@@ -180,7 +180,7 @@ public class SearchStateFactory {
     public SearchState createStructureBrowseSearchState() {
         SearchState searchState = new SearchState();
         searchState.setResultFields(new ArrayList<>(searchSettings.resultFields.get("structure")));
-        searchState.setResourceTypes(searchSettings.defaultResourceTypes);
+        searchState.setResourceTypes(new ArrayList<>(searchSettings.defaultResourceTypes));
         searchState.setSearchTermOperator(searchSettings.defaultOperator);
         searchState.setRowsPerPage(0);
         searchState.setStartRow(0);
@@ -206,7 +206,7 @@ public class SearchStateFactory {
         SearchState searchState = new SearchState();
         searchState.setResultFields(new ArrayList<>(searchSettings.resultFields.get("structure")));
         searchState.setBaseFacetLimit(searchSettings.facetsPerGroup);
-        searchState.setResourceTypes(searchSettings.defaultResourceTypes);
+        searchState.setResourceTypes(new ArrayList<>(searchSettings.defaultResourceTypes));
         searchState.setSearchTermOperator(searchSettings.defaultOperator);
         searchState.setRowsPerPage(searchSettings.defaultPerPage);
         searchState.setStartRow(0);
@@ -244,7 +244,7 @@ public class SearchStateFactory {
     public SearchState createFacetSearchState(String facetField, String facetSort, int maxResults) {
         SearchState searchState = new SearchState();
 
-        searchState.setResourceTypes(searchSettings.defaultResourceTypes);
+        searchState.setResourceTypes(new ArrayList<>(searchSettings.defaultResourceTypes));
         searchState.setRowsPerPage(0);
         searchState.setStartRow(0);
 
@@ -358,7 +358,7 @@ public class SearchStateFactory {
 
         //Determine resource types selected
         parameter = getParameter(request, searchSettings.searchStateParam("RESOURCE_TYPES"));
-        ArrayList<String> resourceTypes = new ArrayList<>();
+        var resourceTypes = new ArrayList<String>();
         if (parameter == null) {
             //If resource types aren't specified, load the defaults.
             resourceTypes.addAll(searchSettings.defaultResourceTypes);

--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/SearchActionController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/SearchActionController.java
@@ -167,6 +167,8 @@ public class SearchActionController extends AbstractErrorHandlingSearchControlle
             LOG.debug("Rollup not specified in request, determine rollup should be set to {}", enableRollup);
             searchRequest.getSearchState().setRollup(enableRollup);
             if (!enableRollup && !isListing) {
+                LOG.debug("Removing File objects from non-rollup query {}",
+                        searchRequest.getSearchState().getResourceTypes());
                 searchRequest.getSearchState().getResourceTypes().remove(ResourceType.File.name());
             }
         }


### PR DESCRIPTION
Prevent all collections from SearchSettings from being modifiable, and initialize resourceType lists in search states from new ArrayLists so they can be safely modified. Addresses bug where a blank advanced search would cause the File object type to be removed from default resource types list