### PR TITLE
BXC-3563 - Revisions to full record page faceting

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
@@ -74,6 +74,7 @@ public class MultiSelectFacetListService extends AbstractQueryService {
 
         // Calculate facets with facet filters applied
         SearchRequest facetRequest = new SearchRequest(searchState, searchRequest.getAccessGroups(), true);
+        facetRequest.setApplyCutoffs(searchRequest.isApplyCutoffs());
 
         searchState.setRowsPerPage(0);
         // Set the resource types counted in the facets to exclude File objects

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/NeighborQueryService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/NeighborQueryService.java
@@ -80,7 +80,7 @@ public class NeighborQueryService extends AbstractQueryService {
             // We want only objects at the same level of the hierarchy
             ancestorPath.setCutoff(ancestorPath.getHighestTier() + 1);
 
-            facetFieldUtil.addToSolrQuery(ancestorPath, solrQuery);
+            facetFieldUtil.addToSolrQuery(ancestorPath, true, solrQuery);
         }
 
         // Query for a window of results to either side of the target

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -403,13 +403,11 @@ public class SolrSearchService extends AbstractQueryService {
                 Entry<String, List<SearchFacet>> facetEntry = facetIt.next();
                 LOG.debug("Adding facet {} as a  {}", facetEntry.getKey(),
                         facetEntry.getValue().getClass().getName());
-                facetFieldUtil.addToSolrQuery(facetEntry.getValue(), solrQuery);
+                facetFieldUtil.addToSolrQuery(facetEntry.getValue(), searchRequest.isApplyCutoffs(), solrQuery);
             }
         }
 
-        // Scope hierarchical facet results to the highest tier selected within the facet tree
-        if (searchRequest.isRetrieveFacets() && searchRequest.isApplyCutoffs()
-                && searchState.getFacetsToRetrieve() != null) {
+        if (searchRequest.isRetrieveFacets() && searchState.getFacetsToRetrieve() != null) {
             Set<String> facetsQueried = searchState.getFacets().keySet();
             // Apply closing cutoff to all cutoff facets that are being retrieved but not being queried for
             for (String fieldKey : searchState.getFacetsToRetrieve()) {

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.search.solr.facets.CutoffFacetImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -61,6 +63,9 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
 
     private static final List<String> FACETS_TO_RETRIEVE = Arrays.asList(
             CONTENT_TYPE.name(), ROLE_GROUP.name(), PARENT_COLLECTION.name());
+    private static final List<String> RESOURCE_TYPES_TO_RETRIEVE = Arrays.asList(
+            ResourceType.AdminUnit.name(), ResourceType.Collection.name(),
+            ResourceType.Folder.name(), ResourceType.Work.name());
 
     private TestCorpus testCorpus;
     private boolean corpusLoaded;
@@ -196,10 +201,11 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll1Pid.getId(), 1);
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll2Pid.getId(), 1);
 
-        assertNumberFacetsReturned(resp, CONTENT_TYPE, 3);
+        assertNumberFacetsReturned(resp, CONTENT_TYPE, 4);
         assertFacetValueCount(resp, CONTENT_TYPE, "^text", 2);
         assertFacetValueCount(resp, CONTENT_TYPE, "^image", 2);
         assertFacetValueCount(resp, CONTENT_TYPE, "/text^txt", 2);
+        assertFacetValueCount(resp, CONTENT_TYPE, "/text^pdf", 1);
 
         assertNumberFacetsReturned(resp, ROLE_GROUP, 3);
         assertFacetValueCount(resp, ROLE_GROUP, "canViewOriginals|everyone", 2);
@@ -276,10 +282,11 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll1Pid.getId(), 2);
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll2Pid.getId(), 2);
 
-        assertNumberFacetsReturned(resp, CONTENT_TYPE, 5);
+        assertNumberFacetsReturned(resp, CONTENT_TYPE, 6);
         assertFacetValueCount(resp, CONTENT_TYPE, "^text", 2);
         assertFacetValueCount(resp, CONTENT_TYPE, "^image", 2);
         assertFacetValueCount(resp, CONTENT_TYPE, "/text^txt", 2);
+        assertFacetValueCount(resp, CONTENT_TYPE, "/text^pdf", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "/image^jpg", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "/image^png", 1);
 
@@ -363,6 +370,31 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
     }
 
     @Test
+    public void setContainerAncestorPathCutoffUnitTest() throws Exception {
+        SearchState searchState = new SearchState();
+        searchState.setFacetsToRetrieve(FACETS_TO_RETRIEVE);
+        searchState.setResourceTypes(RESOURCE_TYPES_TO_RETRIEVE);
+
+        SearchRequest request = new SearchRequest(searchState, accessGroups);
+        searchState.addFacet(new CutoffFacetImpl(SearchFieldKey.ANCESTOR_PATH.name(), "2," + testCorpus.unitPid.getId() + "!3"));
+        request.setApplyCutoffs(false);
+        SearchResultResponse resp = service.getFacetListResult(request);
+
+        assertNumberFacetsReturned(resp, PARENT_COLLECTION, 2);
+        assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll1Pid.getId(), 3);
+        assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll2Pid.getId(), 3);
+
+        assertNumberFacetsReturned(resp, CONTENT_TYPE, 2);
+        assertFacetValueCount(resp, CONTENT_TYPE, "^text", 2);
+        assertFacetValueCount(resp, CONTENT_TYPE, "^image", 2);
+
+        assertNumberFacetsReturned(resp, ROLE_GROUP, 3);
+        assertFacetValueCount(resp, ROLE_GROUP, "canViewOriginals|everyone", 6);
+        assertFacetValueCount(resp, ROLE_GROUP, "unitOwner|unitOwner", 8);
+        assertFacetValueCount(resp, ROLE_GROUP, "canManage|manager", 4);
+    }
+
+    @Test
     public void setContainerAndContentTypeTest() throws Exception {
         SearchState searchState = new SearchState();
         searchState.setFacetsToRetrieve(FACETS_TO_RETRIEVE);
@@ -376,10 +408,11 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         assertNumberFacetsReturned(resp, PARENT_COLLECTION, 1);
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll1Pid.getId(), 1);
 
-        assertNumberFacetsReturned(resp, CONTENT_TYPE, 3);
+        assertNumberFacetsReturned(resp, CONTENT_TYPE, 4);
         assertFacetValueCount(resp, CONTENT_TYPE, "^text", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "^image", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "/text^txt", 1);
+        assertFacetValueCount(resp, CONTENT_TYPE, "/text^pdf", 1);
 
         assertNumberFacetsReturned(resp, ROLE_GROUP, 3);
         assertFacetValueCount(resp, ROLE_GROUP, "canViewOriginals|everyone", 1);
@@ -402,10 +435,11 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll1Pid.getId(), 1);
         assertFacetValueCount(resp, PARENT_COLLECTION, testCorpus.coll2Pid.getId(), 1);
 
-        assertNumberFacetsReturned(resp, CONTENT_TYPE, 3);
+        assertNumberFacetsReturned(resp, CONTENT_TYPE, 4);
         assertFacetValueCount(resp, CONTENT_TYPE, "^text", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "^image", 1);
         assertFacetValueCount(resp, CONTENT_TYPE, "/text^txt", 1);
+        assertFacetValueCount(resp, CONTENT_TYPE, "/text^pdf", 1);
 
         assertNumberFacetsReturned(resp, ROLE_GROUP, 3);
         assertFacetValueCount(resp, ROLE_GROUP, "canViewOriginals|everyone", 1);

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/TestCorpus.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/TestCorpus.java
@@ -120,6 +120,7 @@ public class TestCorpus {
                 rootPid, unitPid, coll1Pid, folder1Pid);
         addAclProperties(newDoc, PUBLIC_PRINC, "unitOwner", "manager");
         addFileProperties(newDoc, ContentCategory.text, "txt");
+        addFileProperties(newDoc, ContentCategory.text, "pdf");
         docs.add(newDoc);
 
         newDoc = makeFileDocument(work1File1Pid, "File 1",
@@ -217,7 +218,12 @@ public class TestCorpus {
     public void addFileProperties(SolrInputDocument doc, ContentCategory typeCategory, String typeExt) {
         String tier1 = "^" + typeCategory.name() + "," + typeCategory.getDisplayName();
         String tier2 = "/" + typeCategory.name() + "^" + typeExt + "," + typeExt;
-        doc.addField("contentType", Arrays.asList(tier1, tier2));
+        var existing = doc.getField("contentType");
+        if (existing == null) {
+            doc.addField("contentType", new ArrayList<>(Arrays.asList(tier1, tier2)));
+        } else {
+            existing.addValue(Arrays.asList(tier1, tier2));
+        }
     }
 
     public void addAclProperties(SolrInputDocument doc, String readGroup, String unitOwner, String manager) {

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/utils/FacetFieldUtilTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/utils/FacetFieldUtilTest.java
@@ -57,7 +57,7 @@ public class FacetFieldUtilTest {
 
         CutoffFacetImpl facet = new CutoffFacetImpl("ANCESTOR_PATH", "2,test");
 
-        facetFieldUtil.addToSolrQuery(facet, query);
+        facetFieldUtil.addToSolrQuery(facet, true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -71,12 +71,26 @@ public class FacetFieldUtilTest {
 
         CutoffFacetImpl facet = new CutoffFacetImpl("ANCESTOR_PATH", "2,test!3");
 
-        facetFieldUtil.addToSolrQuery(facet, query);
+        facetFieldUtil.addToSolrQuery(facet, true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
 
         assertEquals("(ancestorPath:2,test AND !ancestorPath:3,*)", filterQueries[0]);
+    }
+
+    @Test
+    public void addFacetCutoffWithCutoffToQueryDisableApplyCutoffs() {
+        SolrQuery query = new SolrQuery();
+
+        CutoffFacetImpl facet = new CutoffFacetImpl("ANCESTOR_PATH", "2,test!3");
+
+        facetFieldUtil.addToSolrQuery(facet, false, query);
+
+        String[] filterQueries = query.getFilterQueries();
+        assertEquals(1, filterQueries.length);
+
+        assertEquals("(ancestorPath:2,test)", filterQueries[0]);
     }
 
     @Test
@@ -86,7 +100,7 @@ public class FacetFieldUtilTest {
         CutoffFacetImpl facet = new CutoffFacetImpl("ANCESTOR_PATH", "2,test1");
         CutoffFacetImpl facet2 = new CutoffFacetImpl("ANCESTOR_PATH", "3,test2!4");
 
-        facetFieldUtil.addToSolrQuery(Arrays.asList(facet, facet2), query);
+        facetFieldUtil.addToSolrQuery(Arrays.asList(facet, facet2), true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -100,7 +114,7 @@ public class FacetFieldUtilTest {
 
         MultivaluedHierarchicalFacet facet = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image/jpg");
 
-        facetFieldUtil.addToSolrQuery(facet, query);
+        facetFieldUtil.addToSolrQuery(facet, true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -116,7 +130,7 @@ public class FacetFieldUtilTest {
         MultivaluedHierarchicalFacet facet2 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "text^pdf");
         MultivaluedHierarchicalFacet facet3 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "text^txt");
 
-        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3), query);
+        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3), true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -133,7 +147,7 @@ public class FacetFieldUtilTest {
         MultivaluedHierarchicalFacet facet3 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image");
         MultivaluedHierarchicalFacet facet4 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image^png");
 
-        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3, facet4), query);
+        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3, facet4), true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -149,7 +163,7 @@ public class FacetFieldUtilTest {
         MultivaluedHierarchicalFacet facet2 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image");
         MultivaluedHierarchicalFacet facet3 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image^png");
 
-        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3), query);
+        facetFieldUtil.addToSolrQuery(Arrays.asList(facet1, facet2, facet3), true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -163,7 +177,7 @@ public class FacetFieldUtilTest {
 
         GenericFacet facet = new RoleGroupFacet("ROLE_GROUP", "canManage|some_group");
 
-        facetFieldUtil.addToSolrQuery(facet, query);
+        facetFieldUtil.addToSolrQuery(facet, true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(1, filterQueries.length);
@@ -176,10 +190,10 @@ public class FacetFieldUtilTest {
         SolrQuery query = new SolrQuery();
 
         CutoffFacetImpl facet = new CutoffFacetImpl("ANCESTOR_PATH", "2,test");
-        facetFieldUtil.addToSolrQuery(facet, query);
+        facetFieldUtil.addToSolrQuery(facet, true, query);
 
         MultivaluedHierarchicalFacet facet2 = new MultivaluedHierarchicalFacet("CONTENT_TYPE", "image/jpg");
-        facetFieldUtil.addToSolrQuery(facet2, query);
+        facetFieldUtil.addToSolrQuery(facet2, true, query);
 
         String[] filterQueries = query.getFilterQueries();
         assertEquals(2, filterQueries.length);

--- a/static/js/vue-cdr-access/package-lock.json
+++ b/static/js/vue-cdr-access/package-lock.json
@@ -20,7 +20,8 @@
         "nouislider": "^15.5.1",
         "vue": "^3.2.31",
         "vue-i18n": "^9.1.9",
-        "vue-router": "^4.0.14"
+        "vue-router": "^4.0.14",
+        "vuex": "^4.0.2"
       },
       "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.17.0",
@@ -13751,6 +13752,17 @@
         "vue": "^3.2.0"
       }
     },
+    "node_modules/vuex": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.2"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "dev": true,
@@ -24033,6 +24045,14 @@
       "integrity": "sha512-wAO6zF9zxA3u+7AkMPqw9LjoUCjSxfFvINQj3E/DceTt6uEz1XZLraDhdg2EYmvVwTBSGlLYsUw8bDmx0754Mw==",
       "requires": {
         "@vue/devtools-api": "^6.0.0"
+      }
+    },
+    "vuex": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "requires": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
       }
     },
     "w3c-hr-time": {

--- a/static/js/vue-cdr-access/package.json
+++ b/static/js/vue-cdr-access/package.json
@@ -22,7 +22,8 @@
     "nouislider": "^15.5.1",
     "vue": "^3.2.31",
     "vue-i18n": "^9.1.9",
-    "vue-router": "^4.0.14"
+    "vue-router": "^4.0.14",
+    "vuex": "^4.0.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.17.0",

--- a/static/js/vue-cdr-access/src/components/browseSearch.vue
+++ b/static/js/vue-cdr-access/src/components/browseSearch.vue
@@ -71,9 +71,6 @@ Search form component displayed on full record pages, allowing keyword searches 
                 const object_text = (object_type === 'adminunit') ? 'collection' : object_type;
                 return `Search within this ${object_text}`
             },
-            allPossibleSearchParameters() {
-                return this.possible_facet_fields.concat(['anywhere']);
-            },
             enableStartOverButton() {
                 return this.anyParamsPopulated(this.allPossibleSearchParameters);
             }

--- a/static/js/vue-cdr-access/src/components/browseSearch.vue
+++ b/static/js/vue-cdr-access/src/components/browseSearch.vue
@@ -87,7 +87,7 @@ Search form component displayed on full record pages, allowing keyword searches 
             },
 
             clearAllFacets() {
-                this.routeWithParams(this.removeQueryParameters(this.possible_facet_fields));
+                this.routeWithParams(this.removeQueryParameters(this.possibleFacetFields));
             }
         },
 

--- a/static/js/vue-cdr-access/src/components/clearFacetsButton.vue
+++ b/static/js/vue-cdr-access/src/components/clearFacetsButton.vue
@@ -17,12 +17,12 @@ export default {
 
     computed: {
         showButton() {
-            return this.anyParamsPopulated(this.possible_facet_fields);
+            return this.anyParamsPopulated(this.possibleFacetFields);
         }
     },
     methods: {
         clearAllFacets() {
-            this.routeWithParams(this.removeQueryParameters(this.possible_facet_fields));
+            this.routeWithParams(this.removeQueryParameters(this.possibleFacetFields));
         }
     }
 };

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -157,11 +157,6 @@ Top level component for full record pages with searching/browsing, including Adm
                 this.is_admin_unit = document.getElementById('is-admin-unit') !== null;
                 this.is_collection = document.getElementById('is-collection') !== null;
                 this.is_folder = document.getElementById('is-folder') !== null;
-
-                // Don't update route if no url parameters are passed in
-                if (!isEmpty(this.$route.query)) {
-                    this.updateUrl();
-                }
             },
 
             /**
@@ -181,6 +176,10 @@ Top level component for full record pages with searching/browsing, including Adm
         mounted() {
             this.findPageType();
             this.adjustFacetsForRetrieval();
+            // Don't update route if no url parameters are passed in
+            if (!isEmpty(this.$route.query)) {
+                this.updateUrl();
+            }
             this.retrieveData();
         },
     }

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -10,8 +10,8 @@ Top level component for full record pages with searching/browsing, including Adm
             <div class="column is-2" v-if="showWidget">
                 <browse-sort browse-type="display"></browse-sort>
             </div>
-            <div class="column is-2 container-note" v-if="showWorksOnly">
-                <works-only :admin-unit="is_admin_unit"></works-only>
+            <div class="column is-2 container-note" v-if="showWidget">
+                <works-only></works-only>
             </div>
             <div class="column is-narrow-tablet" v-if="showWidget">
                 <view-type></view-type>
@@ -101,10 +101,6 @@ Top level component for full record pages with searching/browsing, including Adm
             showWidget() {
                 return this.record_list.length > 0;
             },
-
-            showWorksOnly() {
-                return this.showWidget || this.coerceWorksOnly(this.$route.query.works_only);
-            }
         },
 
         methods: {

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -22,7 +22,7 @@ Top level component for full record pages with searching/browsing, including Adm
             <div class="facet-list column is-one-quarter facets-border">
                 <facets :facet-list="facet_list" :min-created-year="minimumCreatedYear" :show-clear-button="false"></facets>
             </div>
-            <div class="column is-three-quarters">
+            <div id="fullRecordSearchResultDisplay" class="column is-three-quarters">
                 <gallery-display v-if="isBrowseDisplay" :record-list="record_list"></gallery-display>
                 <list-display v-else :record-list="record_list" :is-record-browse="true"></list-display>
             </div>  
@@ -46,6 +46,9 @@ Top level component for full record pages with searching/browsing, including Adm
     import get from 'axios';
     import isEmpty from 'lodash.isempty';
     import routeUtils from '../mixins/routeUtils';
+
+    const FACETS_REMOVE_ADMIN_UNIT = [ 'unit' ];
+    const FACETS_REMOVE_COLLECTION_AND_CHILDREN = [ 'unit', 'collection' ];
 
     export default {
         name: 'displayWrapper',
@@ -159,11 +162,25 @@ Top level component for full record pages with searching/browsing, including Adm
                 if (!isEmpty(this.$route.query)) {
                     this.updateUrl();
                 }
+            },
+
+            /**
+             * Adjusts which facets should be retrieved and displayed based on what type of object is being viewed
+             */
+            adjustFacetsForRetrieval() {
+                let facets_to_remove = [];
+                if (this.is_admin_unit) {
+                    facets_to_remove = FACETS_REMOVE_ADMIN_UNIT;
+                } else if (this.is_collection || this.is_folder) {
+                    facets_to_remove = FACETS_REMOVE_COLLECTION_AND_CHILDREN;
+                }
+                this.possible_facet_fields = this.possible_facet_fields.filter(f => facets_to_remove.indexOf(f) < 0);
             }
         },
 
         mounted() {
             this.findPageType();
+            this.adjustFacetsForRetrieval();
             this.retrieveData();
         },
     }

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -136,8 +136,9 @@ Top level component for full record pages with searching/browsing, including Adm
             },
 
             hasSearchQuery() {
-                let query = this.$route.query.anywhere;
-                return query !== undefined && query !== '';
+                let query_params = this.$route.query;
+                return Object.keys(query_params).some(key => query_params[key]
+                        && this.allPossibleSearchParameters.indexOf(key) >= 0);
             },
 
             updateParams() {

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -103,7 +103,7 @@ Top level component for full record pages with searching/browsing, including Adm
 
             showWidget() {
                 return this.record_list.length > 0;
-            },
+            }
         },
 
         methods: {
@@ -174,7 +174,7 @@ Top level component for full record pages with searching/browsing, including Adm
                 } else if (this.is_collection || this.is_folder) {
                     facets_to_remove = FACETS_REMOVE_COLLECTION_AND_CHILDREN;
                 }
-                this.possible_facet_fields = this.possible_facet_fields.filter(f => facets_to_remove.indexOf(f) < 0);
+                this.$store.commit('removePossibleFacetFields', facets_to_remove);
             }
         },
 

--- a/static/js/vue-cdr-access/src/components/facets.vue
+++ b/static/js/vue-cdr-access/src/components/facets.vue
@@ -152,7 +152,7 @@ Facet list component, used to display all the values of facets and provide links
             },
 
             /**
-             * Used to determine if a collection has been selected. If so, remove collections from facets to select from
+             * Determine if a facet should be displayed or not
              * @param facet
              * @returns {boolean|boolean}
              */
@@ -160,8 +160,7 @@ Facet list component, used to display all the values of facets and provide links
                 if (facet.name === 'DATE_CREATED_YEAR' && this.minCreatedYear !== undefined) {
                     return true;
                 }
-                return facet.values.length > 0 &&
-                    (facet.name !== 'PARENT_COLLECTION' || (facet.name === 'PARENT_COLLECTION' && !this.routeHasCollectionId));
+                return facet.values.length > 0;
             },
 
             /**

--- a/static/js/vue-cdr-access/src/components/facets.vue
+++ b/static/js/vue-cdr-access/src/components/facets.vue
@@ -173,7 +173,7 @@ Facet list component, used to display all the values of facets and provide links
                 };
 
                 // Unset current facets
-                this.possible_facet_fields.forEach((facet) => delete base_search.query[facet]);
+                this.possibleFacetFields.forEach((facet) => delete base_search.query[facet]);
                 // Add/Update with new facets
                 base_search.query = Object.assign(base_search.query, updated_facet_params.queryFacets);
                 this.$router.push(base_search).catch((e) => {
@@ -389,7 +389,7 @@ Facet list component, used to display all the values of facets and provide links
              */
             setFacetsFromParams() {
                 let params = this.urlParams();
-                this.possible_facet_fields.forEach((type) => {
+                this.possibleFacetFields.forEach((type) => {
                     this._setFacetFromRoute(type, params[type]);
                 });
             },

--- a/static/js/vue-cdr-access/src/components/facets.vue
+++ b/static/js/vue-cdr-access/src/components/facets.vue
@@ -37,7 +37,6 @@ Facet list component, used to display all the values of facets and provide links
     import clearFacetsButton from "@/components/clearFacetsButton.vue";
     import routeUtils from '../mixins/routeUtils';
 
-    const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
     const CURRENT_YEAR = new Date().getFullYear();
 
     export default {
@@ -86,10 +85,6 @@ Facet list component, used to display all the values of facets and provide links
         },
 
         computed: {
-            routeHasCollectionId() {
-                return UUID_REGEX.test(this.$route.path);
-            },
-
             selectedFacetInfo() {
                 const display_list = [];
                 this.selected_facets.map((f) => {

--- a/static/js/vue-cdr-access/src/components/filterTags.vue
+++ b/static/js/vue-cdr-access/src/components/filterTags.vue
@@ -61,7 +61,7 @@ export default {
     methods: {
         updateQueryUrl(event) {
             const params = this._updateParams(event);
-            this.routeWithParams(params, "searchRecords");
+            this.routeWithParams(params, this.$route.name, this.routeParams);
         },
 
         _updateParams(event) {

--- a/static/js/vue-cdr-access/src/components/pagination.vue
+++ b/static/js/vue-cdr-access/src/components/pagination.vue
@@ -50,14 +50,14 @@ Pagination component for search results, listing pages, previous/next buttons, c
         computed: {
             currentPage() {
                 let query = this.$route.query;
-                let display_type = (this.$route.name === 'searchRecords') ? query['a.setStartRow'] : query.start;
+                let start_row = query.start;
 
-                if (isEmpty(query) || parseInt(query.start) === 0 ||  (this.$route.name === 'searchRecords' &&
-                    (query['a.setStartRow'] === undefined || parseInt(query['a.setStartRow']) === 0))) {
+                if (isEmpty(query) || parseInt(start_row) === 0 ||  (this.$route.name === 'searchRecords' &&
+                    (start_row === undefined || parseInt(start_row) === 0))) {
                     return 1;
                 }
 
-                return Math.ceil(parseInt(display_type) / parseInt(this.rows_per_page)) + 1;
+                return Math.ceil(parseInt(start_row) / parseInt(this.rows_per_page)) + 1;
             },
 
             currentPageList() {
@@ -113,7 +113,7 @@ Pagination component for search results, listing pages, previous/next buttons, c
                     });
                 } else {
                     this.$router.push({ path: this.$route.path, query: this.urlParams(update_params = {
-                            'a.setStartRow': start_record,
+                            start: start_record,
                             rows: this.rows_per_page + ''
                         }, true)
                     }).catch((e) => {

--- a/static/js/vue-cdr-access/src/components/searchWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/searchWrapper.vue
@@ -45,8 +45,6 @@ Top level component wrapper for search pages
     import routeUtils from "../mixins/routeUtils";
     import get from 'axios';
 
-    const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
-
     export default {
         name: 'searchWrapper',
 
@@ -101,7 +99,7 @@ Top level component wrapper for search pages
             retrieveData() {
                 let param_string = `${this.formatParamsString(this.$route.query)}&getFacets=true`;
                 let search_path = 'searchJson';
-                this.collection = UUID_REGEX.test(this.$route.path) ? this.$route.path.split('/')[2] : '';
+                this.collection = this.routeHasPathId ? this.$route.path.split('/')[2] : '';
 
                 get(`${search_path}/${param_string}`).then((response) => {
                     this.records = response.data.metadata;

--- a/static/js/vue-cdr-access/src/components/searchWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/searchWrapper.vue
@@ -77,7 +77,7 @@ Top level component wrapper for search pages
 
         computed: {
             recordDisplayCounts() {
-                let search_start = parseInt(this.$route.query['a.setStartRow']);
+                let search_start = parseInt(this.$route.query.start);
                 let start = (search_start > 0) ? search_start + 1 : 1;
                 let records = (this.records.length < this.rows_per_page) ? this.records.length : parseInt(this.rows_per_page);
                 let offset = (search_start > 0) ? search_start : 0;

--- a/static/js/vue-cdr-access/src/components/worksOnly.vue
+++ b/static/js/vue-cdr-access/src/components/worksOnly.vue
@@ -3,7 +3,7 @@ Checkbox to switch search result modes between including only works with a flatt
 and including all types with hierarchy retained.
 -->
 <template>
-    <div id="browse-display-type" class="display-wrapper" v-if="!adminUnit">
+    <div id="browse-display-type" class="display-wrapper">
         <div class="field">
             <input @click="showWorks" type="checkbox" id="works-only" class="is-checkradio is-large" v-model="works_only">
             <label for="works-only"><p>{{ $t('works_only.show')}}</p></label>
@@ -22,10 +22,6 @@ and including all types with hierarchy retained.
 
     export default {
         name: 'worksOnly',
-
-        props: {
-            adminUnit: Boolean
-        },
 
         mixins: [routeUtils],
 

--- a/static/js/vue-cdr-access/src/main.js
+++ b/static/js/vue-cdr-access/src/main.js
@@ -2,6 +2,7 @@ import { createApp, h } from 'vue'
 import { createI18n } from 'vue-i18n'
 import App from './App.vue'
 import router from './router'
+import store from './store'
 import translations from '@/translations';
 import './assets/common-styles.css';
 import './assets/nouislider.css'; // Imported here, otherwise it breaks component tests, as an invalid import
@@ -17,5 +18,5 @@ if (document.getElementById('app') !== null && window.dcr_browse_records === und
     render() {
       return h(App);
     }
-  }).use(router).use(i18n).mount('#app');
+  }).use(router).use(store).use(i18n).mount('#app');
 }

--- a/static/js/vue-cdr-access/src/mixins/routeUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/routeUtils.js
@@ -1,6 +1,6 @@
 import isEmpty from 'lodash.isempty';
-import store from '../store'
 
+const UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
 export default {
     data() {
         return {
@@ -136,12 +136,13 @@ export default {
         },
 
         /**
-         * Push updated url to history, using the provided query parambers
+         * Push updated url to history, using the provided query parameters
          * @param params query parameters to push to url
          * @param route_name optional name for pushed route
+         * @param route_params path parameters for formatting into route
          */
-        routeWithParams(params, route_name = undefined) {
-            this.$router.push({ query: params, name: route_name }).catch((e) => {
+        routeWithParams(params, route_name = undefined, route_params = undefined) {
+            this.$router.push({ query: params, name: route_name, params: route_params }).catch((e) => {
                 if (this.nonDuplicateNavigationError(e)) {
                     throw e;
                 }
@@ -171,6 +172,17 @@ export default {
         },
         allPossibleSearchParameters() {
             return this.possibleFacetFields.concat(['anywhere']);
+        },
+        routeParams() {
+            let params = {};
+            let match = UUID_REGEX.exec(this.$route.path);
+            if (match != null) {
+                params.uuid = match[1];
+            }
+            return params;
+        },
+        routeHasPathId() {
+            return UUID_REGEX.test(this.$route.path);
         }
     }
 }

--- a/static/js/vue-cdr-access/src/mixins/routeUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/routeUtils.js
@@ -1,13 +1,10 @@
 import isEmpty from 'lodash.isempty';
-
-const POSSIBLE_FACET_FIELDS = ['unit', 'collection', 'createdYear', 'format', 'language', 'subject', 'location',
-    'creatorContributor', 'publisher'];
+import store from '../store'
 
 export default {
     data() {
         return {
             rows_per_page: this.$route.query.rows || 20,
-            possible_facet_fields: POSSIBLE_FACET_FIELDS.slice(),
             min_created_year: undefined
         }
     },
@@ -25,7 +22,7 @@ export default {
                 start: 0,
                 rows: this.rows_per_page,
                 sort: 'default,normal',
-                facetSelect: this.possible_facet_fields.join(',')
+                facetSelect: this.possibleFacetFields.join(',')
             };
 
             if (!is_search) {
@@ -163,6 +160,9 @@ export default {
     },
 
     computed: {
+        possibleFacetFields() {
+            return this.$store.state.possibleFacetFields;
+        },
         minimumCreatedYear() {
             if (this.min_created_year !== undefined) {
                 return parseInt(this.min_created_year)
@@ -170,7 +170,7 @@ export default {
             return undefined;
         },
         allPossibleSearchParameters() {
-            return this.possible_facet_fields.concat(['anywhere']);
-        },
+            return this.possibleFacetFields.concat(['anywhere']);
+        }
     }
 }

--- a/static/js/vue-cdr-access/src/mixins/routeUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/routeUtils.js
@@ -1,11 +1,13 @@
 import isEmpty from 'lodash.isempty';
 
+const POSSIBLE_FACET_FIELDS = ['unit', 'collection', 'createdYear', 'format', 'language', 'subject', 'location',
+    'creatorContributor', 'publisher'];
+
 export default {
     data() {
         return {
             rows_per_page: this.$route.query.rows || 20,
-            possible_facet_fields: ['unit', 'collection', 'createdYear', 'format', 'language', 'subject', 'location',
-                'creatorContributor', 'publisher'],
+            possible_facet_fields: POSSIBLE_FACET_FIELDS.slice(),
             min_created_year: undefined
         }
     },
@@ -19,23 +21,16 @@ export default {
          * @returns {any}
          */
         urlParams(params_to_update = {}, is_search = false) {
-            let defaults;
+            let defaults = {
+                start: 0,
+                rows: this.rows_per_page,
+                sort: 'default,normal',
+                facetSelect: this.possible_facet_fields.join(',')
+            };
 
-            if (is_search) {
-                defaults = {
-                    'a.setStartRow': 0,
-                    rows: this.rows_per_page,
-                    sort: 'default,normal',
-                    facetSelect: this.possible_facet_fields.join(',')
-                };
-            } else {
-                defaults = {
-                    rows: this.rows_per_page,
-                    start: 0,
-                    sort: 'default,normal',
-                    browse_type: 'list-display',
-                    works_only: false
-                };
+            if (!is_search) {
+                defaults.works_only = false;
+                defaults.browse_type = 'list-display';
             }
 
             let route_params = Object.assign(defaults, this.$route.query);

--- a/static/js/vue-cdr-access/src/mixins/routeUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/routeUtils.js
@@ -173,6 +173,9 @@ export default {
                 return parseInt(this.min_created_year)
             }
             return undefined;
-        }
+        },
+        allPossibleSearchParameters() {
+            return this.possible_facet_fields.concat(['anywhere']);
+        },
     }
 }

--- a/static/js/vue-cdr-access/src/store.js
+++ b/static/js/vue-cdr-access/src/store.js
@@ -13,6 +13,18 @@ const store = createStore({
     mutations: {
         removePossibleFacetFields (state, removeFacets) {
             state.possibleFacetFields = state.possibleFacetFields.filter(f => removeFacets.indexOf(f) < 0);
+        },
+        resetPossibleFacetFields (state) {
+            state.possibleFacetFields = POSSIBLE_FACET_FIELDS.slice();
+        }
+    },
+    actions: {
+        /**
+         * Used to reset the store back to its initial state, primarily for testing
+         * @param context
+         */
+        resetState (context) {
+            context.commit("resetPossibleFacetFields");
         }
     }
 });

--- a/static/js/vue-cdr-access/src/store.js
+++ b/static/js/vue-cdr-access/src/store.js
@@ -1,0 +1,23 @@
+import { createStore } from 'vuex'
+
+const POSSIBLE_FACET_FIELDS = ['unit', 'collection', 'createdYear', 'format', 'language', 'subject', 'location',
+    'creatorContributor', 'publisher'];
+
+// Create a new store instance.
+const store = createStore({
+    state () {
+        return {
+            possibleFacetFields: POSSIBLE_FACET_FIELDS.slice()
+        }
+    },
+    mutations: {
+        removePossibleFacetFields (state, removeFacets) {
+            state.possibleFacetFields = state.possibleFacetFields.filter(f => removeFacets.indexOf(f) < 0);
+        },
+        resetPossibleFacetFields (state) {
+            state.possibleFacetFields = POSSIBLE_FACET_FIELDS.slice();
+        }
+    }
+});
+
+export default store;

--- a/static/js/vue-cdr-access/src/store.js
+++ b/static/js/vue-cdr-access/src/store.js
@@ -13,9 +13,6 @@ const store = createStore({
     mutations: {
         removePossibleFacetFields (state, removeFacets) {
             state.possibleFacetFields = state.possibleFacetFields.filter(f => removeFacets.indexOf(f) < 0);
-        },
-        resetPossibleFacetFields (state) {
-            state.possibleFacetFields = POSSIBLE_FACET_FIELDS.slice();
         }
     }
 });

--- a/static/js/vue-cdr-access/tests/unit/browseSearch.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/browseSearch.spec.js
@@ -1,6 +1,7 @@
 import { flushPromises, mount } from '@vue/test-utils';
 import { createI18n } from 'vue-i18n';
 import  { createRouter, createWebHistory } from 'vue-router';
+import store from '@/store';
 import browseSearch from '@/components/browseSearch.vue';
 import displayWrapper from "@/components/displayWrapper.vue";
 import translations from "@/translations";
@@ -28,7 +29,7 @@ describe('browseSearch.vue', () => {
         });
         wrapper = mount(browseSearch, {
             global: {
-                plugins: [i18n, router]
+                plugins: [i18n, store, router]
             },
             props: {
                 objectType: 'Folder',
@@ -95,7 +96,7 @@ describe('browseSearch.vue', () => {
                 mocks: {
                     $route
                 },
-                plugins: [i18n]
+                plugins: [i18n, store]
             },
             props: { filterParameters: {} }
         });
@@ -114,7 +115,7 @@ describe('browseSearch.vue', () => {
                 mocks: {
                     $route
                 },
-                plugins: [i18n]
+                plugins: [i18n, store]
             },
             props: {
                 objectType: 'Folder',

--- a/static/js/vue-cdr-access/tests/unit/browseSort.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/browseSort.spec.js
@@ -5,6 +5,7 @@ import displayWrapper from '@/components/displayWrapper.vue';
 import searchWrapper from '@/components/searchWrapper.vue';
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
+import store from '@/store';
 
 let wrapper, wrapper_search, router;
 
@@ -33,7 +34,7 @@ describe('browseSort.vue', () => {
         });
         wrapper = mount(browseSort, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 browseType: 'display'
@@ -42,7 +43,7 @@ describe('browseSort.vue', () => {
 
         wrapper_search = mount(browseSort, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 browseType: 'search'

--- a/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
@@ -115,8 +115,8 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameter for non admin set browse works only browse", async () => {
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?works_only=true');
         mountApp();
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?works_only=true')
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -126,8 +126,8 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameters for non admin works only browse",  async () => {
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?works_only=false');
+        mountApp();
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -137,10 +137,10 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameters if search text is specified", async () => {
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?anywhere=search query');
         mountApp({
             filter_parameters: { "anywhere" : "search query"}
         });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?anywhere=search query');
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -150,10 +150,10 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameters if facet parameter is specified", async () => {
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?subject=subj value');
         mountApp({
             filter_parameters: { "subject" : "subj value" }
         });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?subject=subj value');
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -164,12 +164,12 @@ describe('displayWrapper.vue', () => {
 
     it("uses the correct parameters for admin unit browse", async () => {
         stubQueryResponse(`listJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+`, response);
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=false');
         mountApp({
             is_admin_unit: true,
             is_collection: false,
             is_folder: false
         });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=false');
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -181,13 +181,13 @@ describe('displayWrapper.vue', () => {
     });
 
     it("updates the url when work type changes", async () => {
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?browse_type=gallery-display');
         mountApp({
             is_admin_unit: false,
             is_collection: true,
             is_folder: false
         });
 
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?browse_type=gallery-display');
         wrapper.vm.updateUrl();
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.types).toEqual('Work,Folder,Collection');
@@ -195,8 +195,8 @@ describe('displayWrapper.vue', () => {
 
     it("displays a 'works only' option if the 'works only' box is checked and no records are works", async () => {
         stubQueryResponse(`searchJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+`, response);
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=true');
+        mountApp();
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();
@@ -207,11 +207,11 @@ describe('displayWrapper.vue', () => {
     });
 
     it("does not display a 'works only' option if the 'works only' box is not checked and no records are works", async () => {
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=false');
-        wrapper.vm.updateUrl();
-        wrapper.vm.retrieveData();
-        await flushPromises();
+        mountApp();
+        // wrapper.vm.updateUrl();
+        // wrapper.vm.retrieveData();
+        // await flushPromises();
         let works_only = wrapper.find('.container-note');
         expect(works_only.exists()).toBe(false)
     });
@@ -219,8 +219,9 @@ describe('displayWrapper.vue', () => {
     it("adjusts facets retrieved for admin unit", async () => {
         document.body.innerHTML = document.body.innerHTML + '<div id="is-admin-unit"></div>';
         stubQueryResponse(`listJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+&facetSelect=collection%2CcreatedYear%2Cformat%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&.*`, response);
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
+        mountApp();
+        await flushPromises();
 
         // Verify that there are still other facets, but that the unit facet has been removed
         expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
@@ -232,8 +233,9 @@ describe('displayWrapper.vue', () => {
     it("adjusts facets retrieved for collection object", async () => {
         document.body.innerHTML = document.body.innerHTML + '<div id="is-collection"></div>';
         stubQueryResponse(`listJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+&facetSelect=createdYear%2Cformat%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&.*`, response);
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
+        mountApp();
+        await flushPromises();
 
         // Verify that there are still other facets, but that the unit and collection facets have been removed
         expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
@@ -246,8 +248,9 @@ describe('displayWrapper.vue', () => {
     it("adjusts facets retrieved for folder object", async () => {
         document.body.innerHTML = document.body.innerHTML + '<div id="is-folder"></div>';
         stubQueryResponse(`listJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+&facetSelect=createdYear%2Cformat%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&.*`, response);
-        mountApp();
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
+        mountApp();
+        await flushPromises();
 
         // Verify that there are still other facets, but that the unit and collection facets have been removed
         expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
@@ -257,8 +260,31 @@ describe('displayWrapper.vue', () => {
         expect(wrapper.find('#fullRecordSearchResultDisplay').exists()).toBe(true);
     });
 
+    it("adjusts facets retrieved for admin unit and maintains them after checking works only", async () => {
+        document.body.innerHTML = document.body.innerHTML + '<div id="is-admin-unit"></div>';
+        stubQueryResponse(`listJson/73bc003c-9603-4cd9-8a65-93a22520ef6a?.+&facetSelect=collection%2CcreatedYear%2Cformat%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&.*`, response);
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?browse_type=list-display');
+        mountApp();
+        await flushPromises();
+
+        // Verify that there are still other facets, but that the unit facet has been removed
+        let num_facets = wrapper.vm.$store.state.possibleFacetFields.length;
+        expect(num_facets).toBeGreaterThan(0);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('unit')).toEqual(-1);
+        expect(wrapper.vm.$route.query.facetSelect.indexOf('unit')).toEqual(-1);
+
+        // Trigger works only filter and make sure that the set of facets does not change
+        await wrapper.find('#works-only').trigger('click');
+        await flushPromises();
+
+        expect(wrapper.vm.$store.state.possibleFacetFields.length).toEqual(num_facets);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('unit')).toEqual(-1);
+        expect(wrapper.vm.$route.query.facetSelect.indexOf('unit')).toEqual(-1);
+    });
+
     afterEach(() => {
         moxios.uninstall();
+        wrapper.vm.$store.dispatch("resetState");
         wrapper = null;
         router = null;
         // Reset the dom to avoid tags added persisting across tests

--- a/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
@@ -78,7 +78,8 @@ describe('displayWrapper.vue', () => {
                     is_folder: false,
                     record_count: 0,
                     record_list: [],
-                    uuid: '0410e5c1-a036-4b7c-8d7d-63bfda2d6a36'
+                    uuid: '0410e5c1-a036-4b7c-8d7d-63bfda2d6a36',
+                    filter_parameters: {}
                 }
             }
         });
@@ -122,7 +123,23 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameters if search text is specified", async () => {
+        await wrapper.setData({
+            filter_parameters: { "anywhere" : "search query"}
+        });
         await router.push('/record/1234?anywhere=search query');
+
+        wrapper.vm.updateUrl();
+        wrapper.vm.retrieveData();
+        await flushPromises();
+        expect(wrapper.vm.search_method).toEqual('searchJson');
+        expect(wrapper.vm.$router.currentRoute.value.query.types).toEqual('Work,Folder,Collection');
+    });
+
+    it("uses the correct search parameters if facet parameter is specified", async () => {
+        await wrapper.setData({
+            filter_parameters: { "subject" : "subj value"}
+        });
+        await router.push('/record/1234?subject=subj value');
 
         wrapper.vm.updateUrl();
         wrapper.vm.retrieveData();

--- a/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
@@ -1,6 +1,7 @@
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router';
 import displayWrapper from '@/components/displayWrapper.vue';
+import store from '@/store';
 import moxios from "moxios";
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
@@ -84,7 +85,7 @@ describe('displayWrapper.vue', () => {
         let data = {...default_data, ...data_overrides};
         wrapper = mount(displayWrapper, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             data() {
                 return data;
@@ -222,8 +223,8 @@ describe('displayWrapper.vue', () => {
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
 
         // Verify that there are still other facets, but that the unit facet has been removed
-        expect(wrapper.vm.possible_facet_fields.length).toBeGreaterThan(0);
-        expect(wrapper.vm.possible_facet_fields.indexOf('unit')).toEqual(-1);
+        expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('unit')).toEqual(-1);
         // Verify that record list is displaying, indicating that a request was made which did not include unit facet
         expect(wrapper.find('#fullRecordSearchResultDisplay').exists()).toBe(true);
     });
@@ -235,9 +236,9 @@ describe('displayWrapper.vue', () => {
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
 
         // Verify that there are still other facets, but that the unit and collection facets have been removed
-        expect(wrapper.vm.possible_facet_fields.length).toBeGreaterThan(0);
-        expect(wrapper.vm.possible_facet_fields.indexOf('unit')).toEqual(-1);
-        expect(wrapper.vm.possible_facet_fields.indexOf('collection')).toEqual(-1);
+        expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('unit')).toEqual(-1);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('collection')).toEqual(-1);
         // Verify that record list is displaying, indicating that a request was made which did not include unwanted facets
         expect(wrapper.find('#fullRecordSearchResultDisplay').exists()).toBe(true);
     });
@@ -249,9 +250,9 @@ describe('displayWrapper.vue', () => {
         await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a');
 
         // Verify that there are still other facets, but that the unit and collection facets have been removed
-        expect(wrapper.vm.possible_facet_fields.length).toBeGreaterThan(0);
-        expect(wrapper.vm.possible_facet_fields.indexOf('unit')).toEqual(-1);
-        expect(wrapper.vm.possible_facet_fields.indexOf('collection')).toEqual(-1);
+        expect(wrapper.vm.$store.state.possibleFacetFields.length).toBeGreaterThan(0);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('unit')).toEqual(-1);
+        expect(wrapper.vm.$store.state.possibleFacetFields.indexOf('collection')).toEqual(-1);
         // Verify that record list is displaying, indicating that a request was made which did not include unwanted facets
         expect(wrapper.find('#fullRecordSearchResultDisplay').exists()).toBe(true);
     });

--- a/static/js/vue-cdr-access/tests/unit/facets.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/facets.spec.js
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import facets from '@/components/facets.vue';
 import searchWrapper from '@/components/searchWrapper.vue';
 import displayWrapper from '@/components/displayWrapper.vue';
+import store from '@/store';
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
 
@@ -35,7 +36,7 @@ describe('facets.vue', () => {
 
         wrapper = mount(facets, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 minCreatedYear: 2011,
@@ -131,7 +132,7 @@ describe('facets.vue', () => {
     it("does not display facets with no returned results", () => {
         let emptyFacetWrapper = mount(facets, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 minSearchYear: 2011,
@@ -190,7 +191,7 @@ describe('facets.vue', () => {
     it("does not display date facets with no minimum search year set", () => {
         let emptyFacetWrapper = mount(facets, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 minCreatedYear: undefined,

--- a/static/js/vue-cdr-access/tests/unit/filterTags.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/filterTags.spec.js
@@ -235,4 +235,20 @@ describe('filterTags.vue', () => {
         await router.push('/search?added=,2005');
         expect(wrapper.find('.search-text').text()).toMatch(/Date\sAdded.*?All\sdates\sthrough\s2005/s);
     });
+
+    it("clears anywhere term when container selected", async () => {
+        mountWithFilterParameters({
+            anywhere: "barns"
+        });
+        await router.push('/search/d77fd8c9-744b-42ab-8e20-5ad9bdf8194e?anywhere=barns');
+        expect(global.window.location.href).toEqual('https://localhost/search/d77fd8c9-744b-42ab-8e20-5ad9bdf8194e?anywhere=barns');
+        let selected_tags = wrapper.findAll('.search-text');
+        expect(selected_tags[0].text()).toMatch(/barns/);
+
+        await wrapper.find('.search-text').trigger('click');
+        await wrapper.setProps({ filterParameters: {} });
+        await flushPromises();
+        expect(global.window.location.href).toEqual('https://localhost/search/d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        expect(wrapper.find('.search-text').exists()).toBe(false);
+    });
 });

--- a/static/js/vue-cdr-access/tests/unit/pagination.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/pagination.spec.js
@@ -6,6 +6,7 @@ import displayWrapper from '@/components/displayWrapper.vue';
 import searchWrapper from '@/components/searchWrapper.vue';
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
+import store from '@/store';
 
 let router, wrapper;
 
@@ -34,7 +35,7 @@ describe('pagination.vue', () => {
         });
         wrapper = shallowMount(pagination, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 browseType: 'display',

--- a/static/js/vue-cdr-access/tests/unit/pagination.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/pagination.spec.js
@@ -92,7 +92,7 @@ describe('pagination.vue', () => {
 
         await wrapper.findAll('.page-number')[1].trigger('click');
         await flushPromises();
-        expect(wrapper.vm.$router.currentRoute.value.query['a.setStartRow']).toEqual('20');
+        expect(wrapper.vm.$router.currentRoute.value.query.start).toEqual('20');
     });
 
     it("displays a link to jump to the first page if the user in on a page beyond the pageLimit", async () => {

--- a/static/js/vue-cdr-access/tests/unit/routeUtils.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/routeUtils.spec.js
@@ -51,7 +51,7 @@ describe('routeUtils',  () => {
 
     it("sets default url parameters for search view if none are given", () => {
         const defaults = {
-            'a.setStartRow': 0,
+            start: 0,
             rows: 20,
             sort: 'default,normal',
             facetSelect: wrapper.vm.possible_facet_fields.join(',')
@@ -60,7 +60,7 @@ describe('routeUtils',  () => {
         let results = wrapper.vm.urlParams({}, true);
 
         expect(results.rows).toEqual(defaults.rows);
-        expect(results['a.setStartRow']).toEqual(defaults['a.setStartRow']);
+        expect(results.start).toEqual(defaults.start);
         expect(results.sort).toEqual(defaults.sort);
         expect(results.facetSelect).toEqual(defaults.facetSelect);
     });
@@ -87,16 +87,16 @@ describe('routeUtils',  () => {
 
     it("updates url parameters for a search view", () => {
         const defaults = {
-            'a.setStartRow': 0,
+            start: 0,
             rows: 20,
             sort: 'default,normal',
             facetSelect: wrapper.vm.possible_facet_fields.join(',')
         };
 
-        let results = wrapper.vm.urlParams({'a.setStartRow': 20}, true);
+        let results = wrapper.vm.urlParams({start: 20}, true);
 
         expect(results.rows).toEqual(defaults.rows);
-        expect(results['a.setStartRow']).toEqual(20);
+        expect(results.start).toEqual(20);
         expect(results.sort).toEqual(defaults.sort);
         expect(results.facetSelect).toEqual(defaults.facetSelect);
     });

--- a/static/js/vue-cdr-access/tests/unit/routeUtils.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/routeUtils.spec.js
@@ -3,6 +3,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import pagination from '@/components/pagination.vue'
 import displayWrapper from "@/components/displayWrapper.vue";
 import routeUtils from '@/mixins/routeUtils.js';
+import store from '@/store';
 
 const gallery = 'gallery-display';
 const list_display = 'list-display';
@@ -23,7 +24,7 @@ describe('routeUtils',  () => {
         // Set wrapper using any component that uses routeUtils mixin to avoid test warnings about missing template
         wrapper = shallowMount(pagination, {
             global: {
-                plugins: [router]
+                plugins: [router, store]
             }
         });
         await router.push('/record/1234');
@@ -54,7 +55,7 @@ describe('routeUtils',  () => {
             start: 0,
             rows: 20,
             sort: 'default,normal',
-            facetSelect: wrapper.vm.possible_facet_fields.join(',')
+            facetSelect: wrapper.vm.possibleFacetFields.join(',')
         };
 
         let results = wrapper.vm.urlParams({}, true);
@@ -90,7 +91,7 @@ describe('routeUtils',  () => {
             start: 0,
             rows: 20,
             sort: 'default,normal',
-            facetSelect: wrapper.vm.possible_facet_fields.join(',')
+            facetSelect: wrapper.vm.possibleFacetFields.join(',')
         };
 
         let results = wrapper.vm.urlParams({start: 20}, true);

--- a/static/js/vue-cdr-access/tests/unit/viewType.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/viewType.spec.js
@@ -4,6 +4,7 @@ import viewType from '@/components/viewType.vue'
 import displayWrapper from "@/components/displayWrapper.vue";
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
+import store from '@/store';
 
 let wrapper, btns, router;
 
@@ -28,7 +29,7 @@ describe('viewType.vue', () => {
         sessionStorage.clear();
         wrapper = shallowMount(viewType, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             }
         });
 

--- a/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
@@ -45,17 +45,6 @@ describe('worksOnly.vue', () => {
 
     afterEach(() => router = null);
 
-    it("does not display for admin unit records", async () => {
-        await wrapper.setProps({
-            adminUnit: true
-        });
-        expect(wrapper.find('#browse-display-type').exists()).toBe(false);
-    });
-
-    it("does display for non admin units", () => {
-        expect(wrapper.find('#browse-display-type').exists()).toBe(true);
-    });
-
     it("updates route to only show works if button is checked for a gallery view",  async () => {
         await router.push('/record/1234/?browse_type=gallery-display');
         await wrapper.setData({ works_only: false });

--- a/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
@@ -4,6 +4,7 @@ import worksOnly from '@/components/worksOnly.vue';
 import displayWrapper from '@/components/displayWrapper.vue';
 import {createI18n} from "vue-i18n";
 import translations from "@/translations";
+import store from '@/store';
 
 
 let wrapper, record_input, router;
@@ -28,7 +29,7 @@ describe('worksOnly.vue', () => {
         });
         wrapper = shallowMount(worksOnly, {
             global: {
-                plugins: [router, i18n]
+                plugins: [router, store, i18n]
             },
             props: {
                 adminUnit: false


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3563
Also addresses https://jira.lib.unc.edu/browse/BXC-3610

* Facet results in listJson requests now include all children
    * Required fixing an issue applyCutoffs parameter, which was not being honored for the ancestorPath facet when constructing solr queries (it is the only CutoffFacet), and was incorrectly being used to prevent other facet behaviors (most likely code had moved around at some point and the conditional not been updated)
* Applying facet restrictions now switches from listJson to searchJson, just like search terms
* "Show works only" button now shown on admin unit pages
* Suppress Admin Unit facet on all full record pages, suppress Collection facet on collection and folder pages
    * Required switching possible_facet_fields over to vuex so a consistent list of facets was used after removing values from the list, which required adding in vuex
* Fix bug that caused the UUID in the url to be removed when clearing the `anywhere` term
* A few minor refactors, like using "start" everywhere, centralizing UUID regex