### PR TITLE
BXC-3758 adding test and methods to get parentCollectionId

### DIFF
--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/models/ContentObjectRecord.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/models/ContentObjectRecord.java
@@ -63,6 +63,8 @@ public interface ContentObjectRecord {
 
     public String getParentCollection();
 
+    public String getParentCollectionId();
+
     public String getRollup();
 
     public Long get_version_();

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecord.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecord.java
@@ -52,6 +52,7 @@ public class ContentObjectSolrRecord extends IndexDocumentBean implements Conten
     protected ObjectPath objectPath;
     protected String ancestorNames;
     protected String parentName;
+    protected String parentId;
     protected List<HierarchicalFacet> contentTypeFacet;
     protected List<Datastream> datastreamObjects;
     // Inverted map of the roleGroup, clustering roles into buckets by group
@@ -222,6 +223,19 @@ public class ContentObjectSolrRecord extends IndexDocumentBean implements Conten
         var facetVal = new FilterableDisplayValueFacet(SearchFieldKey.PARENT_COLLECTION.name(), parentCollection);
         parentName = facetVal.getDisplayValue();
         return parentName;
+    }
+
+    public String getParentCollectionId() {
+        if (parentId != null) {
+            return parentId;
+        }
+        String parentCollection = getParentCollection();
+        if (StringUtils.isBlank(parentCollection)) {
+            return null;
+        }
+        // split the parent collection string at | and get the second part
+        parentId = parentCollection.split("[|]")[1];
+        return parentId;
     }
 
     @Override

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/GroupedContentObjectSolrRecord.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/GroupedContentObjectSolrRecord.java
@@ -118,6 +118,10 @@ public class GroupedContentObjectSolrRecord implements GroupedContentObjectRecor
         return this.representative.getParentCollectionName();
     }
 
+    public String getParentCollectionId() {
+        return this.representative.getParentCollectionId();
+    }
+
     @Override
     public String getCollectionId() {
         return this.representative.getCollectionId();

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecordTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecordTest.java
@@ -44,4 +44,13 @@ public class ContentObjectSolrRecordTest extends Assert {
         assertEquals(2, mdb.getGroupRoleMap().size());
         assertEquals(2, mdb.getRoleGroup().size());
     }
+
+    @Test
+    public void getParentCollectionNameAndId() {
+        ContentObjectSolrRecord solrRecord = new ContentObjectSolrRecord();
+        solrRecord.setParentCollection("Best Collection|ee8604fb-6d12-4c42-a42f-7fa68679ccbb");
+
+        assertEquals("Best Collection", solrRecord.getParentCollectionName());
+        assertEquals("ee8604fb-6d12-4c42-a42f-7fa68679ccbb", solrRecord.getParentCollectionId());
+    }
 }

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecordTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/models/ContentObjectSolrRecordTest.java
@@ -48,8 +48,10 @@ public class ContentObjectSolrRecordTest extends Assert {
     @Test
     public void getParentCollectionNameAndId() {
         ContentObjectSolrRecord solrRecord = new ContentObjectSolrRecord();
-        solrRecord.setParentCollection("Best Collection|ee8604fb-6d12-4c42-a42f-7fa68679ccbb");
+        var parentString = "Best Collection|ee8604fb-6d12-4c42-a42f-7fa68679ccbb";
+        solrRecord.setParentCollection(parentString);
 
+        assertEquals(parentString, solrRecord.getParentCollection());
         assertEquals("Best Collection", solrRecord.getParentCollectionName());
         assertEquals("ee8604fb-6d12-4c42-a42f-7fa68679ccbb", solrRecord.getParentCollectionId());
     }

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -75,7 +75,7 @@
                             </c:if>
                             <c:if test="${not empty briefObject.parentCollection && briefObject.ancestorPathFacet.highestTier > 0}">
                                 <li>
-                                    <c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollection}" />
+                                    <c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollectionId}" />
                                     <span class="has-text-weight-bold">Collection:</span>
                                     <a href="<c:out value='${parentUrl}' />"><c:out value="${briefObject.parentCollectionName}"/></a>
                                 </li>

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -72,7 +72,7 @@
                     </c:if>
                     <c:if test="${not empty briefObject.parentCollection && briefObject.ancestorPathFacet.highestTier > 0}">
                         <li>
-                            <c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollection}" />
+                            <c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollectionId}" />
                             <span class="has-text-weight-bold">Collection:</span>
                             <a href="<c:out value='${parentUrl}' />"><c:out value="${briefObject.parentCollectionName}"/></a>
                         </li>

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
@@ -54,7 +54,7 @@
             <c:if test="${not empty briefObject.dateAdded}">
                 <p><strong>${searchSettings.searchFieldLabels['DATE_ADDED']}:</strong> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateAdded}" /></p>
             </c:if>
-            <p><strong>Collection:</strong> <a href="<c:out value="record/${briefObject.parentCollection}"/>"><c:out value="${briefObject.parentCollectionName}"/></a></p>
+            <p><strong>Collection:</strong> <a href="<c:out value="record/${briefObject.parentCollectionId}"/>"><c:out value="${briefObject.parentCollectionName}"/></a></p>
             <c:if test="${not empty collectionId}">
                 <p><strong>Collection Number: </strong><c:out value="${collectionId}"></c:out></p>
             </c:if>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3758

As Ben notes, the url is getting generated with a value like:
https://dcr-test.lib.unc.edu/record/This%20is%20a%20serial%20title%7Ca168cf29-a2a9-4da8-9b8d-025855b180d5
but it should be:
https://dcr-test.lib.unc.edu/record/a168cf29-a2a9-4da8-9b8d-025855b180d5

so this PR adds methods to get the second part of the string and return it accordingly