### PR TITLE
BXC-3704/3706 - Stopwords in searches and collection facet

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -451,13 +451,11 @@ public class SolrSearchService extends AbstractQueryService {
         if (searchFields == null || searchFields.isEmpty()) {
             return;
         }
-        var searchOp = searchState.getSearchTermOperator();
-        var terms = new ArrayList<String>();
         Iterator<String> searchTypeIt = searchFields.keySet().iterator();
         while (searchTypeIt.hasNext()) {
             String searchType = searchTypeIt.next();
             String fieldValue = searchState.getSearchFields().get(searchType);
-            String searchValue = computeSearchValue(searchType, fieldValue, searchOp);
+            String searchValue = computeSearchValue(searchType, fieldValue);
             if (StringUtils.isBlank(searchValue)) {
                 continue;
             }
@@ -471,10 +469,10 @@ public class SolrSearchService extends AbstractQueryService {
             }
             solrQuery.addFilterQuery(field.getSolrField() + ":" + searchValue);
         }
-        solrQuery.set("q.op", "AND");
+        solrQuery.set("q.op", searchState.getSearchTermOperator());
     }
 
-    private String computeSearchValue(String searchType, String fieldValue, String searchTermOp) {
+    private String computeSearchValue(String searchType, String fieldValue) {
         if ("*".equals(fieldValue)) {
             return fieldValue;
         }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -471,6 +471,7 @@ public class SolrSearchService extends AbstractQueryService {
             }
             solrQuery.addFilterQuery(field.getSolrField() + ":" + searchValue);
         }
+        solrQuery.set("q.op", "AND");
     }
 
     private String computeSearchValue(String searchType, String fieldValue, String searchTermOp) {
@@ -481,7 +482,7 @@ public class SolrSearchService extends AbstractQueryService {
         if (searchFragments == null || searchFragments.isEmpty()) {
             return null;
         }
-        String searchValue = String.join(' ' + searchTermOp + ' ', searchFragments);
+        String searchValue = String.join(" ", searchFragments);
         if (searchFragments.size() > 1) {
             searchValue = "(" + searchValue + ")";
         }

--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/AdvancedSearchFormController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/AdvancedSearchFormController.java
@@ -64,7 +64,6 @@ public class AdvancedSearchFormController extends AbstractErrorHandlingSearchCon
         // and forward them to the search servlet.
         SearchState searchState = searchStateFactory.createSearchStateAdvancedSearch(request.getParameterMap());
 
-        request.getSession().setAttribute("searchState", searchState);
         model.addAllAttributes(SearchStateUtil.generateStateParameters(searchState));
 
         return "redirect:/search";

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/controllers/AbstractSolrSearchController.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/controllers/AbstractSolrSearchController.java
@@ -90,15 +90,10 @@ public abstract class AbstractSolrSearchController {
 
         //Retrieve the last search state
         if (searchState == null) {
-            searchState = (SearchState)session.getAttribute("searchState");
-            if (searchState == null) {
-                if (searchRequest != null && searchRequest instanceof HierarchicalBrowseRequest) {
-                    searchState = searchStateFactory.createHierarchicalBrowseSearchState(request.getParameterMap());
-                } else {
-                    searchState = searchStateFactory.createSearchState(request.getParameterMap());
-                }
+            if (searchRequest != null && searchRequest instanceof HierarchicalBrowseRequest) {
+                searchState = searchStateFactory.createHierarchicalBrowseSearchState(request.getParameterMap());
             } else {
-                session.removeAttribute("searchState");
+                searchState = searchStateFactory.createSearchState(request.getParameterMap());
             }
         }
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3704
https://jira.lib.unc.edu/browse/BXC-3706

* Changes the way the operator ("AND") is specified between search terms in solr queries to prevent query failures when stopwords are present in the query
    * Solr was receiving queries like `(map AND of AND spanish AND fort)` and then removing stopwords, producing the following query, `(map AND AND spanish AND fort)`. The "AND AND" part doesn't match anything, so the query would return no results.
* Fixes a bug in the advanced search page, where the collection facet did no work. Does this by removing a mechanism that attempted to pass along search state via session, which was not working correctly and offered no real benefits.