### PR TITLE
Bxc 3732 facet filters search

### DIFF
--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
@@ -50,6 +50,19 @@ public class ModsFactory {
                     .setText(options.get("dateCreated"))));
         }
 
+        if (options.containsKey("language")) {
+            modsElement.addContent(new Element("language", MODS_V3_NS)
+                    .addContent(new Element("languageTerm", MODS_V3_NS)
+                            .setAttribute("authority", "iso639-2b")
+                            .setAttribute("type", "code")
+                    .setText(options.get("languageTerm"))));
+        }
+
+        if (options.containsKey("subject")) {
+            modsElement.addContent(new Element("subject", MODS_V3_NS)
+                    .addContent(new Element("topic", MODS_V3_NS).setText(options.get("topic"))));
+        }
+
         return modsElement.getChildren().isEmpty() ? null : xmlDoc;
     }
 }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
@@ -50,7 +50,7 @@ public class ModsFactory {
                     .setText(options.get("dateCreated"))));
         }
 
-        if (options.containsKey("language")) {
+        if (options.containsKey("languageTerm")) {
             modsElement.addContent(new Element("language", MODS_V3_NS)
                     .addContent(new Element("languageTerm", MODS_V3_NS)
                             .setAttribute("authority", "iso639-2b")

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ModsFactory.java
@@ -58,7 +58,7 @@ public class ModsFactory {
                     .setText(options.get("languageTerm"))));
         }
 
-        if (options.containsKey("subject")) {
+        if (options.containsKey("topic")) {
             modsElement.addContent(new Element("subject", MODS_V3_NS)
                     .addContent(new Element("topic", MODS_V3_NS).setText(options.get("topic"))));
         }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/CollectionsEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/CollectionsEndpointIT.java
@@ -53,7 +53,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         createDefaultObjects();
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "type", "AdminUnit");
@@ -65,7 +65,7 @@ public class CollectionsEndpointIT extends EndpointIT{
     @Test
     public void testCollectionsJsonReturnsSuccessWithNoAdminUnits() throws Exception {
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             assertSuccessfulResponse(resp);
             assertEquals(0, metadata.size());
         }
@@ -76,7 +76,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         adminUnitFactory.createAdminUnit(Map.of("title", "Object2"));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "title", "Object2");
@@ -90,7 +90,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         adminUnitFactory.createAdminUnit(options);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "thumbnail_url");
@@ -106,7 +106,7 @@ public class CollectionsEndpointIT extends EndpointIT{
                 Map.of("title", "Collection1", "readGroup", PUBLIC_PRINC));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             var childCount = metadata.get(0).get("counts").get("child").asInt();
 
             assertSuccessfulResponse(resp);
@@ -123,7 +123,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         collectionFactory.createCollection(adminUnit, Map.of("title", "Collection1"));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             var childCount = metadata.get(0).get("counts").get("child").asInt();
 
             assertSuccessfulResponse(resp);

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/CollectionsEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/CollectionsEndpointIT.java
@@ -53,7 +53,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         createDefaultObjects();
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "type", "AdminUnit");
@@ -65,7 +65,7 @@ public class CollectionsEndpointIT extends EndpointIT{
     @Test
     public void testCollectionsJsonReturnsSuccessWithNoAdminUnits() throws Exception {
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             assertSuccessfulResponse(resp);
             assertEquals(0, metadata.size());
         }
@@ -76,7 +76,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         adminUnitFactory.createAdminUnit(Map.of("title", "Object2"));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "title", "Object2");
@@ -90,7 +90,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         adminUnitFactory.createAdminUnit(options);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             assertValuePresent(metadata, 0, "thumbnail_url");
@@ -106,7 +106,7 @@ public class CollectionsEndpointIT extends EndpointIT{
                 Map.of("title", "Collection1", "readGroup", PUBLIC_PRINC));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             var childCount = metadata.get(0).get("counts").get("child").asInt();
 
             assertSuccessfulResponse(resp);
@@ -123,7 +123,7 @@ public class CollectionsEndpointIT extends EndpointIT{
         collectionFactory.createCollection(adminUnit, Map.of("title", "Collection1"));
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             var childCount = metadata.get(0).get("counts").get("child").asInt();
 
             assertSuccessfulResponse(resp);

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
@@ -118,7 +118,6 @@ public class EndpointIT {
     }
 
     public void createLanguageSubjectObjects() throws Exception {
-        //language facet selected
         var languageAdminUnit = adminUnitFactory.createAdminUnit(
                 Map.of("title", "Admin Object", "languageTerm", "eng"));
         collectionFactory.createCollection(languageAdminUnit,
@@ -127,13 +126,13 @@ public class EndpointIT {
                         "readGroup", "everyone"));
         folderFactory.createFolder(collection,
                 Map.of("title","A language folder","languageTerm", "eng",
-                        "subject", "NorthCarolina","readGroup", "everyone"));
+                        "topic", "North Carolina","readGroup", "everyone"));
         adminUnitFactory.createAdminUnit(Map.of(
                 "title", "English Language Admin", "languageTerm", "eng",
-                "subject", "NorthCarolina", "readGroup", "everyone"));
+                "topic", "North Carolina", "readGroup", "everyone"));
         adminUnitFactory.createAdminUnit(Map.of(
                 "title", "Cherokee Language Admin", "languageTerm", "chr",
-                "subject", "UNC", "readGroup", "everyone"));
+                "topic", "UNC", "readGroup", "everyone"));
     }
 
     public List<JsonNode> getNodeFromResponse(CloseableHttpResponse response, String fieldName) throws IOException {

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
@@ -104,42 +104,15 @@ public class EndpointIT {
                 Map.of("title", "Folder Object", "readGroup", "everyone"));
     }
 
-    public List<String> createDatedObjects() throws Exception {
-        List<String> ids = new ArrayList<>();
-        var datedAdminUnit = adminUnitFactory.createAdminUnit(
-                Map.of("title", "Dated Admin Object", "dateCreated", "2018-07-01"));
-        var datedCollection = collectionFactory.createCollection(datedAdminUnit,
-                Map.of("title", "A dated collection",
-                        "dateCreated", "2022-07-01",
-                        "readGroup", "everyone"));
-        ids.add(datedAdminUnit.getPid().getId());
-        ids.add(datedCollection.getPid().getId());
-        return ids;
-    }
-
-    public void createLanguageSubjectObjects() throws Exception {
-        var languageAdminUnit = adminUnitFactory.createAdminUnit(
-                Map.of("title", "Admin Object", "languageTerm", "eng"));
-        collectionFactory.createCollection(languageAdminUnit,
-                Map.of("title", "A language collection",
-                        "languageTerm", "eng",
-                        "readGroup", "everyone"));
-        folderFactory.createFolder(collection,
-                Map.of("title","A language folder","languageTerm", "eng",
-                        "topic", "North Carolina","readGroup", "everyone"));
-        adminUnitFactory.createAdminUnit(Map.of(
-                "title", "English Language Admin", "languageTerm", "eng",
-                "topic", "North Carolina", "readGroup", "everyone"));
-        adminUnitFactory.createAdminUnit(Map.of(
-                "title", "Cherokee Language Admin", "languageTerm", "chr",
-                "topic", "UNC", "readGroup", "everyone"));
-    }
-
     public List<JsonNode> getNodeFromResponse(CloseableHttpResponse response, String fieldName) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         var respJson = mapper.readTree(response.getEntity().getContent());
 
         return IteratorUtils.toList(respJson.get(fieldName).elements());
+    }
+
+    public List<JsonNode> getMetadataFromResponse(CloseableHttpResponse response) throws IOException {
+        return getNodeFromResponse(response, "metadata");
     }
 
     public void assertValuePresent(List<JsonNode> json, int index, String key, String value) {
@@ -170,7 +143,7 @@ public class EndpointIT {
 
     protected void assertResultCountEquals(HttpGet getMethod, int expectedCount) throws IOException {
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
             assertEquals(expectedCount, metadata.size());

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
@@ -39,6 +39,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -103,11 +104,43 @@ public class EndpointIT {
                 Map.of("title", "Folder Object", "readGroup", "everyone"));
     }
 
-    public List<JsonNode> getMetadataFromResponse(CloseableHttpResponse response) throws IOException {
+    public List<String> createDatedObjects() throws Exception {
+        List<String> ids = new ArrayList<>();
+        var datedAdminUnit = adminUnitFactory.createAdminUnit(
+                Map.of("title", "Dated Admin Object", "dateCreated", "2018-07-01"));
+        var datedCollection = collectionFactory.createCollection(datedAdminUnit,
+                Map.of("title", "A dated collection",
+                        "dateCreated", "2022-07-01",
+                        "readGroup", "everyone"));
+        ids.add(datedAdminUnit.getPid().getId());
+        ids.add(datedCollection.getPid().getId());
+        return ids;
+    }
+
+    public void createLanguageSubjectObjects() throws Exception {
+        //language facet selected
+        var languageAdminUnit = adminUnitFactory.createAdminUnit(
+                Map.of("title", "Admin Object", "languageTerm", "eng"));
+        collectionFactory.createCollection(languageAdminUnit,
+                Map.of("title", "A language collection",
+                        "languageTerm", "eng",
+                        "readGroup", "everyone"));
+        folderFactory.createFolder(collection,
+                Map.of("title","A language folder","languageTerm", "eng",
+                        "subject", "NorthCarolina","readGroup", "everyone"));
+        adminUnitFactory.createAdminUnit(Map.of(
+                "title", "English Language Admin", "languageTerm", "eng",
+                "subject", "NorthCarolina", "readGroup", "everyone"));
+        adminUnitFactory.createAdminUnit(Map.of(
+                "title", "Cherokee Language Admin", "languageTerm", "chr",
+                "subject", "UNC", "readGroup", "everyone"));
+    }
+
+    public List<JsonNode> getNodeFromResponse(CloseableHttpResponse response, String fieldName) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         var respJson = mapper.readTree(response.getEntity().getContent());
 
-        return IteratorUtils.toList(respJson.get("metadata").elements());
+        return IteratorUtils.toList(respJson.get(fieldName).elements());
     }
 
     public void assertValuePresent(List<JsonNode> json, int index, String key, String value) {

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/EndpointIT.java
@@ -170,7 +170,7 @@ public class EndpointIT {
 
     protected void assertResultCountEquals(HttpGet getMethod, int expectedCount) throws IOException {
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
             assertEquals(expectedCount, metadata.size());

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.boxc.integration.web.access;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.integration.factories.FileFactory;
 import edu.unc.lib.boxc.integration.factories.WorkFactory;
@@ -362,7 +363,8 @@ public class SearchEndpointIT extends EndpointIT {
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getNodeFromResponse(resp, "facetFields");
-            var languageFields = IteratorUtils.toList(facetFields.get(0).get("values").elements());
+            var languageFields = new ArrayList<JsonNode>();
+            facetFields.get(0).get("values").elements().forEachRemaining(languageFields::add);
 
             assertSuccessfulResponse(resp);
             // should find all available languages: English, Cherokee
@@ -376,18 +378,17 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language%2Csubject&subject=NorthCarolina&language=English&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language%2Csubject&subject=North%2520Carolina&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getNodeFromResponse(resp, "facetFields");
-            var languageFields = IteratorUtils.toList(facetFields.get(0).get("values").elements());
+            var languageFields = new ArrayList<JsonNode>();
+            facetFields.get(0).get("values").elements().forEachRemaining(languageFields::add);
 
             assertSuccessfulResponse(resp);
             // should find all available languages: English
-            System.out.println(facetFields);
-            System.out.println(languageFields);
             assertEquals(2,facetFields.size());
-            //assertEquals(1,languageFields.size());
+            assertEquals(1,languageFields.size());
             assertValuePresent(languageFields,0,"value", "English");
         }
     }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -20,7 +20,6 @@ import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.integration.factories.FileFactory;
 import edu.unc.lib.boxc.integration.factories.WorkFactory;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import org.apache.commons.collections.IteratorUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.Before;
@@ -28,10 +27,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import java.io.IOException;
 import java.time.Year;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -138,7 +138,7 @@ public class SearchEndpointIT extends EndpointIT {
             assertValuePresent(metadata, 0, "type", "Work");
         }
     }
-    
+
     @Test
     public void testSearchTypeParamWithFileSpecified() throws Exception {
         createDefaultObjects();
@@ -164,7 +164,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "A first collection", "readGroup", "everyone"));
-        
+
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,normal");
 
         try (var resp = httpClient.execute(getMethod)) {
@@ -188,7 +188,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "A first collection", "readGroup", "everyone"));
-        
+
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,reverse");
 
         try (var resp = httpClient.execute(getMethod)) {
@@ -333,6 +333,29 @@ public class SearchEndpointIT extends EndpointIT {
             assertEquals(5, metadata.size());
             assertIdMatchesNone(metadata, datedAdminUnitId);
             assertIdMatchesNone(metadata, datedCollectionId);
+        }
+    }
+
+    @Test
+    public void testSearchWithOneFacetFilter() throws Exception {
+        createDefaultObjects();
+        var languageAdminUnit = adminUnitFactory.createAdminUnit(
+                Map.of("title", "Admin Object", "languageTerm", "eng"));
+        var languageCollection = collectionFactory.createCollection(languageAdminUnit,
+                Map.of("title", "A language collection",
+                        "languageTerm", "eng",
+                        "readGroup", "everyone"));
+        var languageCollectionId = languageCollection.getPid().getId();
+
+        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=unit%2Ccollection%2CcreatedYear%2Cformat%2Cgenre%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&language=English&getFacets=true");
+
+        try (var resp = httpClient.execute(getMethod)) {
+            var metadata = getMetadataFromResponse(resp);
+            //System.out.println(metadata);
+
+            assertSuccessfulResponse(resp);
+            // should only find the language admin unit and collection
+            assertEquals(1, metadata.size());
         }
     }
 

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -19,6 +19,7 @@ import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.integration.factories.FileFactory;
 import edu.unc.lib.boxc.integration.factories.WorkFactory;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import org.apache.commons.collections.IteratorUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.Before;
@@ -30,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Integration tests for searchJson endpoints
@@ -58,7 +59,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
             assertEquals(5, metadata.size());
@@ -81,7 +82,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?titleIndex=text");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             assertSuccessfulResponse(resp);
             // find the one collection with "Text" in the title, but not the work with the text file
             assertEquals(1, metadata.size());
@@ -108,7 +109,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?anywhere=through");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // find the two items
@@ -129,7 +130,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?types=Work");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // find the one work
@@ -147,7 +148,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?types=Work,File&rollup=false");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // find the two items
@@ -168,7 +169,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,normal");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // make sure all items return
@@ -192,7 +193,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,reverse");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // make sure all items return
@@ -218,7 +219,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?start=0&rows=5");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // there are seven objects but this search should only return 5 because of page size
@@ -235,7 +236,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?start=3");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // there are 6 total items, but since the index starts at 3 we should have only 3 results
@@ -252,7 +253,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             var collectionId = staffOnlyCollection.getPid().getId();
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
@@ -271,7 +272,7 @@ public class SearchEndpointIT extends EndpointIT {
         getMethod.setHeader("isMemberof","adminGroup");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             var collectionId = staffOnlyCollection.getPid().getId();
             assertSuccessfulResponse(resp);
             assertEquals(6, metadata.size());
@@ -288,7 +289,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
             var collectionMetadata = metadata.get(2);
             assertSuccessfulResponse(resp);
             // check "permissions" field in affected result only lists "viewMetadata"
@@ -306,7 +307,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=2022,2022");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // should only find the collection, not the admin unit that has a created date
@@ -326,7 +327,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=unknown");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
+            var metadata = getNodeFromResponse(resp, "metadata");
 
             assertSuccessfulResponse(resp);
             // should only find the five default objects, not the dated admin unit or dated collection
@@ -339,36 +340,55 @@ public class SearchEndpointIT extends EndpointIT {
     @Test
     public void testSearchWithOneFacetFilter() throws Exception {
         createDefaultObjects();
-        var languageAdminUnit = adminUnitFactory.createAdminUnit(
-                Map.of("title", "Admin Object", "languageTerm", "eng"));
-        var languageCollection = collectionFactory.createCollection(languageAdminUnit,
-                Map.of("title", "A language collection",
-                        "languageTerm", "eng",
-                        "readGroup", "everyone"));
-        var languageCollectionId = languageCollection.getPid().getId();
+        createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=unit%2Ccollection%2CcreatedYear%2Cformat%2Cgenre%2Clanguage%2Csubject%2Clocation%2CcreatorContributor%2Cpublisher&language=English&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language&language=English&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getMetadataFromResponse(resp);
-            //System.out.println(metadata);
+            var facetFields = getNodeFromResponse(resp, "facetFields");
 
             assertSuccessfulResponse(resp);
-            // should only find the language admin unit and collection
-            assertEquals(1, metadata.size());
+            // should only find the language facet
+            assertEquals(1, facetFields.size());
         }
     }
 
-    private List<String> createDatedObjects() throws Exception {
-        List<String> ids = new ArrayList<>();
-        var datedAdminUnit = adminUnitFactory.createAdminUnit(
-                Map.of("title", "Dated Admin Object", "dateCreated", "2018-07-01"));
-        var datedCollection = collectionFactory.createCollection(datedAdminUnit,
-                Map.of("title", "A dated collection",
-                        "dateCreated", "2022-07-01",
-                        "readGroup", "everyone"));
-        ids.add(datedAdminUnit.getPid().getId());
-        ids.add(datedCollection.getPid().getId());
-        return ids;
+    @Test
+    public void testSearchWithLanguageFilterSelectedDisplaysAllAvailableLanguages() throws Exception {
+        createDefaultObjects();
+        createLanguageSubjectObjects();
+
+        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language&language=English&getFacets=true");
+
+        try (var resp = httpClient.execute(getMethod)) {
+            var facetFields = getNodeFromResponse(resp, "facetFields");
+            var languageFields = IteratorUtils.toList(facetFields.get(0).get("values").elements());
+
+            assertSuccessfulResponse(resp);
+            // should find all available languages: English, Cherokee
+            assertValuePresent(languageFields,0,"value", "English");
+            assertValuePresent(languageFields,1,"value", "Cherokee");
+        }
+    }
+
+    @Test
+    public void testSearchWithSubjectFilterSelectedDisplaysAvailableLanguages() throws Exception {
+        createDefaultObjects();
+        createLanguageSubjectObjects();
+
+        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language%2Csubject&subject=NorthCarolina&language=English&getFacets=true");
+
+        try (var resp = httpClient.execute(getMethod)) {
+            var facetFields = getNodeFromResponse(resp, "facetFields");
+            var languageFields = IteratorUtils.toList(facetFields.get(0).get("values").elements());
+
+            assertSuccessfulResponse(resp);
+            // should find all available languages: English
+            System.out.println(facetFields);
+            System.out.println(languageFields);
+            assertEquals(2,facetFields.size());
+            //assertEquals(1,languageFields.size());
+            assertValuePresent(languageFields,0,"value", "English");
+        }
     }
 }

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -29,6 +29,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.time.Year;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -59,7 +60,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
             assertEquals(5, metadata.size());
@@ -82,7 +83,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?titleIndex=text");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             assertSuccessfulResponse(resp);
             // find the one collection with "Text" in the title, but not the work with the text file
             assertEquals(1, metadata.size());
@@ -109,7 +110,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?anywhere=through");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // find the two items
@@ -130,7 +131,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?types=Work");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // find the one work
@@ -148,7 +149,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?types=Work,File&rollup=false");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // find the two items
@@ -169,7 +170,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,normal");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // make sure all items return
@@ -193,7 +194,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,reverse");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // make sure all items return
@@ -219,7 +220,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?start=0&rows=5");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // there are seven objects but this search should only return 5 because of page size
@@ -236,7 +237,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?start=3");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // there are 6 total items, but since the index starts at 3 we should have only 3 results
@@ -253,7 +254,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             var collectionId = staffOnlyCollection.getPid().getId();
             assertSuccessfulResponse(resp);
             // two admin units, 1 collection (nested in the admin unit), 1 work (with nested file), and 1 folder
@@ -272,7 +273,7 @@ public class SearchEndpointIT extends EndpointIT {
         getMethod.setHeader("isMemberof","adminGroup");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             var collectionId = staffOnlyCollection.getPid().getId();
             assertSuccessfulResponse(resp);
             assertEquals(6, metadata.size());
@@ -289,7 +290,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL);
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
             var collectionMetadata = metadata.get(2);
             assertSuccessfulResponse(resp);
             // check "permissions" field in affected result only lists "viewMetadata"
@@ -317,7 +318,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=2022,2022");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // should only find the collection, not the admin unit that has a created date
@@ -337,7 +338,7 @@ public class SearchEndpointIT extends EndpointIT {
         var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=unknown");
 
         try (var resp = httpClient.execute(getMethod)) {
-            var metadata = getNodeFromResponse(resp, "metadata");
+            var metadata = getMetadataFromResponse(resp);
 
             assertSuccessfulResponse(resp);
             // should only find the five default objects, not the dated admin unit or dated collection
@@ -377,8 +378,8 @@ public class SearchEndpointIT extends EndpointIT {
 
             assertSuccessfulResponse(resp);
             // should find all available languages: English, Cherokee
-            assertValuePresent(languageFields,0,"value", "English");
-            assertValuePresent(languageFields,1,"value", "Cherokee");
+            assertValuePresent(languageFields, 0, "value", "English");
+            assertValuePresent(languageFields, 1, "value", "Cherokee");
         }
     }
 
@@ -393,12 +394,46 @@ public class SearchEndpointIT extends EndpointIT {
             var facetFields = getNodeFromResponse(resp, "facetFields");
             var languageFields = new ArrayList<JsonNode>();
             facetFields.get(0).get("values").elements().forEachRemaining(languageFields::add);
+            var subjectFields = new ArrayList<JsonNode>();
+            facetFields.get(1).get("values").elements().forEachRemaining(subjectFields::add);
 
             assertSuccessfulResponse(resp);
-            // should find all available languages: English
+            // should find all available languages (English) and subjects (North Carolina)
             assertEquals(2,facetFields.size());
             assertEquals(1,languageFields.size());
-            assertValuePresent(languageFields,0,"value", "English");
+            assertValuePresent(languageFields, 0, "value", "English");
+            assertValuePresent(subjectFields, 0, "value", "North Carolina");
         }
+    }
+
+    public List<String> createDatedObjects() throws Exception {
+        List<String> ids = new ArrayList<>();
+        var datedAdminUnit = adminUnitFactory.createAdminUnit(
+                Map.of("title", "Dated Admin Object", "dateCreated", "2018-07-01"));
+        var datedCollection = collectionFactory.createCollection(datedAdminUnit,
+                Map.of("title", "A dated collection",
+                        "dateCreated", "2022-07-01",
+                        "readGroup", "everyone"));
+        ids.add(datedAdminUnit.getPid().getId());
+        ids.add(datedCollection.getPid().getId());
+        return ids;
+    }
+
+    public void createLanguageSubjectObjects() throws Exception {
+        var languageAdminUnit = adminUnitFactory.createAdminUnit(
+                Map.of("title", "Admin Object", "languageTerm", "eng"));
+        collectionFactory.createCollection(languageAdminUnit,
+                Map.of("title", "A language collection",
+                        "languageTerm", "eng",
+                        "readGroup", "everyone"));
+        folderFactory.createFolder(collection,
+                Map.of("title","A language folder","languageTerm", "eng",
+                        "topic", "North Carolina","readGroup", "everyone"));
+        adminUnitFactory.createAdminUnit(Map.of(
+                "title", "English Language Admin", "languageTerm", "eng",
+                "topic", "North Carolina", "readGroup", "everyone"));
+        adminUnitFactory.createAdminUnit(Map.of(
+                "title", "Cherokee Language Admin", "languageTerm", "chr",
+                "topic", "UNC", "readGroup", "everyone"));
     }
 }


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-3732](https://jira.lib.unc.edu/browse/BXC-3732)

- add language and subject facets to `ModsFactory.java`
- modify `getNodeFromResponse` (previously `getMetadataFromResponse`)
- move `createDatedObjects` and add `createLanguageSubjectObjects` to `EndpointIT.java`
- add integration tests for language and subject facet filter searches to `SearchEndpointIT.java`