### PR TITLE
BXC-3785 add ClearOrderValidator

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.impl.order;
+
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.operations.api.order.OrderValidator;
+import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author snluong
+ */
+public class ClearOrderValidator implements OrderValidator {
+    private RepositoryObjectLoader repositoryObjectLoader;
+    private OrderRequest request;
+    private Boolean result;
+    private List<String> errors = new ArrayList<>();
+
+    @Override
+    public boolean isValid() {
+        if (result != null) {
+            return result;
+        }
+        result = validate();
+        return result;
+    }
+
+    private boolean validate() {
+        var parentId = request.getParentPid().getId();
+        var parentObj = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
+        if (!ResourceType.Work.equals(parentObj.getResourceType())) {
+            errors.add("Object " + parentId + " of type " + parentObj.getResourceType().name()
+                    + " does not support setting member order");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repositoryObjectLoader = repositoryObjectLoader;
+    }
+
+    public void setRequest(OrderRequest request) {
+        this.request = request;
+    }
+}

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Validator for a request to clear member order of a work
  * @author snluong
  */
 public class ClearOrderValidator implements OrderValidator {
@@ -46,7 +47,7 @@ public class ClearOrderValidator implements OrderValidator {
         var parentObj = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
         if (!ResourceType.Work.equals(parentObj.getResourceType())) {
             errors.add("Object " + parentId + " of type " + parentObj.getResourceType().name()
-                    + " does not support setting member order");
+                    + " does not support member ordering");
             return false;
         }
         return true;

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
@@ -50,7 +50,7 @@ public class OrderValidatorFactory {
             return validator;
         }
         default:
-            throw new UnsupportedOperationException("Unable to determine order for request " + request);
+            throw new UnsupportedOperationException("Unable to determine validator for request " + request);
         }
     }
 

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
@@ -23,7 +23,7 @@ import edu.unc.lib.boxc.operations.api.order.OrderValidator;
 /**
  * Factory to construct validators for order request
  *
- * @author bbpennel
+ * @author bbpennel, snluong
  */
 public class OrderValidatorFactory {
     private RepositoryObjectLoader repositoryObjectLoader;
@@ -35,11 +35,23 @@ public class OrderValidatorFactory {
      * @return new validator
      */
     public OrderValidator createValidator(OrderRequest request) {
-        var validator = new SetOrderValidator();
-        validator.setMembershipService(membershipService);
-        validator.setRepositoryObjectLoader(repositoryObjectLoader);
-        validator.setRequest(request);
-        return validator;
+        switch(request.getOperation()) {
+        case SET: {
+            var validator = new SetOrderValidator();
+            validator.setMembershipService(membershipService);
+            validator.setRepositoryObjectLoader(repositoryObjectLoader);
+            validator.setRequest(request);
+            return validator;
+        }
+        case CLEAR: {
+            var validator = new ClearOrderValidator();
+            validator.setRepositoryObjectLoader(repositoryObjectLoader);
+            validator.setRequest(request);
+            return validator;
+        }
+        default:
+            throw new UnsupportedOperationException("Unable to determine order for request " + request);
+        }
     }
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
@@ -45,7 +45,7 @@ public class SetOrderValidator implements OrderValidator {
     @Override
     public boolean isValid() {
         if (result != null) {
-            return result.booleanValue();
+            return result;
         }
         result = validate();
         return result;
@@ -56,7 +56,7 @@ public class SetOrderValidator implements OrderValidator {
         var parentObj = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
         if (!ResourceType.Work.equals(parentObj.getResourceType())) {
             errors.add("Object " + parentId + " of type " + parentObj.getResourceType().name()
-                    + " does not support setting member order");
+                    + " does not support member ordering");
             return false;
         }
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
@@ -58,4 +58,10 @@ public class OrderValidatorFactoryTest {
         var request = OrderRequestFactory.createRequest(OrderOperationType.SET, PARENT_UUID, Arrays.asList(CHILD1_UUID));
         assertTrue(factory.createValidator(request) instanceof SetOrderValidator);
     }
+
+    @Test
+    public void forClearOrderRequestTest() {
+        var request = OrderRequestFactory.createRequest(OrderOperationType.CLEAR, PARENT_UUID, Arrays.asList(CHILD1_UUID));
+        assertTrue(factory.createValidator(request) instanceof ClearOrderValidator);
+    }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
@@ -61,7 +61,7 @@ public class OrderValidatorFactoryTest {
 
     @Test
     public void forClearOrderRequestTest() {
-        var request = OrderRequestFactory.createRequest(OrderOperationType.CLEAR, PARENT_UUID, Arrays.asList(CHILD1_UUID));
+        var request = OrderRequestFactory.createRequest(OrderOperationType.CLEAR, PARENT_UUID);
         assertTrue(factory.createValidator(request) instanceof ClearOrderValidator);
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
@@ -83,7 +83,7 @@ public class SetOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors("Object " + PARENT_UUID + " of type AdminUnit does not support setting member order");
+        assertHasErrors("Object " + PARENT_UUID + " of type AdminUnit does not support member ordering");
     }
 
     @Test


### PR DESCRIPTION
Adding a ClearOrderValidator that checks whether the target is a work object, with a test and adding a switch statement to the OrderValidator class.

https://jira.lib.unc.edu/browse/BXC-3785