### PR TITLE
LIB-16359 - Resolve issues with refreshing solr after move operations

### DIFF
--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/services/ContentPathFactory.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/services/ContentPathFactory.java
@@ -34,4 +34,9 @@ public interface ContentPathFactory {
      */
     List<PID> getAncestorPids(PID pid);
 
+    /**
+     * Invalidates cached data for the provided pid
+     * @param pid
+     */
+    void invalidate(PID pid);
 }

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/ContentPathFactoryImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/ContentPathFactoryImpl.java
@@ -95,6 +95,11 @@ public class ContentPathFactoryImpl implements ContentPathFactory {
         }
     }
 
+    @Override
+    public void invalidate(PID pid) {
+        childToParentCache.invalidate(pid);
+    }
+
     private List<PID> buildPath(PID pid) {
         PID currentPid = pid;
         List<PID> result = new ArrayList<>();

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.services.camel.util;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -39,6 +40,7 @@ public class CacheInvalidatingProcessor implements Processor {
     private static final Logger log = getLogger(CacheInvalidatingProcessor.class);
     private RepositoryObjectLoader repoObjLoader;
     private ObjectAclFactory objectAclFactory;
+    private ContentPathFactory contentPathFactory;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -64,6 +66,7 @@ public class CacheInvalidatingProcessor implements Processor {
         log.debug("Invalidating caches for {}", pid);
         repoObjLoader.invalidate(pid);
         objectAclFactory.invalidate(pid);
+        contentPathFactory.invalidate(pid);
     }
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
@@ -72,5 +75,9 @@ public class CacheInvalidatingProcessor implements Processor {
 
     public void setObjectAclFactory(ObjectAclFactory objectAclFactory) {
         this.objectAclFactory = objectAclFactory;
+    }
+
+    public void setContentPathFactory(ContentPathFactory contentPathFactory) {
+        this.contentPathFactory = contentPathFactory;
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
@@ -15,21 +15,20 @@
  */
 package edu.unc.lib.boxc.services.camel.util;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
+import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
+import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.ids.PIDConstants;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.fcrepo.camel.FcrepoHeaders;
 import org.slf4j.Logger;
 
-import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
-import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.ids.PIDConstants;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Processor which invalidates cache entries for updated objects

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -206,6 +206,7 @@
     <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="objectAclFactory" ref="objectAclFactory" />
+        <property name="contentPathFactory" ref="contentPathFactory" />
     </bean>
 
     <bean id="addSmallThumbnailProcessor" class="edu.unc.lib.boxc.services.camel.images.AddDerivativeProcessor">

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -54,6 +54,7 @@
                 <ref bean="setRecordDatesFilter" />
                 <ref bean="setPathFilter" />
                 <ref bean="setAccessControlFilter" />
+                <ref bean="setAccessStatusFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
             </list>
         </property>

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.junit.Before;
@@ -36,7 +37,6 @@ import edu.unc.lib.boxc.model.api.ids.PIDConstants;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectLoaderImpl;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor;
 
 /**
  * @author bbpennel
@@ -50,6 +50,8 @@ public class CacheInvalidatingProcessorTest {
     private RepositoryObjectLoaderImpl repoObjLoader;
     @Mock
     private ObjectAclFactory objectAclFactory;
+    @Mock
+    private ContentPathFactory contentPathFactory;
 
     private CacheInvalidatingProcessor processor;
 
@@ -60,6 +62,7 @@ public class CacheInvalidatingProcessorTest {
         processor = new CacheInvalidatingProcessor();
         processor.setRepositoryObjectLoader(repoObjLoader);
         processor.setObjectAclFactory(objectAclFactory);
+        processor.setContentPathFactory(contentPathFactory);
     }
 
     @Test
@@ -72,6 +75,7 @@ public class CacheInvalidatingProcessorTest {
         PID pid = PIDs.get(FEDORA_BASE + objPath);
         verify(repoObjLoader).invalidate(pid);
         verify(objectAclFactory).invalidate(pid);
+        verify(contentPathFactory).invalidate(pid);
     }
 
     @Test
@@ -83,6 +87,7 @@ public class CacheInvalidatingProcessorTest {
 
         verify(repoObjLoader, never()).invalidate(any(PID.class));
         verify(objectAclFactory, never()).invalidate(any(PID.class));
+        verify(contentPathFactory, never()).invalidate(any(PID.class));
     }
 
     @Test
@@ -94,6 +99,7 @@ public class CacheInvalidatingProcessorTest {
 
         verify(repoObjLoader, never()).invalidate(any(PID.class));
         verify(objectAclFactory, never()).invalidate(any(PID.class));
+        verify(contentPathFactory, never()).invalidate(any(PID.class));
     }
 
     private Exchange mockExchange(String rescPath) {

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
@@ -15,6 +15,20 @@
  */
 package edu.unc.lib.boxc.services.camel.util;
 
+import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
+import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.ids.PIDConstants;
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectLoaderImpl;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -22,21 +36,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
-
-import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
-import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
-import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
-import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.ids.PIDConstants;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectLoaderImpl;
-import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 
 /**
  * @author bbpennel

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -174,6 +174,7 @@
     <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.boxc.services.camel.util.CacheInvalidatingProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader"/>
         <property name="objectAclFactory" ref="objectAclFactory"/>
+        <property name="contentPathFactory" ref="contentPathFactory"/>
     </bean>
     
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/LIB-16359
* Add status updating filter to move operation indexing, since inherited statuses were not clearing when moving out of a folder with permissions restrictions
* Invalidate path cache when an object is modified, to prevent stale value from preventing the path from updating in solr from a move operation if the same object had recently been indexed