### PR TITLE
BXC-3676 - Fix error when indexing work with tombstone primary object

### DIFF
--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/exceptions/TombstoneFoundException.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/exceptions/TombstoneFoundException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.model.api.exceptions;
+
+/**
+ * Exception indicating that the requested resource has been destroyed and replaced by a tombstone object
+ *
+ * @author bbpennel
+ */
+public class TombstoneFoundException extends RepositoryException {
+    private static final long serialVersionUID = 1L;
+
+    public TombstoneFoundException(String message) {
+        super(message);
+    }
+}

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
@@ -71,14 +71,13 @@ public interface WorkObject extends ContentContainerObject {
      * original file, using the provided pid as the identifier for the new
      * FileObject.
      *
-     *
-     * @param contentStream
-     *            Inputstream containing the binary content for the data file. Required.
+     * @param filePid
+     * @param storageUri
      * @param filename
      * @param mimetype
      * @param sha1Checksum
+     * @param md5Checksum
      * @param model
-     *            model containing properties for the new fileObject
      * @return
      */
     FileObject addDataFile(PID filePid, URI storageUri, String filename, String mimetype, String sha1Checksum,

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
@@ -17,6 +17,8 @@ package edu.unc.lib.boxc.model.fcrepo.objects;
 
 import java.net.URI;
 
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.exceptions.TombstoneFoundException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -39,6 +41,8 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A repository object which represents a single work, and should contain one or
@@ -51,6 +55,7 @@ import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectDriver;
  *
  */
 public class WorkObjectImpl extends AbstractContentContainerObject implements WorkObject {
+    private static final Logger log = LoggerFactory.getLogger(WorkObjectImpl.class);
 
     protected WorkObjectImpl(PID pid, RepositoryObjectDriver driver, RepositoryObjectFactory repoObjFactory) {
         super(pid, driver, repoObjFactory);
@@ -116,7 +121,12 @@ public class WorkObjectImpl extends AbstractContentContainerObject implements Wo
         }
 
         PID primaryPid = PIDs.get(primaryStmt.getResource().getURI());
-        return driver.getRepositoryObject(primaryPid, FileObject.class);
+        try {
+            return driver.getRepositoryObject(primaryPid, FileObject.class);
+        } catch (TombstoneFoundException e) {
+            log.debug("Cannot retrieve primary object for {}", getPid().getId(), e);
+        }
+        return null;
     }
 
     @Override

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectDriver.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectDriver.java
@@ -23,7 +23,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import edu.unc.lib.boxc.model.api.exceptions.TombstoneFoundException;
 import edu.unc.lib.boxc.model.api.objects.Tombstone;
 import org.apache.http.HttpStatus;

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectDriver.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectDriver.java
@@ -23,6 +23,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.exceptions.TombstoneFoundException;
+import edu.unc.lib.boxc.model.api.objects.Tombstone;
 import org.apache.http.HttpStatus;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QuerySolution;
@@ -162,6 +165,9 @@ public class RepositoryObjectDriver {
     public <T extends RepositoryObject> T getRepositoryObject(PID pid, Class<T> type)
             throws ObjectTypeMismatchException {
         RepositoryObject repoObj = repositoryObjectLoader.getRepositoryObject(pid);
+        if (repoObj instanceof Tombstone) {
+            throw new TombstoneFoundException("Tombstone found, requested object " + pid + " no longer exists");
+        }
         if (!type.isInstance(repoObj)) {
             throw new ObjectTypeMismatchException("Requested object " + pid + " is not a " + type.getName());
         }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/AbstractDestroyObjectsJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/AbstractDestroyObjectsJob.java
@@ -127,7 +127,7 @@ public abstract class AbstractDestroyObjectsJob implements Runnable {
         }
         cleanupBinaryUris.forEach(contentUri -> {
             try {
-                log.error("Deleting destroyed binary {}", contentUri);
+                log.debug("Deleting destroyed binary {}", contentUri);
                 StorageLocation storageLoc = locManager.getStorageLocationForUri(contentUri);
                 transferSession.forDestination(storageLoc)
                         .delete(contentUri);

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/AbstractDestroyObjectsJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/AbstractDestroyObjectsJob.java
@@ -127,7 +127,7 @@ public abstract class AbstractDestroyObjectsJob implements Runnable {
         }
         cleanupBinaryUris.forEach(contentUri -> {
             try {
-                log.debug("Deleting destroyed binary {}", contentUri);
+                log.error("Deleting destroyed binary {}", contentUri);
                 StorageLocation storageLoc = locManager.getStorageLocationForUri(contentUri);
                 transferSession.forDestination(storageLoc)
                         .delete(contentUri);

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsJob.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.NodeIterator;
@@ -95,6 +96,14 @@ public class DestroyObjectsJob extends AbstractDestroyObjectsJob {
 
                 if (!repoObj.getResource(true).hasProperty(RDF.type, Cdr.Tombstone)) {
                     RepositoryObject parentObj = repoObj.getParent();
+                    // If the object being deleted is the primary object of a work, then clear the relation
+                    if (parentObj instanceof WorkObject && repoObj instanceof FileObject) {
+                        var parentWork = (WorkObject) parentObj;
+                        var primaryObj = parentWork.getPrimaryObject();
+                        if (primaryObj != null && primaryObj.getPid().equals(repoObj.getPid())) {
+                            parentWork.clearPrimaryObject();
+                        }
+                    }
 
                     // purge tree with repoObj as root from repository
                     // Add the root of the tree to delete

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/AbstractSolrProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/AbstractSolrProcessorIT.java
@@ -25,8 +25,13 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Paths;
+import java.util.UUID;
 
 import edu.unc.lib.boxc.indexing.solr.test.RepositoryObjectSolrIndexer;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.boxc.persist.impl.storage.StorageLocationTestHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.test.spring.CamelSpringRunner;
@@ -104,6 +109,8 @@ public abstract class AbstractSolrProcessorIT {
     protected RepositoryObjectTreeIndexer treeIndexer;
     @Autowired
     protected RepositoryObjectSolrIndexer repositoryObjectSolrIndexer;
+    @Autowired
+    protected StorageLocationManager locManager;
 
     protected ContentRootObject rootObj;
     protected AdminUnit unitObj;
@@ -143,10 +150,12 @@ public abstract class AbstractSolrProcessorIT {
     }
 
     protected URI makeContentUri(String content) throws Exception {
-        File contentFile = File.createTempFile("test", ".txt");
+        var loc1 = locManager.getStorageLocationById(StorageLocationTestHelper.LOC1_ID);
+        var storageUri = loc1.getNewStorageUri(PIDs.get(UUID.randomUUID().toString()));
+        var contentFile = new File(storageUri);
         contentFile.deleteOnExit();
         FileUtils.write(contentFile, content, UTF_8);
-        return contentFile.toPath().toUri();
+        return storageUri;
     }
 
     protected InputStream streamResource(String resourcePath) throws Exception {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3676

* Catch case when primary object is a tombstone, return null instead
    * Throwing a specialized error when unexpectedly retrieving a tombstone to support this
* Clear primary object relation on work if the object it references gets destroyed (aka, turned into a tombstone)