### PR TITLE
BXC-3624 - API For listing facet values

### DIFF
--- a/etc/solr-config/access/conf/solrconfig.xml
+++ b/etc/solr-config/access/conf/solrconfig.xml
@@ -210,7 +210,7 @@
 
        For more details see http://wiki.apache.org/solr/SolrJmx
     -->
-  <jmx />
+<!--  <jmx />-->
   <!-- If you want to connect to a particular server, specify the
        agentId
     -->

--- a/pom.xml
+++ b/pom.xml
@@ -508,6 +508,13 @@
             </dependency>
             <dependency>
                 <groupId>edu.unc.lib.cdr</groupId>
+                <artifactId>search-solr</artifactId>
+                <version>${cdr.version}</version>
+                <scope>test</scope>
+                <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>edu.unc.lib.cdr</groupId>
                 <artifactId>indexing-solr</artifactId>
                 <version>${cdr.version}</version>
             </dependency>

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
@@ -91,6 +91,9 @@ public enum SearchFieldKey {
     private static Map<String, SearchFieldKey> nameToKey = Arrays.stream(SearchFieldKey.values())
             .collect(Collectors.toMap(SearchFieldKey::getSolrField, Function.identity()));
 
+    private static Map<String, SearchFieldKey> urlParamToKey = Arrays.stream(SearchFieldKey.values())
+            .collect(Collectors.toMap(SearchFieldKey::getUrlParam, Function.identity()));
+
     private SearchFieldKey(String solrField, String urlParam, String displayLabel) {
         this.solrField = solrField;
         this.urlParam = urlParam;
@@ -125,5 +128,13 @@ public enum SearchFieldKey {
      */
     public static SearchFieldKey getByName(String name) {
         return nameToKey.get(name);
+    }
+
+    /**
+     * @param urlParam
+     * @return the SearchFieldKey which has a urlParam matching the provided value
+     */
+    public static SearchFieldKey getByUrlParam(String urlParam) {
+        return urlParamToKey.get(urlParam);
     }
 }

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/FacetValuesRequest.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/FacetValuesRequest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.api.requests;
+
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+
+/**
+ * Request for listing values of a facet
+ *
+ * @author bbpennel
+ */
+public class FacetValuesRequest {
+    private SearchRequest baseSearchRequest;
+    private SearchFieldKey facetFieldKey;
+    private String sort;
+    private Integer start;
+    private Integer rows;
+
+    public FacetValuesRequest(SearchFieldKey facetFieldKey) {
+        this.facetFieldKey = facetFieldKey;
+    }
+
+    public SearchRequest getBaseSearchRequest() {
+        return baseSearchRequest;
+    }
+
+    public void setBaseSearchRequest(SearchRequest baseSearchRequest) {
+        this.baseSearchRequest = baseSearchRequest;
+    }
+
+    public SearchFieldKey getFacetFieldKey() {
+        return facetFieldKey;
+    }
+
+    public void setFacetFieldKey(SearchFieldKey facetFieldKey) {
+        this.facetFieldKey = facetFieldKey;
+    }
+
+    public String getSort() {
+        return sort;
+    }
+
+    public void setSort(String sort) {
+        this.sort = sort;
+    }
+
+    public Integer getStart() {
+        return start;
+    }
+
+    public void setStart(Integer start) {
+        this.start = start;
+    }
+
+    public Integer getRows() {
+        return rows;
+    }
+
+    public void setRows(Integer rows) {
+        this.rows = rows;
+    }
+}

--- a/search-solr/pom.xml
+++ b/search-solr/pom.xml
@@ -24,6 +24,12 @@
                 </excludes>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
     <dependencies>
         <dependency>

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/config/SearchSettings.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/config/SearchSettings.java
@@ -109,6 +109,8 @@ public class SearchSettings extends AbstractSettings {
     public int maxPerPage;
     // Upper limit to the number of results allowed in a browse request.
     public int maxBrowsePerPage;
+    // Upper limit to the number of facet values that can be returned at once
+    public int maxFacetsPerPage;
     // Upper limit to the number of page navigation links to display at a time.
     public int pagesToDisplay;
     // Max number of neighbor items to display in the neighbor view
@@ -177,6 +179,7 @@ public class SearchSettings extends AbstractSettings {
         setMaxBrowsePerPage(Integer.parseInt(properties.getProperty("search.results.maxBrowsePerPage", "100")));
         setPagesToDisplay(Integer.parseInt(properties.getProperty("search.results.pagesToDisplay", "10")));
         setMaxNeighborResults(Integer.parseInt(properties.getProperty("search.results.neighborItems", "7")));
+        setMaxFacetsPerPage(Integer.parseInt(properties.getProperty("search.results.maxFacetsPerPage", "1000")));
 
         setStructuredDepthDefault(Integer.parseInt(properties.getProperty("search.structure.depth.default", "1")));
         setStructuredDepthMax(Integer.parseInt(properties.getProperty("search.structure.depth.max", "4")));
@@ -256,6 +259,14 @@ public class SearchSettings extends AbstractSettings {
 
     public void setMaxBrowsePerPage(int maxBrowsePerPage) {
         this.maxBrowsePerPage = maxBrowsePerPage;
+    }
+
+    public int getMaxFacetsPerPage() {
+        return maxFacetsPerPage;
+    }
+
+    public void setMaxFacetsPerPage(int maxFacetsPerPage) {
+        this.maxFacetsPerPage = maxFacetsPerPage;
     }
 
     public Set<String> getSearchableFields() {

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractFacetListService.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.services;
+
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
+import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.api.requests.SearchState;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract service for retrieving lists of facet values
+ *
+ * @author bbpennel
+ */
+public class AbstractFacetListService extends AbstractQueryService {
+    protected static final List<String> DEFAULT_RESOURCE_TYPES = Arrays.asList(
+            ResourceType.AdminUnit.name(), ResourceType.Collection.name(),
+            ResourceType.Folder.name(), ResourceType.Work.name());
+
+    protected SolrSearchService searchService;
+
+    protected ContentObjectRecord addSelectedContainer(SearchRequest searchRequest) {
+        if (searchRequest.getRootPid() != null) {
+            var selectedContainer = searchService.addSelectedContainer(searchRequest.getRootPid(),
+                    searchRequest.getSearchState(), searchRequest.isApplyCutoffs(), searchRequest.getAccessGroups());
+            if (selectedContainer == null) {
+                throw new NotFoundException("Invalid container selected");
+            }
+            return selectedContainer;
+        }
+        return null;
+    }
+
+    /**
+     * Set the resource types counted in the facets to exclude File objects
+     * @param searchState
+     */
+    protected void assignResourceTypes(SearchState searchState) {
+        if (searchState.getResourceTypes() == null) {
+            searchState.setResourceTypes(DEFAULT_RESOURCE_TYPES);
+        } else {
+            searchState.setResourceTypes(searchState.getResourceTypes().stream()
+                    .filter(t -> !t.equals(ResourceType.File.name()))
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    public void setSearchService(SolrSearchService searchService) {
+        this.searchService = searchService;
+    }
+}

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetFieldFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetFieldFactory.java
@@ -88,9 +88,9 @@ public class FacetFieldFactory {
         }
         FacetFieldList facetFieldList = new FacetFieldList();
         for (FacetField facetField : facetFields) {
-            String fieldName = SearchFieldKey.getByName(facetField.getName()).name();
+            var fieldKey = SearchFieldKey.getByName(facetField.getName());
             if (facetField.getValueCount() > 0) {
-                facetFieldList.add(createFacetFieldObject(fieldName, facetField));
+                facetFieldList.add(createFacetFieldObject(fieldKey, facetField));
             }
         }
         return facetFieldList;
@@ -103,16 +103,16 @@ public class FacetFieldFactory {
      * @param facetField
      * @return
      */
-    public FacetFieldObject createFacetFieldObject(String fieldKey, FacetField facetField) {
+    public FacetFieldObject createFacetFieldObject(SearchFieldKey fieldKey, FacetField facetField) {
         List<SearchFacet> values = new ArrayList<SearchFacet>();
 
         // Generate list of facet values from Solr facet fields if they are provided.
         if (facetField != null) {
-            Class<?> facetClass = SearchSettings.getFacetClass(fieldKey);
+            Class<?> facetClass = SearchSettings.getFacetClass(fieldKey.name());
             try {
                 Constructor<?> constructor = facetClass.getConstructor(String.class, FacetField.Count.class);
                 for (FacetField.Count value : facetField.getValues()) {
-                    values.add((GenericFacet) constructor.newInstance(fieldKey, value));
+                    values.add((GenericFacet) constructor.newInstance(fieldKey.name(), value));
                 }
             } catch (Exception e) {
                 throw new InvalidFacetException(
@@ -121,7 +121,7 @@ public class FacetFieldFactory {
             }
         }
 
-        return new FacetFieldObject(fieldKey, values);
+        return new FacetFieldObject(fieldKey.name(), values);
     }
 
     /**
@@ -132,7 +132,7 @@ public class FacetFieldFactory {
     public void addMissingFacetFieldObjects(FacetFieldList facetFieldList, Collection<String> allFacetNames) {
         for (String facetName : allFacetNames) {
             if (!facetFieldList.contains(facetName)) {
-                facetFieldList.add(createFacetFieldObject(facetName, null));
+                facetFieldList.add(createFacetFieldObject(SearchFieldKey.valueOf(facetName), null));
             }
         }
     }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
@@ -18,8 +18,6 @@ package edu.unc.lib.boxc.search.solr.services;
 import edu.unc.lib.boxc.search.api.exceptions.SolrRuntimeException;
 import edu.unc.lib.boxc.search.api.facets.FacetFieldObject;
 import edu.unc.lib.boxc.search.api.requests.FacetValuesRequest;
-import edu.unc.lib.boxc.search.api.requests.SearchRequest;
-import edu.unc.lib.boxc.search.api.requests.SearchState;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.params.FacetParams;
@@ -73,7 +71,8 @@ public class FacetValuesService extends AbstractFacetListService {
 
         try {
             var resp = searchService.executeQuery(query);
-            return facetFieldFactory.createFacetFieldObject(facetSolrField, resp.getFacetField(facetSolrField));
+            return facetFieldFactory.createFacetFieldObject(request.getFacetFieldKey(),
+                    resp.getFacetField(facetSolrField));
         } catch (SolrServerException e) {
             throw new SolrRuntimeException(e);
         }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.services;
+
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.exceptions.SolrRuntimeException;
+import edu.unc.lib.boxc.search.api.facets.FacetFieldObject;
+import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.api.requests.SearchState;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.params.FacetParams;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.springframework.util.Assert.notNull;
+
+/**
+ * Service for navigating and returning values of facets
+ * @author bbpennel
+ */
+public class FacetValuesService {
+    private final static Set<String> SORT_VALUES = new HashSet<>(Arrays.asList(
+            FacetParams.FACET_SORT_COUNT, FacetParams.FACET_SORT_INDEX));
+
+    private SolrSearchService searchService;
+    private FacetFieldFactory facetFieldFactory;
+
+    /**
+     * List a page of values from the specified facet
+     * @param facetFieldKey facet to retrieve values for
+     * @param sort sort order for the results, defaults to count.
+     * @param start offset into the result set at which to start for paging
+     * @param rows number of values to return in the page
+     * @param searchRequest base request around which the facet values will be scoped
+     * @return FacetFieldObject contains the facet values
+     */
+    public FacetFieldObject listValues(SearchFieldKey facetFieldKey, String sort, Integer start, Integer rows,
+                                       SearchRequest searchRequest) {
+        notNull(facetFieldKey, "Must provide a facetFieldKey");
+        var facetSolrField = facetFieldKey.getSolrField();
+
+        // Produce base query from provided searchRequest and its state
+        var query = searchService.generateSearch(searchRequest);
+        query.setRows(0);
+        query.addFacetField(facetSolrField);
+        query.setFacetMinCount(1);
+        if (start != null && start >= 0) {
+            query.set(FacetParams.FACET_OFFSET, start.toString());
+        }
+        if (sort != null && SORT_VALUES.contains(sort)) {
+            query.setFacetSort(sort);
+        }
+        if (rows != null && rows > 0) {
+            query.setFacetLimit(rows);
+        }
+
+        try {
+            var resp = searchService.executeQuery(query);
+            return facetFieldFactory.createFacetFieldObject(facetSolrField, resp.getFacetField(facetSolrField));
+        } catch (SolrServerException e) {
+            throw new SolrRuntimeException(e);
+        }
+    }
+
+    /**
+     * Assert that the provided sort value is valid. Throws IllegalArgumentException if not.
+     * @param sort
+     */
+    public static void assertValidFacetSortValue(String sort) {
+        if (sort != null && !SORT_VALUES.contains(sort)) {
+            throw new IllegalArgumentException("Invalid facet sort type, values are: "
+                    + String.join(", ", SORT_VALUES));
+        }
+    }
+
+    public void setSearchService(SolrSearchService searchService) {
+        this.searchService = searchService;
+    }
+
+    public void setFacetFieldFactory(FacetFieldFactory facetFieldFactory) {
+        this.facetFieldFactory = facetFieldFactory;
+    }
+}

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
@@ -15,8 +15,6 @@
  */
 package edu.unc.lib.boxc.search.solr.services;
 
-import edu.unc.lib.boxc.model.api.ResourceType;
-import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.facets.FacetFieldList;
 import edu.unc.lib.boxc.search.api.facets.SearchFacet;

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/facets/CutoffFacetTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/facets/CutoffFacetTest.java
@@ -73,7 +73,7 @@ public class CutoffFacetTest extends Assert {
 
         FacetFieldFactory facetFieldFactory = new FacetFieldFactory();
 
-        FacetFieldObject ffo = facetFieldFactory.createFacetFieldObject("ANCESTOR_PATH", facetField);
+        FacetFieldObject ffo = facetFieldFactory.createFacetFieldObject(SearchFieldKey.ANCESTOR_PATH, facetField);
         assertTrue(ffo.getValues().get(0) instanceof CutoffFacet);
         assertEquals("1,uuid:a", ffo.getValues().get(0).getSearchValue());
         assertEquals("1,uuid:a", ffo.getValues().get(0).getValue());

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.services;
+
+import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
+import edu.unc.lib.boxc.search.solr.test.TestCorpus;
+import org.apache.solr.common.SolrInputDocument;
+
+import java.util.List;
+
+/**
+ * @author bbpennel
+ */
+public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
+
+    // single page of results
+    // multiple pages
+    // sort index
+    // sort count
+    // filtered by root id
+    // filtered by keyword
+    // returns no values
+    // invalid sort
+    // invalid start
+    // invalid number of rows
+
+    public class FacetValueTestCorpus extends TestCorpus {
+        @Override
+        public List<SolrInputDocument> populate() {
+            super.populate();
+        }
+    }
+}

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
@@ -15,32 +15,354 @@
  */
 package edu.unc.lib.boxc.search.solr.services;
 
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.services.GlobalPermissionEvaluator;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.search.api.ContentCategory;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.facets.FacetFieldObject;
+import edu.unc.lib.boxc.search.api.facets.SearchFacet;
+import edu.unc.lib.boxc.search.api.requests.FacetValuesRequest;
+import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.api.requests.SearchState;
+import edu.unc.lib.boxc.search.solr.facets.GenericFacet;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
+import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
+import edu.unc.lib.boxc.search.solr.utils.FacetFieldUtil;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * @author bbpennel
  */
 public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
+    private final static String SUBJECT_1 = "Oral History";
+    private final static String SUBJECT_2 = "North Carolina";
+    private final static String SUBJECT_3 = "Digital Repositories";
+    private final static String SUBJECT_4 = "Voting--North Carolina";
+    private final static String SUBJECT_5 = "Biography";
+    private final static String SUBJECT_6 = "University of North Carolina";
+    private final static String SUBJECT_7 = "Chapel Hill";
+    private final static String SUBJECT_8 = "Boxy";
 
-    // single page of results
-    // multiple pages
-    // sort index
-    // sort count
-    // filtered by root id
-    // filtered by keyword
-    // returns no values
-    // invalid sort
-    // invalid start
-    // invalid number of rows
+    @Mock
+    private GlobalPermissionEvaluator globalPermissionEvaluator;
+    private FacetFieldFactory facetFieldFactory;
+    private FacetFieldUtil facetFieldUtil;
+    private AccessRestrictionUtil accessRestrictionUtil;
+    private SolrSearchService searchService;
+
+    private FacetValuesService facetValuesService;
+
+    private FacetValueTestCorpus testCorpus;
+    private boolean corpusLoaded;
+    private AccessGroupSet accessGroups;
+
+    public FacetValuesServiceIT() {
+        testCorpus = new FacetValueTestCorpus();
+    }
+
+    @Before
+    public void setupFacets() throws Exception {
+        initMocks(this);
+
+        accessRestrictionUtil = new AccessRestrictionUtil();
+        accessRestrictionUtil.setSearchSettings(searchSettings);
+        accessRestrictionUtil.setGlobalPermissionEvaluator(globalPermissionEvaluator);
+
+        facetFieldFactory = new FacetFieldFactory();
+        facetFieldFactory.setSearchSettings(searchSettings);
+        facetFieldFactory.setSolrSettings(solrSettings);
+
+        facetFieldUtil = new FacetFieldUtil();
+        facetFieldUtil.setSearchSettings(searchSettings);
+        facetFieldUtil.setSolrSettings(solrSettings);
+
+        searchService = new SolrSearchService();
+        searchService.setSolrSettings(solrSettings);
+        searchService.setSearchSettings(searchSettings);
+        searchService.setFacetFieldUtil(facetFieldUtil);
+        searchService.setAccessRestrictionUtil(accessRestrictionUtil);
+        searchService.setFacetFieldFactory(facetFieldFactory);
+        searchService.setSolrClient(server);
+
+        facetValuesService = new FacetValuesService();
+        facetValuesService.setSearchService(searchService);
+        facetValuesService.setFacetFieldFactory(facetFieldFactory);
+
+        accessGroups = new AccessGroupSetImpl("unitOwner", PUBLIC_PRINC);
+
+        if (!corpusLoaded) {
+            corpusLoaded = true;
+            index(testCorpus.populate());
+        }
+    }
+
+    @Test
+    public void singlePageOfResultsTest() throws Exception {
+        var request = buildFacetRequest();
+
+        var result = facetValuesService.listValues(request);
+        assertUnfilteredCountSort(result);
+    }
+
+    private void assertUnfilteredCountSort(FacetFieldObject result) throws Exception {
+        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(8, result.getValues().size());
+
+        assertValuePresent(result, 0, SUBJECT_5, 4);
+        assertValuePresent(result, 1, SUBJECT_1, 3);
+        assertValuePresent(result, 2, SUBJECT_7, 2);
+        assertValuePresent(result, 3, SUBJECT_2, 2);
+        assertValuePresent(result, 4, SUBJECT_8, 1);
+        assertValuePresent(result, 5, SUBJECT_3, 1);
+        assertValuePresent(result, 6, SUBJECT_6, 1);
+        assertValuePresent(result, 7, SUBJECT_4, 1);
+    }
+
+    @Test
+    public void pagedResultsTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setRows(3);
+
+        var result = facetValuesService.listValues(request);
+        assertEquals(3, result.getValues().size());
+        assertValuePresent(result, 0, SUBJECT_5, 4);
+        assertValuePresent(result, 1, SUBJECT_1, 3);
+        assertValuePresent(result, 2, SUBJECT_7, 2);
+
+        request.setStart(3);
+        var result2 = facetValuesService.listValues(request);
+        assertEquals(3, result2.getValues().size());
+        assertValuePresent(result2, 0, SUBJECT_2, 2);
+        assertValuePresent(result2, 1, SUBJECT_8, 1);
+        assertValuePresent(result2, 2, SUBJECT_3, 1);
+
+        request.setStart(6);
+        var result3 = facetValuesService.listValues(request);
+        assertEquals(2, result3.getValues().size());
+        assertValuePresent(result3, 0, SUBJECT_6, 1);
+        assertValuePresent(result3, 1, SUBJECT_4, 1);
+
+        request.setStart(9);
+        var result4 = facetValuesService.listValues(request);
+        assertTrue(result4.getValues().isEmpty());
+    }
+
+    @Test
+    public void singlePageSortByIndexTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setSort("index");
+
+        var result = facetValuesService.listValues(request);
+        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(8, result.getValues().size());
+
+        assertValuePresent(result, 0, SUBJECT_5, 4);
+        assertValuePresent(result, 1, SUBJECT_8, 1);
+        assertValuePresent(result, 2, SUBJECT_7, 2);
+        assertValuePresent(result, 3, SUBJECT_3, 1);
+        assertValuePresent(result, 4, SUBJECT_2, 2);
+        assertValuePresent(result, 5, SUBJECT_1, 3);
+        assertValuePresent(result, 6, SUBJECT_6, 1);
+        assertValuePresent(result, 7, SUBJECT_4, 1);
+    }
+
+    @Test
+    public void filterByRootIdTest() throws Exception {
+        var request = buildFacetRequest();
+        request.getBaseSearchRequest().setRootPid(testCorpus.coll1Pid);
+
+        var result = facetValuesService.listValues(request);
+        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(5, result.getValues().size());
+
+        assertValuePresent(result, 0, SUBJECT_2, 2);
+        assertValuePresent(result, 1, SUBJECT_1, 2);
+        assertValuePresent(result, 2, SUBJECT_5, 1);
+        assertValuePresent(result, 3, SUBJECT_3, 1);
+        assertValuePresent(result, 4, SUBJECT_4, 1);
+    }
+
+    @Test
+    public void searchForTermTest() throws Exception {
+        var request = buildFacetRequest();
+        request.getBaseSearchRequest().getSearchState().setSearchFields(
+                Map.of(SearchFieldKey.DEFAULT_INDEX.name(), "north"));
+
+        var result = facetValuesService.listValues(request);
+        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(3, result.getValues().size());
+
+        assertValuePresent(result, 0, SUBJECT_2, 2);
+        assertValuePresent(result, 1, SUBJECT_6, 1);
+        assertValuePresent(result, 2, SUBJECT_4, 1);
+    }
+
+    @Test
+    public void facetBeingRetrievedIsSelectedTest() throws Exception {
+        var request = buildFacetRequest();
+        request.getBaseSearchRequest().getSearchState().setFacet(new GenericFacet(SearchFieldKey.SUBJECT, SUBJECT_1));
+
+        var result = facetValuesService.listValues(request);
+        assertUnfilteredCountSort(result);
+    }
+
+    @Test
+    public void sortByCountTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setSort("count");
+
+        var result = facetValuesService.listValues(request);
+        assertUnfilteredCountSort(result);
+    }
+
+    @Test
+    public void invalidSortTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setSort("boxy");
+
+        var result = facetValuesService.listValues(request);
+        // Reverts to default sort
+        assertUnfilteredCountSort(result);
+    }
+
+    @Test
+    public void invalidStartTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setStart(-1);
+
+        var result = facetValuesService.listValues(request);
+        // Reverts to 0 start
+        assertUnfilteredCountSort(result);
+    }
+
+    @Test
+    public void invalidRowsTest() throws Exception {
+        var request = buildFacetRequest();
+        request.setRows(0);
+
+        var result = facetValuesService.listValues(request);
+        // Reverts to default rows
+        assertUnfilteredCountSort(result);
+    }
+
+    @Test
+    public void withoutAccessToPrivateFoldersTest() throws Exception {
+        var request = buildFacetRequest();
+        request.getBaseSearchRequest().setAccessGroups(new AccessGroupSetImpl(PUBLIC_PRINC));
+
+        var result = facetValuesService.listValues(request);
+        assertEquals(7, result.getValues().size());
+
+        assertValuePresent(result, 0, SUBJECT_5, 4);
+        assertValuePresent(result, 1, SUBJECT_1, 3);
+        assertValuePresent(result, 2, SUBJECT_2, 2);
+        assertValuePresent(result, 3, SUBJECT_7, 1);
+        assertValuePresent(result, 4, SUBJECT_3, 1);
+        assertValuePresent(result, 5, SUBJECT_6, 1);
+        assertValuePresent(result, 6, SUBJECT_4, 1);
+    }
+
+    private FacetValuesRequest buildFacetRequest() {
+        var request = new FacetValuesRequest(SearchFieldKey.SUBJECT);
+        var baseRequest = new SearchRequest();
+        baseRequest.setSearchState(new SearchState());
+        baseRequest.setAccessGroups(accessGroups);
+        request.setBaseSearchRequest(baseRequest);
+        return request;
+    }
+
+    private void assertValuePresent(FacetFieldObject result, int index, String expectedValue, int expectedCount) {
+        var values = result.getValues();
+        if (index >= values.size()) {
+            var vals = values.stream().map(SearchFacet::getSearchValue).collect(Collectors.joining(", "));
+            fail("Index " + index + " out of bounds, expecting " + expectedValue + " but values were " + vals);
+        }
+        var value = values.get(index);
+        assertEquals(expectedValue, value.getSearchValue());
+        assertEquals(expectedCount, value.getCount());
+    }
 
     public class FacetValueTestCorpus extends TestCorpus {
         @Override
         public List<SolrInputDocument> populate() {
-            super.populate();
+            var docs = super.populate();
+
+            // Add a bunch of extra works, distributed across multiple subjects and two collections
+            addWorkWithFile(docs, SUBJECT_1, true, rootPid, unitPid, coll1Pid);
+            addWorkWithFile(docs, SUBJECT_2, true, rootPid, unitPid, coll1Pid);
+            addWorkWithFile(docs, SUBJECT_2, true, rootPid, unitPid, coll1Pid);
+            addWorkWithFile(docs, SUBJECT_3, true, rootPid, unitPid, coll1Pid);
+            addWorkWithFile(docs, SUBJECT_4, true, rootPid, unitPid, coll1Pid, folder1Pid);
+            addWorkWithFile(docs, SUBJECT_5, true, rootPid, unitPid, coll1Pid);
+            addWorkWithFile(docs, SUBJECT_1, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_5, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_5, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_5, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_6, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_7, true, rootPid, unitPid, coll2Pid);
+            addWorkWithFile(docs, SUBJECT_7, false, rootPid, unitPid, coll2Pid, privateFolderPid);
+            addWorkWithFile(docs, SUBJECT_8, false, rootPid, unitPid, coll2Pid, privateFolderPid);
+
+            // Add a work that contains a file with a subject
+            var docsFileWithSubj = addWorkWithFile(docs, SUBJECT_1, true, rootPid, unitPid, coll1Pid);
+            addSubject(docsFileWithSubj[1], SUBJECT_3);
+
+            return docs;
+        }
+
+        private SolrInputDocument[] addWorkWithFile(List<SolrInputDocument> docs, String subject, boolean publicAccess,
+                                                    PID... ancestors) {
+            var workPid = PIDs.get(UUID.randomUUID().toString());
+            var timestamp = System.nanoTime();
+            var workDoc = makeContainerDocument(workPid, "Work " + timestamp, ResourceType.Work,
+                    ancestors);
+            if (publicAccess) {
+                addAclProperties(workDoc, PUBLIC_PRINC, "unitOwner", "manager");
+            } else {
+                addAclProperties(workDoc, null, "unitOwner", "manager");
+            }
+            addFileProperties(workDoc, ContentCategory.text, "text/plain", "Plain Text");
+            addSubject(workDoc, subject);
+            docs.add(workDoc);
+
+            var fileAncestors = ArrayUtils.add(ancestors, workPid);
+            var filePid = PIDs.get(UUID.randomUUID().toString());
+            var fileDoc = makeFileDocument(filePid, "File " + timestamp, fileAncestors);
+            addFileProperties(fileDoc, ContentCategory.text, "text/plain", "Plain Text");
+            if (publicAccess) {
+                addAclProperties(fileDoc, PUBLIC_PRINC, "unitOwner", "manager");
+            } else {
+                addAclProperties(fileDoc, null, "unitOwner", "manager");
+            }
+            docs.add(fileDoc);
+
+            return new SolrInputDocument[] { workDoc, fileDoc };
+        }
+
+        private void addSubject(SolrInputDocument doc, String subject) {
+            if (subject != null) {
+                doc.setField(SearchFieldKey.SUBJECT.getSolrField(), subject);
+            }
         }
     }
 }

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
@@ -125,7 +125,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
     }
 
     private void assertUnfilteredCountSort(FacetFieldObject result) throws Exception {
-        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(SearchFieldKey.SUBJECT.name(), result.getName());
         assertEquals(8, result.getValues().size());
 
         assertValuePresent(result, 0, SUBJECT_5, 4);
@@ -173,7 +173,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
         request.setSort("index");
 
         var result = facetValuesService.listValues(request);
-        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(SearchFieldKey.SUBJECT.name(), result.getName());
         assertEquals(8, result.getValues().size());
 
         assertValuePresent(result, 0, SUBJECT_5, 4);
@@ -192,7 +192,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
         request.getBaseSearchRequest().setRootPid(testCorpus.coll1Pid);
 
         var result = facetValuesService.listValues(request);
-        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(SearchFieldKey.SUBJECT.name(), result.getName());
         assertEquals(5, result.getValues().size());
 
         assertValuePresent(result, 0, SUBJECT_2, 2);
@@ -209,7 +209,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
                 Map.of(SearchFieldKey.DEFAULT_INDEX.name(), "north"));
 
         var result = facetValuesService.listValues(request);
-        assertEquals(SearchFieldKey.SUBJECT.getSolrField(), result.getName());
+        assertEquals(SearchFieldKey.SUBJECT.name(), result.getName());
         assertEquals(3, result.getValues().size());
 
         assertValuePresent(result, 0, SUBJECT_2, 2);

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/TestCorpus.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/TestCorpus.java
@@ -260,11 +260,11 @@ public class TestCorpus {
         }
         if (readGroup != null) {
             roleGroups.add(UserRole.canViewOriginals.name() + "|" + readGroup);
-            doc.addField("readGroup", asList(readGroup));
+            doc.setField("readGroup", asList(readGroup));
         }
 
-        doc.addField("roleGroup", roleGroups);
-        doc.addField("adminGroup", adminList);
+        doc.setField("roleGroup", roleGroups);
+        doc.setField("adminGroup", adminList);
     }
 
     public String makeAncestorIds(PID self, PID... pids) {

--- a/web-services-app/pom.xml
+++ b/web-services-app/pom.xml
@@ -121,6 +121,12 @@
         </dependency>
         <dependency>
             <groupId>edu.unc.lib.cdr</groupId>
+            <artifactId>search-solr</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>edu.unc.lib.cdr</groupId>
             <artifactId>web-common</artifactId>
         </dependency>
         <dependency>

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/FacetRestController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/FacetRestController.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.rest;
+
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.solr.config.SearchSettings;
+import edu.unc.lib.boxc.search.solr.services.FacetValuesService;
+import edu.unc.lib.boxc.web.common.controllers.AbstractSolrSearchController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+/**
+ * Controller for retrieving information from facets
+ *
+ * @author bbpennel
+ */
+@Controller
+public class FacetRestController extends AbstractSolrSearchController {
+    @Autowired
+    private FacetValuesService facetValuesService;
+    @Autowired
+    private SearchSettings searchSettings;
+
+    @RequestMapping(value = "/facet/{facetId}/listValues", produces = APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    ResponseEntity<Object> listValues(@PathVariable("facetId") String facetId,
+                                      @RequestParam("facetSort") String sort,
+                                      @RequestParam("facetStart") Integer start,
+                                      @RequestParam("facetRows") Integer rows,
+                                      HttpServletRequest request) {
+        return listValues(facetId, null, sort, start, rows, request);
+    }
+
+    /**
+     * List values within a particular facet field in paginated form, scoped based on any included search state.
+     * @param facetId
+     * @param sort Sort order to use for the facet values, either by count or index (alphabetic)
+     * @param start starting offset for the page of results
+     * @param rows number of values to return in the page
+     * @param request http request
+     * @return json response containing the facet field and its value
+     */
+    @RequestMapping(value = "/facet/{facetId}/listValues/{rootId}", produces = APPLICATION_JSON_VALUE)
+    public @ResponseBody
+    ResponseEntity<Object> listValues(@PathVariable("facetId") String facetId,
+                                      @PathVariable("rootId") String rootId,
+                                      @RequestParam("facetSort") String sort,
+                                      @RequestParam("facetStart") Integer start,
+                                      @RequestParam("facetRows") Integer rows,
+                                      HttpServletRequest request) {
+
+        var facetKey = SearchFieldKey.getByUrlParam(facetId);
+        if (facetKey == null) {
+            throw new IllegalArgumentException("Unknown facet field specified");
+        }
+        if (!searchSettings.getFacetNames().contains(facetId)) {
+            throw new IllegalArgumentException("Invalid facet field specified: " + facetId);
+        }
+        FacetValuesService.assertValidFacetSortValue(sort);
+
+        SearchRequest searchRequest = generateSearchRequest(request);
+        if (rootId != null) {
+            searchRequest.setRootPid(PIDs.get(rootId));
+        }
+
+        var facetResp = facetValuesService.listValues(facetKey, sort, start, rows, searchRequest);
+
+        return new ResponseEntity<>(facetResp, HttpStatus.OK);
+    }
+}

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -415,6 +415,15 @@
         <property name="aclService" ref="aclService"/>
         <property name="queryLayer" ref="queryLayer"/>
     </bean>
+
+    <bean id="facetValuesService" class="edu.unc.lib.boxc.search.solr.services.FacetValuesService"
+          init-method="initializeSolrServer">
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="searchService" ref="queryLayer" />
+        <property name="facetFieldFactory" ref="facetFieldFactory" />
+        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
+        <property name="solrSettings" ref="solrSettings" />
+    </bean>
     
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="edu.unc.lib.boxc.web.common.utils.SerializationUtil.injectSettings"/>

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/FacetRestControllerIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/FacetRestControllerIT.java
@@ -49,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
-public class FacetRestControllerTest extends AbstractAPIIT {
+public class FacetRestControllerIT extends AbstractAPIIT {
     // non-facet field selected
     // invalid field
     // with root id
@@ -161,10 +161,19 @@ public class FacetRestControllerTest extends AbstractAPIIT {
         assertValuePresent(values, 1, "image/png", 1);
     }
 
+    @Test
+    public void exceedMaxRowsTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues?facetRows=100000"))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        assertTrue("Incorrect response: " + result.getResponse().getContentAsString(),
+                result.getResponse().getContentAsString().contains("Invalid facetRows value, max value is:"));
+    }
+
     private List<JsonNode> extractResponseFacetValues(MvcResult result) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         var respJson = mapper.readTree(result.getResponse().getContentAsString());
-        assertEquals(SearchFieldKey.FILE_FORMAT_TYPE.name(), respJson.get("name").asText());
+        assertEquals(SearchFieldKey.FILE_FORMAT_TYPE.name(), respJson.get("facetName").asText());
         return IteratorUtils.toList(respJson.get("values").elements());
     }
 

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/FacetRestControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/FacetRestControllerTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.rest;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import edu.unc.lib.boxc.search.solr.test.TestCorpus;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author bbpennel
+ */
+@ContextHierarchy({
+        @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+        @ContextConfiguration("/spring-test/solr-indexing-context.xml"),
+        @ContextConfiguration("/facet-rest-it-servlet.xml")
+})
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+public class FacetRestControllerTest extends AbstractAPIIT {
+    // non-facet field selected
+    // invalid field
+    // with root id
+    // without root id
+    // with navigation params
+
+    @Autowired
+    private EmbeddedSolrServer embeddedSolrServer;
+    private TestCorpus testCorpus;
+    private static boolean corpusPopulated;
+
+    @Before
+    public void setup() throws Exception {
+        if (!corpusPopulated) {
+            testCorpus = new TestCorpus();
+            embeddedSolrServer.add(testCorpus.populate());
+            embeddedSolrServer.commit();
+            corpusPopulated = true;
+        }
+    }
+
+    @Test
+    public void invalidFieldTest() throws Exception {
+        var result = mvc.perform(get("/facet/notafield/listValues"))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        assertEquals("Unknown facet field specified", result.getResponse().getContentAsString());
+    }
+
+    @Test
+    public void nonFacetFieldTest() throws Exception {
+        var result = mvc.perform(get("/facet/title/listValues"))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        assertEquals("Invalid facet field specified: title", result.getResponse().getContentAsString());
+    }
+
+    @Test
+    public void noParamsTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var values = extractResponseFacetValues(result);
+        assertEquals(4, values.size());
+
+        assertValuePresent(values, 0, "text/plain", 2);
+        assertValuePresent(values, 1, "application/pdf", 1);
+        assertValuePresent(values, 2, "image/jpeg", 1);
+        assertValuePresent(values, 3, "image/png", 1);
+    }
+
+    @Test
+    public void withRootIdTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues/" + testCorpus.coll1Pid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var values = extractResponseFacetValues(result);
+        assertEquals(3, values.size());
+
+        assertValuePresent(values, 0, "application/pdf", 1);
+        assertValuePresent(values, 1, "image/jpeg", 1);
+        assertValuePresent(values, 2, "text/plain", 1);
+    }
+
+    @Test
+    public void withSortTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues?facetSort=index"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var values = extractResponseFacetValues(result);
+        assertEquals(4, values.size());
+
+        assertValuePresent(values, 0, "application/pdf", 1);
+        assertValuePresent(values, 1, "image/jpeg", 1);
+        assertValuePresent(values, 2, "image/png", 1);
+        assertValuePresent(values, 3, "text/plain", 2);
+    }
+
+    @Test
+    public void withInvalidSortTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues?facetSort=what"))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        assertTrue("Incorrect response: " + result.getResponse().getContentAsString(),
+                result.getResponse().getContentAsString().contains("Invalid facet sort type"));
+    }
+
+    @Test
+    public void withPaginationTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues?facetStart=1&facetRows=2"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var values = extractResponseFacetValues(result);
+        assertEquals(2, values.size());
+
+        assertValuePresent(values, 0, "application/pdf", 1);
+        assertValuePresent(values, 1, "image/jpeg", 1);
+    }
+
+    @Test
+    public void withSearchParamsTest() throws Exception {
+        var result = mvc.perform(get("/facet/fileType/listValues?format=Image"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var values = extractResponseFacetValues(result);
+        assertEquals(2, values.size());
+
+        assertValuePresent(values, 0, "image/jpeg", 1);
+        assertValuePresent(values, 1, "image/png", 1);
+    }
+
+    private List<JsonNode> extractResponseFacetValues(MvcResult result) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        var respJson = mapper.readTree(result.getResponse().getContentAsString());
+        assertEquals(SearchFieldKey.FILE_FORMAT_TYPE.name(), respJson.get("name").asText());
+        return IteratorUtils.toList(respJson.get("values").elements());
+    }
+
+    private void assertValuePresent(List<JsonNode> values, int index, String type, int count) {
+        var result = values.get(index);
+        assertEquals(type, result.get("value").asText());
+        assertEquals(count, result.get("count").asInt());
+    }
+}

--- a/web-services-app/src/test/resources/facet-rest-it-servlet.xml
+++ b/web-services-app/src/test/resources/facet-rest-it-servlet.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan resource-pattern="**/FacetRestController*" base-package="edu.unc.lib.boxc.web.services.rest"/>
+
+    <bean id="facetValuesService" class="edu.unc.lib.boxc.search.solr.services.FacetValuesService">
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="searchService" ref="solrSearchService" />
+        <property name="facetFieldFactory" ref="facetFieldFactory" />
+        <property name="solrClient" ref="solrClient" />
+        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
+        <property name="solrSettings" ref="solrSettings" />
+    </bean>
+</beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3624

* Adds API endpoint for retrieving values for a facet
    * includes navigation options, facetStart, facetRows, facetSort
    * Can but used along with all regular search parameters
    * example: https://dcr-test.lib.unc.edu/services/api/facet/subject/listValues?facetSort=count
* search-solr available as a test jar so that its TestCorpus can be used elsewhere
* Requiring SearchFieldKey as param to FacetFieldFactory to avoid passing in the wrong representation of the field name
* Added method to get SearchFieldKeys by url param