### PR TITLE
BXC-3762 - Index member ordering

### DIFF
--- a/etc/solr-config/access/conf/schema.xml
+++ b/etc/solr-config/access/conf/schema.xml
@@ -187,6 +187,8 @@
     <!-- Timestamp when this record was fully indexed -->
     <field name="lastIndexed" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
     <field name="location" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <!-- Sort order of members within their parent container, if custom ordering is specified -->
+    <field name="memberOrderId" type="int" indexed="true" stored="true" docValues="true" sortMissingLast="true"/>
     <!-- Alternative subjects, not searchable, for use in copy indexes -->
     <field name="otherSubject" type="string" indexed="false" stored="true" multiValued="true"/>
     <!-- Alternative titles, not searchable, for use in copy indexes -->

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/action/SeparateRootAndDescendantsUpdateAction.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/action/SeparateRootAndDescendantsUpdateAction.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.indexing.solr.action;
+
+import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
+import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Action which performs indexing of a tree of objects, where the root of the tree and its children
+ * are indexed with separate indexing actions.
+ *
+ * @author bbpennel
+ */
+public class SeparateRootAndDescendantsUpdateAction extends AbstractIndexingAction {
+    private static final Logger log = LoggerFactory.getLogger(SeparateRootAndDescendantsUpdateAction.class);
+    private IndexingActionType rootActionType;
+    private IndexingActionType descendantsActionType;
+    private RecursiveTreeIndexer treeIndexer;
+    private IndexingMessageSender messageSender;
+
+    @Override
+    public void performAction(SolrUpdateRequest updateRequest) throws IndexingException {
+        log.debug("Queuing update of root {}", updateRequest.getPid());
+        indexRoot(updateRequest);
+        log.debug("Queuing update of descendants of {}", updateRequest.getPid());
+        indexDescendents(updateRequest);
+        log.debug("Finished queuing updates for root and descendants for {}.", updateRequest.getPid());
+    }
+
+    private void indexRoot(SolrUpdateRequest updateRequest) throws IndexingException {
+        messageSender.sendIndexingOperation(updateRequest.getUserID(), updateRequest.getPid(), rootActionType);
+    }
+
+    private void indexDescendents(SolrUpdateRequest updateRequest) throws IndexingException {
+        treeIndexer.indexChildren(updateRequest.getPid(), descendantsActionType, updateRequest.getUserID());
+    }
+
+    /**
+     * @param treeIndexer the treeIndexer to set
+     */
+    public void setTreeIndexer(RecursiveTreeIndexer treeIndexer) {
+        this.treeIndexer = treeIndexer;
+    }
+
+    public void setMessageSender(IndexingMessageSender messageSender) {
+        this.messageSender = messageSender;
+    }
+
+    public void setRootActionType(IndexingActionType rootActionType) {
+        this.rootActionType = rootActionType;
+    }
+
+    public void setDescendantsActionType(IndexingActionType descendantsActionType) {
+        this.descendantsActionType = descendantsActionType;
+    }
+}

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/action/SeparateRootAndDescendantsUpdateAction.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/action/SeparateRootAndDescendantsUpdateAction.java
@@ -40,7 +40,7 @@ public class SeparateRootAndDescendantsUpdateAction extends AbstractIndexingActi
         log.debug("Queuing update of root {}", updateRequest.getPid());
         indexRoot(updateRequest);
         log.debug("Queuing update of descendants of {}", updateRequest.getPid());
-        indexDescendents(updateRequest);
+        indexDescendants(updateRequest);
         log.debug("Finished queuing updates for root and descendants for {}.", updateRequest.getPid());
     }
 
@@ -48,7 +48,7 @@ public class SeparateRootAndDescendantsUpdateAction extends AbstractIndexingActi
         messageSender.sendIndexingOperation(updateRequest.getUserID(), updateRequest.getPid(), rootActionType);
     }
 
-    private void indexDescendents(SolrUpdateRequest updateRequest) throws IndexingException {
+    private void indexDescendants(SolrUpdateRequest updateRequest) throws IndexingException {
         treeIndexer.indexChildren(updateRequest.getPid(), descendantsActionType, updateRequest.getUserID());
     }
 

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.indexing.solr.filter;
+
+import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
+import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
+import edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Filter which sets the member order. Updates the memberOrderId field.
+ *
+ * @author bbpennel
+ */
+public class SetMemberOrderFilter implements IndexDocumentFilter {
+    private static final Logger log = LoggerFactory.getLogger(SetMemberOrderFilter.class);
+
+    private MemberOrderService memberOrderService;
+
+    @Override
+    public void filter(DocumentIndexingPackage dip) throws IndexingException {
+        log.debug("Performing SetMemberOrderFilter for object {}", dip.getPid());
+        var orderId = memberOrderService.getOrderValue(dip.getContentObject());
+        var doc = dip.getDocument();
+        doc.setMemberOrderId(orderId);
+    }
+
+    public void setMemberOrderService(MemberOrderService memberOrderService) {
+        this.memberOrderService = memberOrderService;
+    }
+}

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
@@ -15,10 +15,14 @@
  */
 package edu.unc.lib.boxc.indexing.solr.utils;
 
+import com.googlecode.concurrentlinkedhashmap.ConcurrentLinkedHashMap;
+import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Service which produces a sortable identifier for ordering members within their parent
@@ -26,7 +30,14 @@ import edu.unc.lib.boxc.model.api.objects.WorkObject;
  * @author bbpennel
  */
 public class MemberOrderService {
-    private RepositoryObjectLoader repositoryObjectLoader;
+    private final static int CACHE_SIZE = 64;
+    private Map<PID, List<PID>> cache;
+
+    public void init() {
+        var mapBuilder = new ConcurrentLinkedHashMap.Builder<PID, List<PID>>();
+        mapBuilder.maximumWeightedCapacity(CACHE_SIZE);
+        cache = mapBuilder.build();
+    }
 
     /**
      * Gets the order id for the provided member within its parent
@@ -36,15 +47,28 @@ public class MemberOrderService {
      */
     public Integer getOrderValue(RepositoryObject memberObj) {
         if (memberObj instanceof FileObject) {
-            var parent = (WorkObject) memberObj.getParent();
-            var order = parent.getMemberOrder();
+            var parentPid = memberObj.getParentPid();
+            List<PID> order;
+            // Get order info from cache if available
+            if (cache.containsKey(parentPid)) {
+                order = cache.get(parentPid);
+            } else {
+                // Otherwise, retrieve it from the parent and cache it
+                var parent = (WorkObject) memberObj.getParent();
+                order = parent.getMemberOrder();
+                cache.put(parentPid, order);
+            }
             var index = order.indexOf(memberObj.getPid());
             return index == -1 ? null : index;
         }
         return null;
     }
 
-    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
-        this.repositoryObjectLoader = repositoryObjectLoader;
+    /**
+     * Invalidate a cached member entry
+     * @param pid
+     */
+    public void invalidate(PID pid) {
+        cache.remove(pid);
     }
 }

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
@@ -71,4 +71,11 @@ public class MemberOrderService {
     public void invalidate(PID pid) {
         cache.remove(pid);
     }
+
+    /**
+     * Invalidate all cached entries
+     */
+    public void invalidateAll() {
+        cache.clear();
+    }
 }

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.indexing.solr.utils;
+
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+
+/**
+ * Service which produces a sortable identifier for ordering members within their parent
+ *
+ * @author bbpennel
+ */
+public class MemberOrderService {
+    private RepositoryObjectLoader repositoryObjectLoader;
+
+    /**
+     * Gets the order id for the provided member within its parent
+     * @param memberObj the member object
+     * @return the sortable order value for the member relative to its siblings within its parent.
+     *      Null if its parent does not support ordering, or if the member is not ordered within its parent.
+     */
+    public Integer getOrderValue(RepositoryObject memberObj) {
+        if (memberObj instanceof FileObject) {
+            var parent = (WorkObject) memberObj.getParent();
+            var order = parent.getMemberOrder();
+            var index = order.indexOf(memberObj.getPid());
+            return index == -1 ? null : index;
+        }
+        return null;
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repositoryObjectLoader = repositoryObjectLoader;
+    }
+}

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderService.java
@@ -46,22 +46,22 @@ public class MemberOrderService {
      *      Null if its parent does not support ordering, or if the member is not ordered within its parent.
      */
     public Integer getOrderValue(RepositoryObject memberObj) {
-        if (memberObj instanceof FileObject) {
-            var parentPid = memberObj.getParentPid();
-            List<PID> order;
-            // Get order info from cache if available
-            if (cache.containsKey(parentPid)) {
-                order = cache.get(parentPid);
-            } else {
-                // Otherwise, retrieve it from the parent and cache it
-                var parent = (WorkObject) memberObj.getParent();
-                order = parent.getMemberOrder();
-                cache.put(parentPid, order);
-            }
-            var index = order.indexOf(memberObj.getPid());
-            return index == -1 ? null : index;
+        if (!(memberObj instanceof FileObject)) {
+            return null;
         }
-        return null;
+        var parentPid = memberObj.getParentPid();
+        List<PID> order;
+        // Get order info from cache if available
+        if (cache.containsKey(parentPid)) {
+            order = cache.get(parentPid);
+        } else {
+            // Otherwise, retrieve it from the parent and cache it
+            var parent = (WorkObject) memberObj.getParent();
+            order = parent.getMemberOrder();
+            cache.put(parentPid, order);
+        }
+        var index = order.indexOf(memberObj.getPid());
+        return index == -1 ? null : index;
     }
 
     /**

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilterTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.indexing.solr.filter;
+
+import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
+import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
+import edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * @author bbpennel
+ */
+public class SetMemberOrderFilterTest {
+    private static final String SUBJECT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+
+    @Mock
+    private MemberOrderService memberOrderService;
+    @Mock
+    private DocumentIndexingPackageDataLoader documentIndexingPackageDataLoader;
+    private SetMemberOrderFilter filter;
+
+    private DocumentIndexingPackage dip;
+    private IndexDocumentBean idb;
+    private PID subjectPid;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        subjectPid = PIDs.get(SUBJECT_UUID);
+        dip = new DocumentIndexingPackage(subjectPid, null, documentIndexingPackageDataLoader);
+        dip.setPid(subjectPid);
+        idb = dip.getDocument();
+        filter = new SetMemberOrderFilter();
+        filter.setMemberOrderService(memberOrderService);
+    }
+
+    @Test
+    public void withFileInUnorderedWorkTest() {
+        var subject = mock(FileObject.class);
+        when(documentIndexingPackageDataLoader.getContentObject(dip)).thenReturn(subject);
+        when(memberOrderService.getOrderValue(subject)).thenReturn(null);
+
+        filter.filter(dip);
+
+        assertNull(idb.getMemberOrderId());
+    }
+
+    @Test
+    public void withFileInOrderedWorkTest() {
+        Integer expected = Integer.valueOf(4);
+        var subject = mock(FileObject.class);
+        when(documentIndexingPackageDataLoader.getContentObject(dip)).thenReturn(subject);
+        when(memberOrderService.getOrderValue(subject)).thenReturn(expected);
+
+        filter.filter(dip);
+
+        assertEquals(expected, idb.getMemberOrderId());
+    }
+}

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.indexing.solr.utils;
+
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.AdminUnit;
+import edu.unc.lib.boxc.model.api.objects.CollectionObject;
+import edu.unc.lib.boxc.model.api.objects.ContentRootObject;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.FolderObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bbpennel
+ */
+public class MemberOrderServiceTest {
+    private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
+
+    @Mock
+    private RepositoryObjectLoader repositoryObjectLoader;
+    private MemberOrderService memberOrderService;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        memberOrderService = new MemberOrderService();
+        memberOrderService.setRepositoryObjectLoader(repositoryObjectLoader);
+
+    }
+
+    @Test
+    public void getOrderValueForAdminUnitTest() {
+        orderNotSupportedTest(AdminUnit.class, ContentRootObject.class);
+    }
+
+    @Test
+    public void getOrderValueForCollectionTest() {
+        orderNotSupportedTest(CollectionObject.class, AdminUnit.class);
+    }
+
+    @Test
+    public void getOrderValueForFolderTest() {
+        orderNotSupportedTest(FolderObject.class, CollectionObject.class);
+    }
+
+    @Test
+    public void getOrderValueForWorkTest() {
+        orderNotSupportedTest(WorkObject.class, FolderObject.class);
+    }
+
+    private void orderNotSupportedTest(Class<? extends RepositoryObject> memberClass,
+                                       Class<? extends RepositoryObject> parentClass) {
+        var subject = mockRepositoryObject(memberClass, CHILD1_UUID);
+        var parent = mockRepositoryObject(parentClass, PARENT_UUID);
+        associateWithParent(subject, parent);
+
+        assertNull(memberOrderService.getOrderValue(subject));
+    }
+
+    @Test
+    public void getOrderValueForFileInUnorderedWorkTest() {
+        var subject = mockRepositoryObject(FileObject.class, CHILD1_UUID);
+        var parent = mockRepositoryObject(WorkObject.class, PARENT_UUID);
+        associateWithParent(subject, parent);
+
+        assertNull(memberOrderService.getOrderValue(subject));
+    }
+
+    @Test
+    public void getOrderValueWithFileNotListedInOrderTest() {
+        var subject1 = mockRepositoryObject(FileObject.class, CHILD1_UUID);
+        var subject2 = mockRepositoryObject(FileObject.class, CHILD2_UUID);
+        var parent = mockRepositoryObject(WorkObject.class, PARENT_UUID);
+        associateWithParent(subject1, parent);
+        associateWithParent(subject2, parent);
+        when(parent.getMemberOrder()).thenReturn(pidList(CHILD2_UUID));
+
+        assertNull(memberOrderService.getOrderValue(subject1));
+        assertEquals(Integer.valueOf(0), memberOrderService.getOrderValue(subject2));
+    }
+
+    @Test
+    public void getOrderValueForOrderedFileInSingleFileWorkTest() {
+        var subject = mockRepositoryObject(FileObject.class, CHILD1_UUID);
+        var parent = mockRepositoryObject(WorkObject.class, PARENT_UUID);
+        associateWithParent(subject, parent);
+        when(parent.getMemberOrder()).thenReturn(pidList(CHILD1_UUID));
+
+        assertEquals(Integer.valueOf(0), memberOrderService.getOrderValue(subject));
+    }
+
+    @Test
+    public void getOrderValueForInMultiFileWorkTest() {
+        var subject = mockRepositoryObject(FileObject.class, CHILD1_UUID);
+        var parent = mockRepositoryObject(WorkObject.class, PARENT_UUID);
+        associateWithParent(subject, parent);
+        when(parent.getMemberOrder()).thenReturn(pidList(
+                randomUuid(), randomUuid(), randomUuid(), CHILD1_UUID, randomUuid()));
+
+        assertEquals(Integer.valueOf(3), memberOrderService.getOrderValue(subject));
+    }
+
+    private <T> T mockRepositoryObject(Class<T> classToMock, String uuid) {
+        var subject = mock(classToMock);
+        when(((RepositoryObject) subject).getPid()).thenReturn(PIDs.get(uuid));
+        return subject;
+    }
+
+    private void associateWithParent(RepositoryObject child, RepositoryObject parent) {
+        when(child.getParent()).thenReturn(parent);
+        when(child.getParentPid()).thenReturn(PIDs.get(PARENT_UUID));
+    }
+
+    private List<PID> pidList(String... uuids) {
+        return Arrays.stream(uuids).map(PIDs::get).collect(Collectors.toList());
+    }
+
+    private String randomUuid() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/integration/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/integration/src/test/resources/spring-test/solr-indexing-context.xml
@@ -27,6 +27,7 @@
                 <ref bean="setContentStatusFilter" />
                 <ref bean="setFullTextFilter" />
                 <ref bean="setObjectTypeFilter" />
+                <ref bean="setMemberOrderFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
             </list>
         </property>
@@ -143,6 +144,10 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
+    <bean id="memberOrderService" class="edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService"
+          init-method="init">
+    </bean>
+
     <bean id="titleRetrievalService" class="edu.unc.lib.boxc.search.solr.services.TitleRetrievalService"
           init-method="init">
         <property name="solrSearchService" ref="solrSearchService" />
@@ -199,6 +204,10 @@
 
     <bean id="setRecordDatesFilter"
           class="edu.unc.lib.boxc.indexing.solr.filter.SetRecordDatesFilter">
+    </bean>
+
+    <bean id="setMemberOrderFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetMemberOrderFilter">
+        <property name="memberOrderService" ref="memberOrderService" />
     </bean>
 
     <bean id="dipDataLoader"

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.boxc.model.api.objects;
 
 import java.net.URI;
+import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
 
@@ -83,4 +84,10 @@ public interface WorkObject extends ContentContainerObject {
     FileObject addDataFile(PID filePid, URI storageUri, String filename, String mimetype, String sha1Checksum,
             String md5Checksum, Model model);
 
+    /**
+     * Retrieves the list of ordered member ids within this container
+     *
+     * @return Ordered list of member ids, or an empty list if members aren't ordered.
+     */
+    List<PID> getMemberOrder();
 }

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
@@ -16,6 +16,10 @@
 package edu.unc.lib.boxc.model.fcrepo.objects;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import edu.unc.lib.boxc.model.api.exceptions.TombstoneFoundException;
@@ -212,5 +216,14 @@ public class WorkObjectImpl extends AbstractContentContainerObject implements Wo
         shouldRefresh();
 
         return fileObj;
+    }
+
+    @Override
+    public List<PID> getMemberOrder() {
+        var memberOrder = getResource().getProperty(Cdr.memberOrder);
+        if (memberOrder == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(memberOrder.getString().split("\\|")).map(PIDs::get).collect(Collectors.toList());
     }
 }

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
@@ -224,6 +224,9 @@ public class WorkObjectImpl extends AbstractContentContainerObject implements Wo
         if (memberOrder == null) {
             return Collections.emptyList();
         }
-        return Arrays.stream(memberOrder.getString().split("\\|")).map(PIDs::get).collect(Collectors.toList());
+        // Split the value from fedora up by pipes, convert into PID objects, return as a list
+        return Arrays.stream(memberOrder.getString().split("\\|"))
+                .map(PIDs::get)
+                .collect(Collectors.toList());
     }
 }

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
@@ -290,7 +290,8 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
         var member2 = makePid();
         var member3 = makePid();
         var members = Arrays.asList(member1, member2, member3);
-        resc.addProperty(Cdr.memberOrder, members.stream().map(PID::getId).collect(Collectors.joining("|")));
+        var memberValue = member1.getId() + "|" + member2.getId() + "|" + member3.getId();
+        resc.addProperty(Cdr.memberOrder, memberValue);
         assertEquals(members, work.getMemberOrder());
     }
 

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
@@ -31,8 +31,10 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -275,6 +277,21 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
     public void addDataFileNoContentTest() {
 
         work.addDataFile(null, FILENAME, MIMETYPE, SHA1, MD5);
+    }
+
+    @Test
+    public void getMemberOrderNotSet() {
+        assertEquals(Collections.emptyList(), work.getMemberOrder());
+    }
+
+    @Test
+    public void getMemberOrderWithMembers() {
+        var member1 = makePid();
+        var member2 = makePid();
+        var member3 = makePid();
+        var members = Arrays.asList(member1, member2, member3);
+        resc.addProperty(Cdr.memberOrder, members.stream().map(PID::getId).collect(Collectors.joining("|")));
+        assertEquals(members, work.getMemberOrder());
     }
 
     private PID makePid() {

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
@@ -63,6 +63,8 @@ public enum IndexingActionType {
             "Update the resource type of a set of objects and all their children"),
     SET_PRIMARY_OBJECT("Set Primary Object", "Update the primary object for a work"),
     UPDATE_MEMBER_ORDER("Update Member Order", "Update the order of members within an object"),
+    UPDATE_MEMBER_ORDER_CHILD("Update Member Order Child", "Update the order of a member of a container"),
+    UPDATE_MEMBER_ORDER_PARENT("Update Member Order Parent", "Update a container after its order changed"),
     UNKNOWN("Unknown action", "Unknown action");
 
     private final String label;

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingActionType.java
@@ -63,7 +63,7 @@ public enum IndexingActionType {
             "Update the resource type of a set of objects and all their children"),
     SET_PRIMARY_OBJECT("Set Primary Object", "Update the primary object for a work"),
     UPDATE_MEMBER_ORDER("Update Member Order", "Update the order of members within an object"),
-    UPDATE_MEMBER_ORDER_CHILD("Update Member Order Child", "Update the order of a member of a container"),
+    UPDATE_MEMBER_ORDER_CHILD("Update Member Order Child", "Update the order of a container member"),
     UPDATE_MEMBER_ORDER_PARENT("Update Member Order Parent", "Update a container after its order changed"),
     UNKNOWN("Unknown action", "Unknown action");
 

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
@@ -59,6 +59,7 @@ public enum SearchFieldKey {
     LANGUAGE("language", "language", "Language"),
     LAST_INDEXED("lastIndexed", "lastIndexed", "lastIndexed"),
     LOCATION("location", "location", "Location"),
+    MEMBER_ORDER_ID("memberOrderId", "memberOrderId", "Member Order ID"),
     OTHER_SUBJECT("otherSubject", "otherSubject", "Other Subject"),
     OTHER_TITLE("otherTitle", "otherTitle", "otherTitle"),
     PARENT_COLLECTION("parentCollection", "collection", "Collection"),

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/models/ContentObjectRecord.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/models/ContentObjectRecord.java
@@ -103,6 +103,8 @@ public interface ContentObjectRecord {
 
     public String getIdentifierSort();
 
+    public Integer getMemberOrderId();
+
     public String getTitle();
 
     public String getAncestorNames();

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/GroupedContentObjectSolrRecord.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/GroupedContentObjectSolrRecord.java
@@ -373,6 +373,11 @@ public class GroupedContentObjectSolrRecord implements GroupedContentObjectRecor
     }
 
     @Override
+    public Integer getMemberOrderId() {
+        return representative.getMemberOrderId();
+    }
+
+    @Override
     public String getThumbnailId() {
         return representative.getThumbnailId();
     }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/IndexDocumentBean.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/models/IndexDocumentBean.java
@@ -314,6 +314,15 @@ public class IndexDocumentBean {
         fields.put(IDENTIFIER_SORT.getSolrField(), identifierSort);
     }
 
+    public Integer getMemberOrderId() {
+        return (Integer) fields.get(SearchFieldKey.MEMBER_ORDER_ID.getSolrField());
+    }
+
+    @Field
+    public void setMemberOrderId(Integer value) {
+        fields.put(SearchFieldKey.MEMBER_ORDER_ID.getSolrField(), value);
+    }
+
     public String getTitle() {
         return (String) fields.get(TITLE.getSolrField());
     }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.services.camel.util;
 
 import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
 import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService;
 import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDConstants;
@@ -44,6 +45,7 @@ public class CacheInvalidatingProcessor implements Processor {
     private ObjectAclFactory objectAclFactory;
     private ContentPathFactory contentPathFactory;
     private TitleRetrievalService titleRetrievalService;
+    private MemberOrderService memberOrderService;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -77,6 +79,7 @@ public class CacheInvalidatingProcessor implements Processor {
         repoObjLoader.invalidate(pid);
         objectAclFactory.invalidate(pid);
         contentPathFactory.invalidate(pid);
+        memberOrderService.invalidate(pid);
         if (pid.getComponentPath() == null || pid.getComponentPath().contains(DatastreamType.MD_DESCRIPTIVE.getId())) {
             titleRetrievalService.invalidate(pid);
         }
@@ -96,5 +99,9 @@ public class CacheInvalidatingProcessor implements Processor {
 
     public void setTitleRetrievalService(TitleRetrievalService titleRetrievalService) {
         this.titleRetrievalService = titleRetrievalService;
+    }
+
+    public void setMemberOrderService(MemberOrderService memberOrderService) {
+        this.memberOrderService = memberOrderService;
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/IndexingActionUtil.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/IndexingActionUtil.java
@@ -48,6 +48,7 @@ public class IndexingActionUtil {
                     ADD_SET_TO_PARENT,
                     UPDATE_ACCESS_TREE,
                     DELETE_CHILDREN_PRIOR_TO_TIMESTAMP,
+                    IndexingActionType.UPDATE_MEMBER_ORDER,
                     UPDATE_PARENT_PATH_TREE);
 
     // Indexing actions which impact one object, or no objects directly
@@ -60,6 +61,8 @@ public class IndexingActionUtil {
                     IndexingActionType.UPDATE_WORK_FILES,
                     IndexingActionType.UPDATE_FULL_TEXT,
                     IndexingActionType.UPDATE_PARENT_PATH_INFO,
+                    IndexingActionType.UPDATE_MEMBER_ORDER_CHILD,
+                    IndexingActionType.UPDATE_MEMBER_ORDER_PARENT,
                     IndexingActionType.COMMIT,
                     IndexingActionType.DELETE);
 }

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -208,6 +208,7 @@
         <property name="objectAclFactory" ref="objectAclFactory" />
         <property name="contentPathFactory" ref="contentPathFactory" />
         <property name="titleRetrievalService" ref="titleRetrievalService" />
+        <property name="memberOrderService" ref="memberOrderService" />
     </bean>
 
     <bean id="addSmallThumbnailProcessor" class="edu.unc.lib.boxc.services.camel.images.AddDerivativeProcessor">

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -31,6 +31,7 @@
                 <ref bean="setContentStatusFilter" />
                 <ref bean="setFullTextFilter" />
                 <ref bean="setObjectTypeFilter" />
+                <ref bean="setMemberOrderFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
             </list>
         </property>
@@ -126,6 +127,26 @@
         </property>
     </bean>
 
+    <bean id="solrOrderMembersParentUpdatePipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setContentStatusFilter" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="solrOrderMembersChildUpdatePipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setMemberOrderFilter" />
+            </list>
+        </property>
+    </bean>
+
     <bean id="solrUpdateDriver"
         class="edu.unc.lib.boxc.indexing.solr.indexing.SolrUpdateDriver"
         init-method="init">
@@ -196,6 +217,10 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
+    <bean id="memberOrderService" class="edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService"
+          init-method="init">
+    </bean>
+
     <bean id="titleRetrievalService" class="edu.unc.lib.boxc.search.solr.services.TitleRetrievalService"
           init-method="init">
         <property name="solrSearchService" ref="queryLayer" />
@@ -252,6 +277,10 @@
     
     <bean id="setRecordDatesFilter"
         class="edu.unc.lib.boxc.indexing.solr.filter.SetRecordDatesFilter">
+    </bean>
+
+    <bean id="setMemberOrderFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetMemberOrderFilter">
+        <property name="memberOrderService" ref="memberOrderService" />
     </bean>
 
     <!-- Ingest Actions -->
@@ -397,6 +426,26 @@
         <property name="actionType" value="ADD" />
         <property name="treeIndexer" ref="recursiveTreeIndexer" />
     </bean>
+
+    <bean id="updateMemberOrderTreeAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.SeparateRootAndDescendantsUpdateAction">
+        <property name="rootActionType" value="UPDATE_MEMBER_ORDER_PARENT" />
+        <property name="descendantsActionType" value="UPDATE_MEMBER_ORDER_CHILD" />
+        <property name="treeIndexer" ref="recursiveTreeIndexer" />
+        <property name="messageSender" ref="indexingMessageSender" />
+    </bean>
+
+    <bean id="updateMemberOrderParentAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrOrderMembersParentUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
+
+    <bean id="updateMemberOrderChildAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrOrderMembersChildUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
     
     <util:map id="solrIndexingActionMap"
         key-type="edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType"
@@ -423,6 +472,9 @@
         <entry key="ADD_SET_TO_PARENT" value-ref="addSetToParentAction" />
         <entry key="UPDATE_TYPE" value-ref="updateTypeAction" />
         <entry key="UPDATE_TYPE_TREE" value-ref="updateTypeTreeAction" />
+        <entry key="UPDATE_MEMBER_ORDER" value-ref="updateMemberOrderTreeAction" />
+        <entry key="UPDATE_MEMBER_ORDER_PARENT" value-ref="updateMemberOrderParentAction" />
+        <entry key="UPDATE_MEMBER_ORDER_CHILD" value-ref="updateMemberOrderChildAction" />
     </util:map>
     
     <bean id="dipDataLoader"

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
@@ -173,7 +173,7 @@ public class OrderRequestProcessorTest {
     @Test
     public void invalidRequestTest() throws Exception {
         var errors = new String[] { "This doesn't look good", "Whoa no thanks" };
-        produceInvalidValidator(PARENT1_UUID, errors);
+        produceValidatorWithErrors(PARENT1_UUID, errors);
 
         var requestExchange = createRequestExchange(Map.of(PARENT1_UUID, Arrays.asList(CHILD1_UUID)));
         processor.process(requestExchange);
@@ -225,7 +225,7 @@ public class OrderRequestProcessorTest {
         var validationError = "Bad bad very not good";
         // All requests except for one for PARENT1 are valid
         mockRequestAsValid();
-        produceInvalidValidator(PARENT1_UUID, validationError);
+        produceValidatorWithErrors(PARENT1_UUID, validationError);
         // Second one does not have permission
         mockDoesNotHavePermission(PARENT2_UUID);
 
@@ -286,7 +286,7 @@ public class OrderRequestProcessorTest {
     }
 
     // Setup production of a validator that will return errors for the given id
-    private void produceInvalidValidator(String uuid, String... errors) {
+    private void produceValidatorWithErrors(String uuid, String... errors) {
         var validator = mock(OrderValidator.class);
         when(validator.isValid()).thenReturn(false);
         when(validator.getErrors()).thenReturn(Arrays.asList(errors));

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -417,8 +417,7 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
         // Update the work's record in the triple store
         treeIndexer.indexTree(workObj.getModel());
 
-        System.out.println("Model for work: " + workObj.getModel(true));
-
+        // Initial message should produce 4 individual record indexing messages, need to wait for all 5
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
                 .whenCompleted(5)
                 .create();

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -452,10 +452,9 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
         var fileObject = work.addDataFile(file.toPath().toUri(), filename, null, null, null);
 
         var fitsPid = DatastreamPids.getTechnicalMetadataPid(fileObject.getPid());
-        var fitsUri = Objects.requireNonNull(
-                this.getClass().getResource("/datastream/techmd.xml")).toURI();
-        // add FITS file. Same one for all formats at the moment
-        fileObject.addBinary(fitsPid, fitsUri, TECHNICAL_METADATA.getDefaultFilename(), TECHNICAL_METADATA.getMimetype(),
+        var fitsFile = tmpFolder.newFile();
+        FileUtils.copyInputStreamToFile(this.getClass().getResourceAsStream("/datastream/techmd.xml"), fitsFile);
+        fileObject.addBinary(fitsPid, fitsFile.toURI(), TECHNICAL_METADATA.getDefaultFilename(), TECHNICAL_METADATA.getMimetype(),
                 null, null, IanaRelation.derivedfrom, DCTerms.conformsTo, createResource(FITS_URI));
         return fileObject;
     }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.services.camel.util;
 
 import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
 import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDConstants;
 import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
@@ -54,6 +55,8 @@ public class CacheInvalidatingProcessorTest {
     private ContentPathFactory contentPathFactory;
     @Mock
     private TitleRetrievalService titleRetrievalService;
+    @Mock
+    private MemberOrderService memberOrderService;
 
     private CacheInvalidatingProcessor processor;
 
@@ -66,6 +69,7 @@ public class CacheInvalidatingProcessorTest {
         processor.setObjectAclFactory(objectAclFactory);
         processor.setContentPathFactory(contentPathFactory);
         processor.setTitleRetrievalService(titleRetrievalService);
+        processor.setMemberOrderService(memberOrderService);
     }
 
     @Test
@@ -79,6 +83,7 @@ public class CacheInvalidatingProcessorTest {
         verify(repoObjLoader).invalidate(pid);
         verify(objectAclFactory).invalidate(pid);
         verify(contentPathFactory).invalidate(pid);
+        verify(memberOrderService).invalidate(pid);
     }
 
     @Test
@@ -91,6 +96,7 @@ public class CacheInvalidatingProcessorTest {
         verify(repoObjLoader, never()).invalidate(any(PID.class));
         verify(objectAclFactory, never()).invalidate(any(PID.class));
         verify(contentPathFactory, never()).invalidate(any(PID.class));
+        verify(memberOrderService, never()).invalidate(any(PID.class));
     }
 
     @Test
@@ -103,6 +109,7 @@ public class CacheInvalidatingProcessorTest {
         verify(repoObjLoader, never()).invalidate(any(PID.class));
         verify(objectAclFactory, never()).invalidate(any(PID.class));
         verify(contentPathFactory, never()).invalidate(any(PID.class));
+        verify(memberOrderService, never()).invalidate(any(PID.class));
     }
 
     private Exchange mockExchange(String rescPath) {

--- a/services-camel-app/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-indexing-it-context.xml
@@ -20,25 +20,6 @@
     <util:set id="accessGroups" set-class="edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl">
         <value>${access.group.admin}</value>
     </util:set>
-
-    <bean id="solrFullUpdatePipeline"
-        class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
-        <property name="filters">
-            <list>
-                <ref bean="setRecordDatesFilter" />
-                <ref bean="setPathFilter" />
-                <ref bean="setAccessControlFilter" />
-                <ref bean="setAccessStatusFilter" />
-                <ref bean="setContentTypeFilter" />
-                <ref bean="setDatastreamFilter" />
-                <ref bean="setDescriptiveMetadataFilter" />
-                <ref bean="setContentStatusFilter" />
-                <ref bean="setFullTextFilter" />
-                <ref bean="setObjectTypeFilter" />
-                <ref bean="setCollectionSupplementalInformationFilter" />
-            </list>
-        </property>
-    </bean>
     
     <bean id="solrAccessControlUpdatePipeline"
         class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
@@ -126,6 +107,26 @@
                 <ref bean="setRecordDatesFilter" />
                 <ref bean="setPathFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="solrOrderMembersParentUpdatePipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setContentStatusFilter" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="solrOrderMembersChildUpdatePipeline"
+          class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline">
+        <property name="filters">
+            <list>
+                <ref bean="setRecordDatesFilter" />
+                <ref bean="setMemberOrderFilter" />
             </list>
         </property>
     </bean>

--- a/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-update-processor-it-context.xml
@@ -136,6 +136,26 @@
         <property name="treeIndexer" ref="recursiveTreeIndexer" />
     </bean>
 
+    <bean id="updateMemberOrderTreeAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.SeparateRootAndDescendantsUpdateAction">
+        <property name="rootActionType" value="UPDATE_MEMBER_ORDER_PARENT" />
+        <property name="descendantsActionType" value="UPDATE_MEMBER_ORDER_CHILD" />
+        <property name="treeIndexer" ref="recursiveTreeIndexer" />
+        <property name="messageSender" ref="indexingMessageSender" />
+    </bean>
+
+    <bean id="updateMemberOrderParentAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrOrderMembersParentUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
+
+    <bean id="updateMemberOrderChildAction"
+          class="edu.unc.lib.boxc.indexing.solr.action.UpdateObjectAction">
+        <property name="pipeline" ref="solrOrderMembersChildUpdatePipeline" />
+        <property name="addDocumentMode" value="false" />
+    </bean>
+
     <util:map id="solrIndexingActionMap"
               key-type="edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType"
               value-type="edu.unc.lib.boxc.indexing.solr.action.IndexingAction">
@@ -161,6 +181,9 @@
         <entry key="ADD_SET_TO_PARENT" value-ref="addSetToParentAction" />
         <entry key="UPDATE_TYPE" value-ref="updateTypeAction" />
         <entry key="UPDATE_TYPE_TREE" value-ref="updateTypeTreeAction" />
+        <entry key="UPDATE_MEMBER_ORDER" value-ref="updateMemberOrderTreeAction" />
+        <entry key="UPDATE_MEMBER_ORDER_PARENT" value-ref="updateMemberOrderParentAction" />
+        <entry key="UPDATE_MEMBER_ORDER_CHILD" value-ref="updateMemberOrderChildAction" />
     </util:map>
     
     <bean id="solrUpdateJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
@@ -199,6 +222,7 @@
         <property name="objectAclFactory" ref="objectAclFactory"/>
         <property name="contentPathFactory" ref="contentPathFactory"/>
         <property name="titleRetrievalService" ref="titleRetrievalService" />
+        <property name="memberOrderService" ref="memberOrderService" />
     </bean>
     
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.boxc.services.camel.solrUpdate.SolrUpdatePreprocessor">

--- a/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -27,6 +27,7 @@
                 <ref bean="setContentStatusFilter" />
                 <ref bean="setFullTextFilter" />
                 <ref bean="setObjectTypeFilter" />
+                <ref bean="setMemberOrderFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
             </list>
         </property>
@@ -172,6 +173,10 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
+    <bean id="memberOrderService" class="edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService"
+          init-method="init">
+    </bean>
+
     <bean id="titleRetrievalService" class="edu.unc.lib.boxc.search.solr.services.TitleRetrievalService"
           init-method="init">
         <property name="solrSearchService" ref="solrSearchService" />
@@ -230,6 +235,9 @@
           class="edu.unc.lib.boxc.indexing.solr.filter.SetRecordDatesFilter">
     </bean>
 
+    <bean id="setMemberOrderFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetMemberOrderFilter">
+        <property name="memberOrderService" ref="memberOrderService" />
+    </bean>
 
     <bean id="dipDataLoader"
           class="edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader">

--- a/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -27,6 +27,7 @@
                 <ref bean="setContentStatusFilter" />
                 <ref bean="setFullTextFilter" />
                 <ref bean="setObjectTypeFilter" />
+                <ref bean="setMemberOrderFilter" />
                 <ref bean="setCollectionSupplementalInformationFilter" />
             </list>
         </property>
@@ -191,6 +192,10 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
+    <bean id="memberOrderService" class="edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService"
+          init-method="init">
+    </bean>
+
     <bean id="titleRetrievalService" class="edu.unc.lib.boxc.search.solr.services.TitleRetrievalService"
           init-method="init">
         <property name="solrSearchService" ref="solrSearchService" />
@@ -247,6 +252,10 @@
 
     <bean id="setRecordDatesFilter"
           class="edu.unc.lib.boxc.indexing.solr.filter.SetRecordDatesFilter">
+    </bean>
+
+    <bean id="setMemberOrderFilter" class="edu.unc.lib.boxc.indexing.solr.filter.SetMemberOrderFilter">
+        <property name="memberOrderService" ref="memberOrderService" />
     </bean>
 
     <bean id="dipDataLoader"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3762

I manually tested that the field is being populated when reindexing on my local vm, but there is still no way to add ordering via the UI, so this still has no visible impact.

* Adds support for indexing of member order, both during full (re)index operations and for partial updates after the order has been modified.
    * For a partial update, a UPDATE_MEMBER_ORDER message is sent. This triggers an action that causes a UPDATE_MEMBER_ORDER_PARENT action to be sent which will update 
    * Adds a service which computes the ordering id. There is a cache involved, so invalidation was hooked into the CacheInvalidatingProcessor which triggers when an object is modified.
* Adds memberOrderId field to solr, and objects representing solr records
* Adds method for getting ordered member ids from WorkObject