### PR TITLE
Bxc 3747 front page facet link bug

### DIFF
--- a/web-access-app/src/main/webapp/WEB-INF/jsp/frontPage.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/frontPage.jsp
@@ -53,10 +53,10 @@
         <div class="info container">
             <h3>What's in the repository?</h3>
             <div class="info-icons">
-                <div><a href="search?format=image"><i class="fas fa-image"></i><c:out value="${formatCounts.image}"/> images</a></div>
-                <div><a href="search?format=video"><i class="fas fa-video"></i><c:out value="${formatCounts.video}"/> video files</a></div>
-                <div><a href="search?format=audio"><i class="fas fa-music"></i><c:out value="${formatCounts.audio}"/> audio files</a></div>
-                <div><a href="search?format=text"><i class="fas fa-file-alt"></i><c:out value="${formatCounts.text}"/> texts</a></div>
+                <div><a href="search?format=Image"><i class="fas fa-image"></i><c:out value="${formatCounts.image}"/> images</a></div>
+                <div><a href="search?format=Video"><i class="fas fa-video"></i><c:out value="${formatCounts.video}"/> video files</a></div>
+                <div><a href="search?format=Audio"><i class="fas fa-music"></i><c:out value="${formatCounts.audio}"/> audio files</a></div>
+                <div><a href="search?format=Text"><i class="fas fa-file-alt"></i><c:out value="${formatCounts.text}"/> texts</a></div>
             </div>
             <p>Interested in seeing more?</p>
             <p>See <a href="https://library.unc.edu/find/digitalcollections/">more digital collections</a> or visit the <a href="https://library.unc.edu/wilson">Wilson Special Collections Library</a> website.</p>

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/SolrQueryLayerService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/SolrQueryLayerService.java
@@ -182,6 +182,7 @@ public class SolrQueryLayerService extends SolrSearchService {
             query.setRows(0);
             query.addFacetField(SearchFieldKey.FILE_FORMAT_CATEGORY.getSolrField());
             query.setFacetLimit(-1);
+            query.addFilterQuery("resourceType:(Work)");
 
             QueryResponse response = this.executeQuery(query);
             FacetField facetField = response.getFacetField(SearchFieldKey.FILE_FORMAT_CATEGORY.getSolrField());

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/SolrQueryLayerService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/SolrQueryLayerService.java
@@ -182,7 +182,7 @@ public class SolrQueryLayerService extends SolrSearchService {
             query.setRows(0);
             query.addFacetField(SearchFieldKey.FILE_FORMAT_CATEGORY.getSolrField());
             query.setFacetLimit(-1);
-            query.addFilterQuery("resourceType:(Work)");
+            query.addFilterQuery(SearchFieldKey.RESOURCE_TYPE.getSolrField() + ":(" + ResourceType.Work.name() + ")");
 
             QueryResponse response = this.executeQuery(query);
             FacetField facetField = response.getFacetField(SearchFieldKey.FILE_FORMAT_CATEGORY.getSolrField());


### PR DESCRIPTION
It was noticed that the links for "What's in the Repository" weren't working, and also that the counts were off between the front page and the actual results. This capitalizes the facet options and makes the count only return the works, not the works and the files.

https://jira.lib.unc.edu/browse/BXC-3747