### PR TITLE
BXC-3695 - Fix NullPointerException when reindexing Work content type

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilter.java
@@ -25,6 +25,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
 import edu.unc.lib.boxc.search.api.ContentCategory;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.facets.CutoffFacet;
@@ -70,6 +71,7 @@ public class SetContentTypeFilter implements IndexDocumentFilter {
             SearchFieldKey.FILE_FORMAT_CATEGORY.name(), SearchFieldKey.FILE_FORMAT_TYPE.name());
     private SolrSearchService solrSearchService;
     private TechnicalMetadataService technicalMetadataService;
+    private ContentPathFactory contentPathFactory;
 
     public SetContentTypeFilter() throws IOException {
         contentTypeProperties = new Properties();
@@ -153,7 +155,8 @@ public class SetContentTypeFilter implements IndexDocumentFilter {
         if (doc.getAncestorPath() != null && !doc.getAncestorPath().isEmpty()) {
             ancestorPath = new CutoffFacetImpl(SearchFieldKey.ANCESTOR_PATH.name(), doc.getAncestorPath(), -1);
         } else {
-            ancestorPath = (CutoffFacetImpl) solrSearchService.getAncestorPath(doc.getId(), null);
+            var ancestorPids = contentPathFactory.getAncestorPids(doc.getPid());
+            ancestorPath = new CutoffFacetImpl(SearchFieldKey.ANCESTOR_PATH.name(), ancestorPids);
         }
         ancestorPath.addNode(doc.getId());
         return ancestorPath;
@@ -248,6 +251,10 @@ public class SetContentTypeFilter implements IndexDocumentFilter {
 
     public void setSolrSearchService(SolrSearchService solrSearchService) {
         this.solrSearchService = solrSearchService;
+    }
+
+    public void setContentPathFactory(ContentPathFactory contentPathFactory) {
+        this.contentPathFactory = contentPathFactory;
     }
 
     public void setTechnicalMetadataService(TechnicalMetadataService technicalMetadataService) {

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -25,6 +25,7 @@ import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.FolderObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.ContentCategory;
@@ -87,6 +88,8 @@ public class SetContentTypeFilterTest {
     @Mock
     private SolrSearchService solrSearchService;
     @Mock
+    private ContentPathFactory contentPathFactory;
+    @Mock
     private DocumentIndexingPackageDataLoader documentIndexingPackageDataLoader;
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
@@ -120,6 +123,7 @@ public class SetContentTypeFilterTest {
         filter = new SetContentTypeFilter();
         filter.setSolrSearchService(solrSearchService);
         filter.setTechnicalMetadataService(technicalMetadataService);
+        filter.setContentPathFactory(contentPathFactory);
     }
 
     @Test

--- a/integration/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/integration/src/test/resources/spring-test/solr-indexing-context.xml
@@ -171,6 +171,7 @@
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
         <property name="solrSearchService" ref="solrSearchService" />
         <property name="technicalMetadataService" ref="technicalMetadataService" />
+        <property name="contentPathFactory" ref="contentPathFactory" />
     </bean>
 
     <bean id="setDatastreamFilter"

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/facets/CutoffFacetImpl.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/facets/CutoffFacetImpl.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import edu.unc.lib.boxc.model.api.ids.PID;
 import org.apache.solr.client.solrj.response.FacetField;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +72,20 @@ public class CutoffFacetImpl extends AbstractHierarchicalFacet implements Cutoff
         CutoffFacetNodeImpl node = new CutoffFacetNodeImpl(this.value);
         this.facetNodes.add(node);
 
+    }
+
+    /**
+     * Instantiate a CutoffFacet from an ordered list of ancestor PIDs
+     * @param fieldName
+     * @param tierPids
+     */
+    public CutoffFacetImpl(String fieldName, List<PID> tierPids) {
+        super(fieldName, (String) null);
+        for (int i = 0; i < tierPids.size(); i++) {
+            var facetString = (i + 1) + "," + tierPids.get(i).getId();
+            CutoffFacetNodeImpl node = new CutoffFacetNodeImpl(facetString);
+            this.facetNodes.add(node);
+        }
     }
 
     public CutoffFacetImpl(String fieldName, List<String> facetStrings, long count) {

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -224,6 +224,7 @@
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
         <property name="solrSearchService" ref="queryLayer" />
         <property name="technicalMetadataService" ref="technicalMetadataService" />
+        <property name="contentPathFactory" ref="contentPathFactory" />
     </bean>
     
     <bean id="setDatastreamFilter"

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -472,6 +472,7 @@
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
+        <property name="forceCommit" value="true" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">

--- a/services-camel-app/src/test/resources/cdr-event-routing-it-context.xml
+++ b/services-camel-app/src/test/resources/cdr-event-routing-it-context.xml
@@ -88,6 +88,7 @@
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
+        <property name="forceCommit" value="true" />
     </bean>
 
     <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>

--- a/services-camel-app/src/test/resources/solr-update-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-context.xml
@@ -41,6 +41,7 @@
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="mockIndexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
+        <property name="forceCommit" value="true" />
     </bean>
 
     <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -207,6 +207,7 @@
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
+        <property name="forceCommit" value="true" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">

--- a/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -200,6 +200,7 @@
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
         <property name="solrSearchService" ref="solrSearchService" />
         <property name="technicalMetadataService" ref="technicalMetadataService" />
+        <property name="contentPathFactory" ref="contentPathFactory" />
     </bean>
 
     <bean id="setDatastreamFilter"

--- a/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -219,6 +219,7 @@
     <bean id="setContentTypeFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetContentTypeFilter">
         <property name="solrSearchService" ref="solrSearchService" />
         <property name="technicalMetadataService" ref="technicalMetadataService" />
+        <property name="contentPathFactory" ref="contentPathFactory" />
     </bean>
 
     <bean id="setDatastreamFilter"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3695

* Force commits of solr changes before starting batches of reindexes of Work objects triggered by indexing of File objects. 
* Use ContentPathService to get ancestor path information when looking up which Files are in a Work, so that it is using the same mechanism/caching as other indexing jobs