### PR TITLE
BXC-3709 - Advanced search date range fixes

### DIFF
--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
@@ -131,4 +131,17 @@ public class EndpointIT {
     public void assertIdMatchesNone(List<JsonNode> json, String id) {
         assertTrue(json.stream().noneMatch(entry -> id.equals(entry.get("id").asText())));
     }
+
+    protected void assertResultCountEquals(String url, int expectedCount) throws IOException {
+        assertResultCountEquals(new HttpGet(url), expectedCount);
+    }
+
+    protected void assertResultCountEquals(HttpGet getMethod, int expectedCount) throws IOException {
+        try (var resp = httpClient.execute(getMethod)) {
+            var metadata = getMetadataFromResponse(resp);
+            assertSuccessfulResponse(resp);
+            // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
+            assertEquals(expectedCount, metadata.size());
+        }
+    }
 }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -309,19 +309,6 @@ public class SearchEndpointIT extends EndpointIT {
         assertResultCountEquals(SEARCH_URL + "/?added=" + (currentYear + 1) + ",", 0);
     }
 
-    private void assertResultCountEquals(String url, int expectedCount) throws IOException {
-        assertResultCountEquals(new HttpGet(url), expectedCount);
-    }
-
-    private void assertResultCountEquals(HttpGet getMethod, int expectedCount) throws IOException {
-        try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
-            assertSuccessfulResponse(resp);
-            // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
-            assertEquals(expectedCount, metadata.size());
-        }
-    }
-
     @Test
     public void testSearchWithCreatedDateRangeSpecified() throws Exception {
         createDefaultObjects();

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
@@ -437,32 +437,32 @@ public class SearchStateFactory {
      * @param request
      */
     private void populateSearchStateAdvancedSearch(SearchState searchState, Map<String,String[]> request) {
-        String parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.DEFAULT_INDEX.name()));
+        String parameter = getParameter(request, SearchFieldKey.DEFAULT_INDEX.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             searchState.getSearchFields().put(SearchFieldKey.DEFAULT_INDEX.name(), parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.SUBJECT_INDEX.name()));
+        parameter = getParameter(request, SearchFieldKey.SUBJECT_INDEX.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             searchState.getSearchFields().put(SearchFieldKey.SUBJECT_INDEX.name(), parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.CONTRIBUTOR_INDEX.name()));
+        parameter = getParameter(request, SearchFieldKey.CONTRIBUTOR_INDEX.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             searchState.getSearchFields().put(SearchFieldKey.CONTRIBUTOR_INDEX.name(), parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.TITLE_INDEX.name()));
+        parameter = getParameter(request, SearchFieldKey.TITLE_INDEX.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             searchState.getSearchFields().put(SearchFieldKey.TITLE_INDEX.name(), parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.PARENT_COLLECTION.name()));
+        parameter = getParameter(request, SearchFieldKey.PARENT_COLLECTION.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             searchState.setFacet(new GenericFacet(SearchFieldKey.PARENT_COLLECTION, parameter));
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(SearchFieldKey.FILE_FORMAT_CATEGORY.name()));
+        parameter = getParameter(request, SearchFieldKey.FILE_FORMAT_CATEGORY.getUrlParam());
         if (parameter != null && parameter.length() > 0) {
             var fileFormatCat = new GenericFacet(SearchFieldKey.FILE_FORMAT_CATEGORY.name(), parameter);
             searchState.addFacet(fileFormatCat);
@@ -470,14 +470,12 @@ public class SearchStateFactory {
 
         //Store date added.
         RangePair dateAdded = new RangePair();
-        parameter = getParameter(request, searchSettings.searchFieldParam(
-                SearchFieldKey.DATE_ADDED.name()) + "Start");
+        parameter = getParameter(request, SearchFieldKey.DATE_ADDED.getUrlParam() + "Start");
         if (parameter != null && parameter.length() > 0) {
             dateAdded.setLeftHand(parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(
-                SearchFieldKey.DATE_ADDED.name()) + "End");
+        parameter = getParameter(request, SearchFieldKey.DATE_ADDED.getUrlParam() + "End");
         if (parameter != null && parameter.length() > 0) {
             dateAdded.setRightHand(parameter);
         }
@@ -488,20 +486,18 @@ public class SearchStateFactory {
 
         //Store date added.
         RangePair dateCreated = new RangePair();
-        parameter = getParameter(request, searchSettings.searchFieldParam(
-                SearchFieldKey.DATE_CREATED.name()) + "Start");
+        parameter = getParameter(request, SearchFieldKey.DATE_CREATED_YEAR.getUrlParam() + "Start");
         if (parameter != null && parameter.length() > 0) {
             dateCreated.setLeftHand(parameter);
         }
 
-        parameter = getParameter(request, searchSettings.searchFieldParam(
-                SearchFieldKey.DATE_CREATED.name()) + "End");
+        parameter = getParameter(request, SearchFieldKey.DATE_CREATED_YEAR.getUrlParam() + "End");
         if (parameter != null && parameter.length() > 0) {
             dateCreated.setRightHand(parameter);
         }
 
         if (dateCreated.getLeftHand() != null || dateCreated.getRightHand() != null) {
-            searchState.getRangeFields().put(SearchFieldKey.DATE_CREATED.name(), dateCreated);
+            searchState.getRangeFields().put(SearchFieldKey.DATE_CREATED_YEAR.name(), dateCreated);
         }
     }
 

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -551,8 +551,8 @@ public class SolrSearchService extends AbstractQueryService {
                 }
                 // Assume RangePair, as the only other implementation at present
                 var rangePair = (RangePair) rangeTerm.getValue();
-                String left = getRangeValue(key, rangePair.getLeftHand());
-                String right = getRangeValue(key, rangePair.getRightHand());
+                String left = getRangeValue(key, rangePair.getLeftHand(), false);
+                String right = getRangeValue(key, rangePair.getRightHand(), true);
                 if (left.equals("*") && right.equals("*")) {
                     continue;
                 }
@@ -562,14 +562,14 @@ public class SolrSearchService extends AbstractQueryService {
         }
     }
 
-    private String getRangeValue(String key, String value) {
+    private String getRangeValue(String key, String value, boolean endRange) {
         if (StringUtils.isBlank(value)) {
             return "*";
         }
 
         if (SearchSettings.FIELDS_DATE_SEARCHABLE.contains(key)) {
             try {
-                return DateFormatUtil.getFormattedDate(value, true, true);
+                return DateFormatUtil.getFormattedDate(value, true, endRange);
             } catch (NumberFormatException e) {
                 return "*";
             }

--- a/static/js/public/advancedSearch.js
+++ b/static/js/public/advancedSearch.js
@@ -15,7 +15,7 @@ require.config({
 });
 define('advancedSearch', ['module', 'jquery', 'datepicker', 'qtip'], function(module, $) {
 	$(".advsearch_date").datepicker({showOn: false});
-	$(".advsearch_date").datepicker("option", "dateFormat", "yy-mm-dd");
+	$(".advsearch_date").datepicker("option", "dateFormat", "yy");
 	$(".date_field_tooltip").qtip({
 		content: {
 			text: false

--- a/static/js/vue-cdr-access/src/components/filterTags.vue
+++ b/static/js/vue-cdr-access/src/components/filterTags.vue
@@ -21,7 +21,7 @@ Displays tags for currently active filters in a search result, with the option t
 import routeUtils from "../mixins/routeUtils";
 
 const TYPES = {
-    added: 'Date Added',
+    added: 'Date Deposited',
     unit: 'Administrative Unit',
     collection: 'Collection',
     created: 'Date Created',

--- a/static/js/vue-cdr-access/tests/unit/filterTags.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/filterTags.spec.js
@@ -220,7 +220,7 @@ describe('filterTags.vue', () => {
             added: "1999,2005"
         });
         await router.push('/search?added=1999,2005');
-        expect(wrapper.find('.search-text').text()).toMatch(/Date\sAdded.*?1999\sto\s2005/s);
+        expect(wrapper.find('.search-text').text()).toMatch(/Date\sDeposited.*?1999\sto\s2005/s);
     });
 
     it("correctly displays a date search with no end date", async () => {
@@ -236,7 +236,7 @@ describe('filterTags.vue', () => {
             added: ",2005"
         });
         await router.push('/search?added=,2005');
-        expect(wrapper.find('.search-text').text()).toMatch(/Date\sAdded.*?All\sdates\sthrough\s2005/s);
+        expect(wrapper.find('.search-text').text()).toMatch(/Date\sDeposited.*?All\sdates\sthrough\s2005/s);
     });
 
     it("clears anywhere term when container selected", async () => {

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
@@ -19,6 +19,7 @@
 <%@ page trimDirectiveWhitespaces="true" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI"%>
+<%@ page import="edu.unc.lib.boxc.search.api.SearchFieldKey" %>
 
 <div class="content-wrap">
 <div class="contentarea">
@@ -30,29 +31,29 @@
 			<div class="contentarea">
 				<h3>Search for</h3>
 				<p class="clear has-text-weight-bold">
-					<label for="anywhere">Anywhere</label> <input id="anywhere" name="${searchSettings.searchFieldParams['DEFAULT_INDEX']}" class="advsearch_text" type="text" />
+					<label for="anywhere">Anywhere</label> <input id="anywhere" name="${SearchFieldKey.DEFAULT_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 				<p class="clear has-text-weight-bold">
-					<label for="title">Title</label> <input id="title" name="${searchSettings.searchFieldParams['TITLE_INDEX']}" class="advsearch_text" type="text" />
+					<label for="title">Title</label> <input id="title" name="${SearchFieldKey.TITLE_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 				<p class="clear has-text-weight-bold">
-					<label for="contributor">Creator/Contributor</label> <input id="contributor"name="${searchSettings.searchFieldParams['CONTRIBUTOR_INDEX']}" class="advsearch_text" type="text" />
+					<label for="contributor">Creator/Contributor</label> <input id="contributor"name="${SearchFieldKey.CONTRIBUTOR_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 				<p class="clear has-text-weight-bold">
-					<label for="subject">Subject</label> <input id="subject" name="${searchSettings.searchFieldParams['SUBJECT_INDEX']}" class="advsearch_text" type="text" />
+					<label for="subject">Subject</label> <input id="subject" name="${SearchFieldKey.SUBJECT_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 			</div>
 		</div>
 		<div class="twocol light shadowtop">
 			<div class="contentarea">
 				<h3>Limit By</h3>
-				<select name="${searchSettings.searchFieldParams['PARENT_COLLECTION']}" class="advsearch_select" aria-label="collection">
+				<select name="${SearchFieldKey.PARENT_COLLECTION.getUrlParam()}" class="advsearch_select" aria-label="collection">
 					<option value="">Collection</option>
 					<c:forEach items="${collectionList}" var="collectionRecord">
 						<option value="<c:out value='${collectionRecord.id}' />"><c:out value="${collectionRecord.title}" /></option>
 					</c:forEach>
 				</select>
-				<select name="${searchSettings.searchFieldParams['FILE_FORMAT_CATEGORY']}" class="advsearch_select" aria-label="format">
+				<select name="${SearchFieldKey.FILE_FORMAT_CATEGORY.getUrlParam()}" class="advsearch_select" aria-label="format">
 					<option value="">Format</option>
 					<c:forEach items="${formats}" var="formatEntry">
 						<option value="${formatEntry}"><c:out value="${formatEntry}"/></option>
@@ -61,21 +62,21 @@
 				
 				<p class="clear"><br /></p>
 				<p class="clear has-text-weight-bold">
-					<label>Date Deposited</label> from <input aria-label="deposited-start-date" name="${searchSettings.searchFieldParams['DATE_ADDED']}Start" class="advsearch_date" type="text" />
-						 to <input aria-label="deposited-end-date" name="${searchSettings.searchFieldParams['DATE_ADDED']}End" class="advsearch_date" type="text" />
-						<a class="date_field_tooltip" title="Enter dates in YYYY-MM-DD format.  Month and day may be omitted.  Leave the right hand date empty to search for items with dates starting at the left hand date, and vice versa.">?</a>
+					<label>Date Deposited</label> from <input aria-label="deposited-start-date" name="${SearchFieldKey.DATE_ADDED.getUrlParam()}Start" class="advsearch_date" type="text" />
+						 to <input aria-label="deposited-end-date" name="${SearchFieldKey.DATE_ADDED.getUrlParam()}End" class="advsearch_date" type="text" />
+						<a class="date_field_tooltip" title="Enter dates in YYYY.  Leave the right hand date empty to search for items with dates starting at the left hand date, and vice versa.">?</a>
 				</p>
 				<p class="clear has-text-weight-bold">
-					<label>Date Created</label> from <input aria-label="created-start-date" name="${searchSettings.searchFieldParams['DATE_CREATED']}Start" class="advsearch_date" type="text" />
-						 to <input aria-label="created-end-date" name="${searchSettings.searchFieldParams['DATE_CREATED']}End" class="advsearch_date" type="text" />
-					<a class="date_field_tooltip" title="Enter dates in YYYY-MM-DD format.  Month and day may be omitted.  Leave the right hand date empty to search for items with dates starting at the left hand date, and vice versa.">?</a>
+					<label>Date Created</label> from <input aria-label="created-start-date" name="${SearchFieldKey.DATE_CREATED_YEAR.getUrlParam()}Start" class="advsearch_date" type="text" />
+						 to <input aria-label="created-end-date" name="${SearchFieldKey.DATE_CREATED_YEAR.getUrlParam()}End" class="advsearch_date" type="text" />
+					<a class="date_field_tooltip" title="Enter dates in YYYY format.  Leave the right hand date empty to search for items with dates starting at the left hand date, and vice versa.">?</a>
 				</p>
 			</div>
 		</div>
 	
 		<div class="onecol white">
 			<div class="contentarea">
-				<input type="submit" class="right" id="advsearch_submit" value="Search"></input>
+				<input type="submit" class="right" id="advsearch_submit" value="Search" />
 			</div>
 		</div>
 	


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3709

* Restricts advanced search Date Deposited and Date Created fields to YEAR only
* Date Created field now searches dateCreatedYear
* Fixed a bug when generating ranges for the solr query, which was incorrectly treating both the start and the end date in the range as end dates. This was causing Date Deposited to not return records that matched the start year.
* Update display name for "added" field on search results page to "Date Deposited" for consistency (was "Date Added")