### PR TITLE
BXC-3748 - Fix ObjectTypeMismatchException thrown during work reindexing batches

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
@@ -17,15 +17,18 @@ package edu.unc.lib.boxc.services.camel.solrUpdate;
 
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import edu.unc.lib.boxc.search.solr.config.SolrSettings;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -37,7 +40,13 @@ public class AggregateUpdateProcessor implements Processor {
     private static final Logger log = LoggerFactory.getLogger(AggregateUpdateProcessor.class);
     private IndexingMessageSender messageSender;
     private IndexingActionType actionType;
+    private SolrSettings solrSettings;
+    private SolrClient solrClient;
     private boolean forceCommit;
+
+    public void init() {
+        solrClient = solrSettings.getSolrClient();
+    }
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -48,7 +57,11 @@ public class AggregateUpdateProcessor implements Processor {
         }
         if (forceCommit) {
             // Force commit of any pending solr updates before sending indexing operations
-            messageSender.sendIndexingOperation(null, RepositoryPaths.getRootPid(), IndexingActionType.COMMIT);
+            try {
+                solrClient.commit();
+            } catch (SolrServerException | IOException e) {
+                log.error("Failed to commit solr updates prior to indexing children of a collection");
+            }
         }
         for (Object idObj : idCollection) {
             PID pid = PIDs.get(idObj.toString());
@@ -58,6 +71,14 @@ public class AggregateUpdateProcessor implements Processor {
 
     public void setIndexingMessageSender(IndexingMessageSender messageSender) {
         this.messageSender = messageSender;
+    }
+
+    public void setSolrSettings(SolrSettings solrSettings) {
+        this.solrSettings = solrSettings;
+    }
+
+    public void setSolrClient(SolrClient solrClient) {
+        this.solrClient = solrClient;
     }
 
     public void setActionType(IndexingActionType actionType) {

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -469,10 +469,12 @@
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
 
-    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
+    <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor"
+          init-method="init">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
         <property name="forceCommit" value="true" />
+        <property name="solrSettings" ref="solrSettings" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -30,6 +30,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+import org.apache.solr.client.solrj.SolrClient;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
@@ -93,6 +94,9 @@ public class SolrUpdateRouterTest {
 
     @Autowired
     private SolrUpdatePreprocessor solrUpdatePreprocessor;
+
+    @Autowired
+    private SolrClient solrClient;
 
     private ArgumentCaptor<Exchange> exchangeCaptor;
 
@@ -262,6 +266,7 @@ public class SolrUpdateRouterTest {
 
         notify.matches(3l, TimeUnit.SECONDS);
 
+        verify(solrClient).commit();
         verify(indexingMessageSender).sendIndexingOperation(null, targetPid1, IndexingActionType.UPDATE_WORK_FILES);
         verify(indexingMessageSender).sendIndexingOperation(null, targetPid2, IndexingActionType.UPDATE_WORK_FILES);
     }

--- a/services-camel-app/src/test/resources/solr-update-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-context.xml
@@ -38,10 +38,15 @@
         <constructor-arg value="edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender" />
     </bean>
 
+    <bean id="mockSolrClient" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="org.apache.solr.client.solrj.SolrClient" />
+    </bean>
+
     <bean id="aggregateWorkForFileProcessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.AggregateUpdateProcessor">
         <property name="indexingMessageSender" ref="mockIndexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
         <property name="forceCommit" value="true" />
+        <property name="solrClient" ref="mockSolrClient" />
     </bean>
 
     <bean id="orderedSetAggregationStrategy" class="edu.unc.lib.boxc.services.camel.util.OrderedSetAggregationStrategy"/>

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -208,6 +208,7 @@
         <property name="indexingMessageSender" ref="indexingMessageSender" />
         <property name="actionType" value="UPDATE_WORK_FILES" />
         <property name="forceCommit" value="true" />
+        <property name="solrClient" ref="embeddedSolrServer" />
     </bean>
 
     <bean id="updateWorkJmsTemplate" class="org.springframework.jms.core.JmsTemplate">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3748

* Call solr commit directly rather than sending commit message referencing the root of fedora, which was causing object tpye mismatch errors when loading the object