### PR TITLE
BXC-3757 - Fix incorrect thumbnails for multifile works

### DIFF
--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/AdminUnitFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/AdminUnitFactory.java
@@ -18,7 +18,6 @@ package edu.unc.lib.boxc.integration.factories;
 import edu.unc.lib.boxc.model.api.objects.AdminUnit;
 import edu.unc.lib.boxc.model.api.objects.ContentRootObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths;
-import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 
 import java.util.Map;
 
@@ -39,9 +38,5 @@ public class AdminUnitFactory extends ContentObjectFactory {
         prepareObject(adminUnit, options);
 
         return adminUnit;
-    }
-
-    public void setDerivativeService(DerivativeService derivativeService) {
-        this.derivativeService = derivativeService;
     }
 }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/CollectionFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/CollectionFactory.java
@@ -17,7 +17,6 @@ package edu.unc.lib.boxc.integration.factories;
 
 import edu.unc.lib.boxc.model.api.objects.AdminUnit;
 import edu.unc.lib.boxc.model.api.objects.CollectionObject;
-import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 
 import java.util.Map;
 
@@ -38,9 +37,5 @@ public class CollectionFactory extends ContentObjectFactory {
         prepareObject(collection, options);
 
         return collection;
-    }
-
-    public void setDerivativeService(DerivativeService derivativeService) {
-        this.derivativeService = derivativeService;
     }
 }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/FileFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/FileFactory.java
@@ -17,20 +17,19 @@ package edu.unc.lib.boxc.integration.factories;
 
 import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
-import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
-import org.apache.commons.io.FileUtils;
 import edu.unc.lib.boxc.model.api.rdf.IanaRelation;
+import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.vocabulary.DCTerms;
-
-import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
-import static edu.unc.lib.boxc.model.api.xml.NamespaceConstants.FITS_URI;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+
+import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.boxc.model.api.xml.NamespaceConstants.FITS_URI;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
 /**
  * Factory for creating test FileObjects
@@ -43,8 +42,6 @@ public class FileFactory extends ContentObjectFactory {
     public static final String PDF_FORMAT = "pdf";
     public static final String AUDIO_FORMAT = "audio";
     public static final String VIDEO_FORMAT = "video";
-
-    private DerivativeService derivativeService;
 
     /*
     Creates a basic File with a FileFormat
@@ -99,10 +96,6 @@ public class FileFactory extends ContentObjectFactory {
         // add FITS file. Same one for all formats at the moment
         file.addBinary(fitsPid, fitsUri, TECHNICAL_METADATA.getDefaultFilename(), TECHNICAL_METADATA.getMimetype(),
                 null, null, IanaRelation.derivedfrom, DCTerms.conformsTo, createResource(FITS_URI));
-    }
-
-    public void setDerivativeService(DerivativeService derivativeService) {
-        this.derivativeService = derivativeService;
     }
 
     private void createOriginalFile(FileObject file, String mimetype, String data, String suffix) throws IOException {

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/WorkFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/WorkFactory.java
@@ -16,8 +16,8 @@
 package edu.unc.lib.boxc.integration.factories;
 
 import edu.unc.lib.boxc.model.api.objects.CollectionObject;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
-import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
 
 import java.util.Map;
 
@@ -41,7 +41,7 @@ public class WorkFactory extends ContentObjectFactory {
      * Adds a specified file (options should have what type of file) to the work
      * optional boolean in options can make this file the primary object in the work
      */
-    public void createFileInWork(WorkObject work, Map<String, String> options) throws Exception {
+    public FileObject createFileInWork(WorkObject work, Map<String, String> options) throws Exception {
         var file = fileFactory.createFile(options);
         work.addMember(file);
         prepareObject(file, options);
@@ -53,13 +53,10 @@ public class WorkFactory extends ContentObjectFactory {
         }
         // need to reindex in solr after adding file object
         indexSolr(work);
+        return file;
     }
 
     public void setFileFactory(FileFactory fileFactory) {
         this.fileFactory = fileFactory;
-    }
-
-    public void setDerivativeService(DerivativeService derivativeService) {
-        this.derivativeService = derivativeService;
     }
 }

--- a/integration/src/test/resources/loris-content-it-servlet.xml
+++ b/integration/src/test/resources/loris-content-it-servlet.xml
@@ -32,9 +32,7 @@
     </bean>
     
     <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService">
-        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
-        <property name="facetFieldUtil" ref="facetFieldUtil" />
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
-        <property name="solrClient" ref="solrClient" />
+        <property name="solrSearchService" ref="solrSearchService" />
     </bean>
 </beans>

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/filters/QueryFilter.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/filters/QueryFilter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.api.filters;
+
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+
+/**
+ * A filter used to adjust the results of a query
+ *
+ * @author bbpennel
+ */
+public interface QueryFilter {
+    /**
+     * @return this filter represented as a query string
+     */
+    public String toFilterString();
+
+    /**
+     * @return SearchFieldKey for the field to apply the filter to
+     */
+    public SearchFieldKey getFieldKey();
+}

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchState.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchState.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import edu.unc.lib.boxc.search.api.filters.QueryFilter;
 import edu.unc.lib.boxc.search.api.ranges.RangeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ public class SearchState implements Serializable, Cloneable {
     private Map<String, List<SearchFacet>> facets;
     private Map<String, Integer> facetLimits;
     private Map<String, String> facetSorts;
+    private List<QueryFilter> filters;
     private List<String> facetsToRetrieve;
     private Collection<Permission> permissionLimits;
     private Integer baseFacetLimit;
@@ -66,12 +68,13 @@ public class SearchState implements Serializable, Cloneable {
 
     public SearchState() {
         LOG.debug("Instantiating new SearchState");
-        searchFields = new HashMap<String, String>();
-        rangeFields = new HashMap<String, RangeValue>();
+        searchFields = new HashMap<>();
+        rangeFields = new HashMap<>();
         permissionLimits = null;
-        facets = new HashMap<String, List<SearchFacet>>();
-        facetLimits = new HashMap<String, Integer>();
-        facetSorts = new HashMap<String, String>();
+        facets = new HashMap<>();
+        facetLimits = new HashMap<>();
+        facetSorts = new HashMap<>();
+        filters = new ArrayList<>();
         resultFields = null;
         facetsToRetrieve = null;
         rollup = null;
@@ -81,6 +84,7 @@ public class SearchState implements Serializable, Cloneable {
     }
 
     public SearchState(SearchState searchState) {
+        this();
         if (searchState.getSearchFields() != null) {
             this.searchFields = new HashMap<>(searchState.getSearchFields());
         }
@@ -95,6 +99,9 @@ public class SearchState implements Serializable, Cloneable {
             for (Entry<String, List<SearchFacet>> item : searchState.getFacets().entrySet()) {
                 facets.put(item.getKey(), item.getValue());
             }
+        }
+        if (searchState.getFilters() != null) {
+            this.filters = new ArrayList<>(searchState.getFilters());
         }
         if (searchState.getFacetLimits() != null) {
             this.facetLimits = new HashMap<String, Integer>(searchState.getFacetLimits());
@@ -260,6 +267,17 @@ public class SearchState implements Serializable, Cloneable {
 
     public void setRangeFields(Map<String, RangeValue> rangeFields) {
         this.rangeFields = rangeFields;
+    }
+
+    /**
+     * @return List of QueryFilters being used to limit the results of this search, which do not impact relevancy
+     */
+    public List<QueryFilter> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(List<QueryFilter> filters) {
+        this.filters = filters;
     }
 
     public Collection<Permission> getPermissionLimits() {

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchState.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchState.java
@@ -276,8 +276,8 @@ public class SearchState implements Serializable, Cloneable {
         return filters;
     }
 
-    public void setFilters(List<QueryFilter> filters) {
-        this.filters = filters;
+    public void addFilter(QueryFilter filter) {
+        filters.add(filter);
     }
 
     public Collection<Permission> getPermissionLimits() {

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/MultipleSelfOwnedDatastreamsFilter.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/MultipleSelfOwnedDatastreamsFilter.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.filters;
+
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.filters.QueryFilter;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Filter which restricts results to entries which contain at least one of the listed datastreams,
+ * where the datastream is owned by the object itself rather than one of its children
+ *
+ * @author bbpennel
+ */
+public class MultipleSelfOwnedDatastreamsFilter implements QueryFilter {
+    private Set<DatastreamType> datastreamTypes;
+    private SearchFieldKey fieldKey;
+
+    protected MultipleSelfOwnedDatastreamsFilter(SearchFieldKey fieldKey, Set<DatastreamType> datastreamTypes) {
+        this.datastreamTypes = datastreamTypes;
+        this.fieldKey = fieldKey;
+    }
+
+    @Override
+    public String toFilterString() {
+        var dsField = fieldKey.getSolrField();
+        return getDatastreamTypes().stream()
+                // Filtering datastreams to exclude those owned by other objects
+                .map(ds -> dsField + ":" + ds.getId() + "|*||")
+                .collect(Collectors.joining(" OR ", "(", ")"));
+    }
+
+    public Set<DatastreamType> getDatastreamTypes() {
+        return datastreamTypes;
+    }
+
+    @Override
+    public SearchFieldKey getFieldKey() {
+        return fieldKey;
+    }
+}

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/NamedDatastreamFilter.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/NamedDatastreamFilter.java
@@ -28,7 +28,7 @@ public class NamedDatastreamFilter implements QueryFilter {
     private DatastreamType datastreamType;
     private SearchFieldKey fieldKey;
 
-    public NamedDatastreamFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
+    protected NamedDatastreamFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
         this.datastreamType = datastreamType;
         this.fieldKey = fieldKey;
     }
@@ -36,6 +36,10 @@ public class NamedDatastreamFilter implements QueryFilter {
     @Override
     public String toFilterString() {
         return getFieldKey().getSolrField() + ":" + datastreamType.getId() + "|*";
+    }
+
+    public DatastreamType getDatastreamType() {
+        return datastreamType;
     }
 
     @Override

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/NamedDatastreamFilter.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/NamedDatastreamFilter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.filters;
+
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.filters.QueryFilter;
+
+/**
+ * Filter which restricts results to entries which contain datastreams of the specified type
+ *
+ * @author bbpennel
+ */
+public class NamedDatastreamFilter implements QueryFilter {
+    private DatastreamType datastreamType;
+    private SearchFieldKey fieldKey;
+
+    public NamedDatastreamFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
+        this.datastreamType = datastreamType;
+        this.fieldKey = fieldKey;
+    }
+
+    @Override
+    public String toFilterString() {
+        return getFieldKey().getSolrField() + ":" + datastreamType.getId() + "|*";
+    }
+
+    @Override
+    public SearchFieldKey getFieldKey() {
+        return fieldKey;
+    }
+}

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
@@ -29,7 +29,7 @@ public class QueryFilterFactory {
     }
     /**
      * @param datastreamType
-     * @return new DatastreamFilter instance with the provided type
+     * @return new QueryFilter instance with the provided type
      */
     public static QueryFilter createFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
         return new NamedDatastreamFilter(fieldKey, datastreamType);

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
@@ -19,6 +19,8 @@ import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.filters.QueryFilter;
 
+import java.util.Set;
+
 /**
  * Factory for creating query filter objects
  *
@@ -27,11 +29,22 @@ import edu.unc.lib.boxc.search.api.filters.QueryFilter;
 public class QueryFilterFactory {
     private QueryFilterFactory() {
     }
+
     /**
+     * @param fieldKey key of field to filter
      * @param datastreamType
      * @return new QueryFilter instance with the provided type
      */
     public static QueryFilter createFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
         return new NamedDatastreamFilter(fieldKey, datastreamType);
+    }
+
+    /**
+     * @param fieldKey key of field to filter
+     * @param datastreamTypes
+     * @return new QueryFilter instance with the provided datastream types
+     */
+    public static QueryFilter createFilter(SearchFieldKey fieldKey, Set<DatastreamType> datastreamTypes) {
+        return new MultipleSelfOwnedDatastreamsFilter(fieldKey, datastreamTypes);
     }
 }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.search.solr.filters;
+
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.filters.QueryFilter;
+
+/**
+ * Factory for creating query filter objects
+ *
+ * @author bbpennel
+ */
+public class QueryFilterFactory {
+    private QueryFilterFactory() {
+    }
+    /**
+     * @param datastreamType
+     * @return new DatastreamFilter instance with the provided type
+     */
+    public static QueryFilter createFilter(SearchFieldKey fieldKey, DatastreamType datastreamType) {
+        return new NamedDatastreamFilter(fieldKey, datastreamType);
+    }
+}

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import edu.unc.lib.boxc.search.api.filters.QueryFilter;
 import edu.unc.lib.boxc.search.solr.config.SearchSettings;
 import edu.unc.lib.boxc.search.solr.ranges.RangePair;
 import edu.unc.lib.boxc.search.solr.ranges.UnknownRange;
@@ -323,6 +324,9 @@ public class SolrSearchService extends AbstractQueryService {
         // Add range Fields to the query
         addRangeFields(searchState, solrQuery);
 
+        // Add other filter queries which to not impact relevancy
+        addQueryFilters(searchState, solrQuery);
+
         // No query terms given, make it an everything query
         if (StringUtils.isEmpty(solrQuery.getQuery())) {
             solrQuery.setQuery("*:*");
@@ -527,6 +531,12 @@ public class SolrSearchService extends AbstractQueryService {
 
             filter.append(')');
             query.addFilterQuery(filter.toString());
+        }
+    }
+
+    private void addQueryFilters(SearchState searchState, SolrQuery query) {
+        for (QueryFilter filter : searchState.getFilters()) {
+            query.addFilterQuery(filter.toFilterString());
         }
     }
 

--- a/web-access-app/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/web-access-app/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -117,12 +117,10 @@
         <property name="solrSettings" ref="solrSettings" />
     </bean>
     
-    <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService"
-        init-method="initializeSolrServer">
-        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
-        <property name="facetFieldUtil" ref="facetFieldUtil" />
+    <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService">
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
         <property name="permissionsHelper" ref="permsHelper" />
+        <property name="solrSearchService" ref="queryLayer" />
     </bean>
     
     <bean id="queryLayer" class="edu.unc.lib.boxc.web.common.services.SolrQueryLayerService"

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
@@ -166,7 +166,7 @@ public class AccessCopiesService {
         var request = buildFirstChildQuery(contentObjectRecord, principals);
         // Limit query to just children which have a thumbnail datastream
         var searchState = request.getSearchState();
-        searchState.getFilters().add(
+        searchState.addFilter(
                 QueryFilterFactory.createFilter(SearchFieldKey.DATASTREAM, DatastreamType.THUMBNAIL_LARGE));
 
         var resp = solrSearchService.getSearchResults(request);
@@ -218,7 +218,7 @@ public class AccessCopiesService {
         CutoffFacet selectedPath = briefObj.getPath();
         searchState.addFacet(selectedPath);
         searchState.setSortType("default");
-        searchState.getFilters().add(
+        searchState.addFilter(
                 QueryFilterFactory.createFilter(SearchFieldKey.DATASTREAM, DatastreamType.JP2_ACCESS_COPY));
 
         var searchRequest = new SearchRequest(searchState, principals);

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
@@ -62,7 +62,6 @@ public class AccessCopiesService {
      * @param principals
      * @return
      */
-    @SuppressWarnings("unchecked")
     public List<ContentObjectRecord> listViewableFiles(PID pid, AccessGroupSet principals) {
         ContentObjectRecord briefObj = solrSearchService.getObjectById(new SimpleIdRequest(pid, principals));
         String resourceType = briefObj.getResourceType();
@@ -203,8 +202,6 @@ public class AccessCopiesService {
         CutoffFacet selectedPath = briefObj.getPath();
         searchState.addFacet(selectedPath);
         SearchRequest searchRequest = new SearchRequest(searchState, principals);
-        searchRequest.setSearchState(searchState);
-        searchRequest.setAccessGroups(principals);
         searchRequest.setApplyCutoffs(true);
         return searchRequest;
     }
@@ -220,7 +217,8 @@ public class AccessCopiesService {
         CutoffFacet selectedPath = briefObj.getPath();
         searchState.addFacet(selectedPath);
         searchState.setSortType("default");
-        QueryFilterFactory.createFilter(SearchFieldKey.DATASTREAM, DatastreamType.JP2_ACCESS_COPY);
+        searchState.getFilters().add(
+                QueryFilterFactory.createFilter(SearchFieldKey.DATASTREAM, DatastreamType.JP2_ACCESS_COPY));
 
         var searchRequest = new SearchRequest(searchState, principals);
         return solrSearchService.getSearchResults(searchRequest);

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/AccessCopiesService.java
@@ -199,6 +199,7 @@ public class AccessCopiesService {
         SearchState searchState = new SearchState();
         searchState.setFacetsToRetrieve(null);
         searchState.setRowsPerPage(1);
+        searchState.setSortType("default");
         CutoffFacet selectedPath = briefObj.getPath();
         searchState.addFacet(selectedPath);
         SearchRequest searchRequest = new SearchRequest(searchState, principals);

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/AccessCopiesServiceTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/AccessCopiesServiceTest.java
@@ -268,6 +268,7 @@ public class AccessCopiesServiceTest  {
         // Gets the ID of the specific child with a thumbnail
         assertEquals(mdObjectImg.getId(), accessCopiesService.getThumbnailId(noOriginalFileObj, principals, true));
         assertRequestedDatastreamFilter(DatastreamType.THUMBNAIL_LARGE);
+        assertSortType("default");
     }
 
     @Test
@@ -308,14 +309,20 @@ public class AccessCopiesServiceTest  {
         // Gets the ID of the specific child with a thumbnail
         assertEquals(mdObjectImg2.getId(), accessCopiesService.getThumbnailId(noOriginalFileObj, principals, true));
         assertRequestedDatastreamFilter(DatastreamType.THUMBNAIL_LARGE);
+        assertSortType("default");
     }
 
     private void assertRequestedDatastreamFilter(DatastreamType expectedType) {
-        var searchRequest = searchRequestCaptor.getValue();
-        var searchState = searchRequest.getSearchState();
+        var searchState = searchRequestCaptor.getValue().getSearchState();
         var queryFilter = (NamedDatastreamFilter) searchState.getFilters().get(0);
         assertEquals("Expected request to be filtered by datastream " + expectedType.name(),
                 expectedType, queryFilter.getDatastreamType());
+    }
+
+    private void assertSortType(String expectedSort) {
+        var searchState = searchRequestCaptor.getValue().getSearchState();
+        assertEquals("Expected request to be sorted by type",
+                expectedSort, searchState.getSortType());
     }
 
     @Test

--- a/web-services-app/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -123,11 +123,9 @@
         <property name="accessControlService" ref="aclService" />
     </bean>
 
-    <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService"
-          init-method="initializeSolrServer">
-        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
-        <property name="facetFieldUtil" ref="facetFieldUtil" />
+    <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService">
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
         <property name="permissionsHelper" ref="permsHelper" />
+        <property name="solrSearchService" ref="queryLayer" />
     </bean>
 </beans>

--- a/web-services-app/src/test/resources/datastream-content-it-servlet.xml
+++ b/web-services-app/src/test/resources/datastream-content-it-servlet.xml
@@ -54,9 +54,7 @@
     </bean>
 
     <bean id="accessCopiesService" class="edu.unc.lib.boxc.web.common.services.AccessCopiesService">
-        <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
-        <property name="facetFieldUtil" ref="facetFieldUtil" />
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
-        <property name="solrClient" ref="solrClient" />
+        <property name="solrSearchService" ref="solrSearchService" />
     </bean>
 </beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3757

* Adds an integration test to reproduce the bug, where random thumbnails were being returned instead of the first one
* Fixes the bug by adding a sort to query which looks up child ids when generating thumbnail url

* Refactor QueryFilters into their own class/interface/factory, so that AccessCopiesService can use our clients for performing searches, rather than going directly to solr (my intent would be to move more query parameters into this structure later, particular the RangePair classes)
    * Updated ExportXmlProcessor to also make use of QueryFilters, since it was the only other situation where datastream queries were being performed
* Adds more tests for AccessCopiesService to help verify some of this refactoring
* Some cleanup in factories, removes extra DerivativeService instance (which was causing nullpointerexceptions in the new test) and duplicate setter methods