### PR TITLE
BXC-3763 - Export Member Order CSV

### DIFF
--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
@@ -49,8 +49,6 @@ public class MemberOrderServiceTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
 
-    @Mock
-    private RepositoryObjectLoader repositoryObjectLoader;
     private MemberOrderService memberOrderService;
 
     @Before

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -29,9 +29,10 @@ public class MemberOrderHelper {
 
     /**
      * @param resourceType resource type to test
-     * @return true if the supplied resourceType supposed member ordering
+     * @return true if the supplied resourceType supports member ordering
      */
     public static boolean supportsMemberOrdering(ResourceType resourceType) {
+        // Currently, only works support the operation, but that is expected to change in the future
         return ResourceType.Work.equals(resourceType);
     }
 

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.api.order;
+
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+
+/**
+ * Helpers for member order operations
+ *
+ * @author bbpennel
+ */
+public class MemberOrderHelper {
+    private MemberOrderHelper() {
+    }
+
+    /**
+     * @param resourceType resource type to test
+     * @return true if the supplied resourceType supposed member ordering
+     */
+    public static boolean supportsMemberOrdering(ResourceType resourceType) {
+        return ResourceType.Work.equals(resourceType);
+    }
+
+    /**
+     * Format a standard message indicating that a resource does not support ordering
+     * @param pid PID of the object that does not support operation
+     * @param resourceType type of the object that does not support it
+     * @return formatted message
+     */
+    public static String formatUnsupportedMessage(PID pid, ResourceType resourceType) {
+        return "Object " + pid.getId() + " of type " + resourceType.name()
+                + " does not support member ordering";
+    }
+}

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderValidator.java
@@ -15,13 +15,15 @@
  */
 package edu.unc.lib.boxc.operations.impl.order;
 
-import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.operations.api.order.OrderValidator;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatUnsupportedMessage;
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.supportsMemberOrdering;
 
 /**
  * Validator for a request to clear member order of a work
@@ -43,11 +45,10 @@ public class ClearOrderValidator implements OrderValidator {
     }
 
     private boolean validate() {
-        var parentId = request.getParentPid().getId();
-        var parentObj = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
-        if (!ResourceType.Work.equals(parentObj.getResourceType())) {
-            errors.add("Object " + parentId + " of type " + parentObj.getResourceType().name()
-                    + " does not support member ordering");
+        var parentPid = request.getParentPid();
+        var parentObj = repositoryObjectLoader.getRepositoryObject(parentPid);
+        if (!supportsMemberOrdering(parentObj.getResourceType())) {
+            errors.add(formatUnsupportedMessage(parentPid, parentObj.getResourceType()));
             return false;
         }
         return true;

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
@@ -15,12 +15,11 @@
  */
 package edu.unc.lib.boxc.operations.impl.order;
 
-import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
-import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 import edu.unc.lib.boxc.operations.api.order.OrderValidator;
+import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,6 +29,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatUnsupportedMessage;
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.supportsMemberOrdering;
 
 /**
  * Validator for a request to set order. This is a stateful class, and will only validate once per instance.
@@ -54,9 +56,8 @@ public class SetOrderValidator implements OrderValidator {
     private boolean validate() {
         var parentId = request.getParentPid().getId();
         var parentObj = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
-        if (!ResourceType.Work.equals(parentObj.getResourceType())) {
-            errors.add("Object " + parentId + " of type " + parentObj.getResourceType().name()
-                    + " does not support member ordering");
+        if (!supportsMemberOrdering(parentObj.getResourceType())) {
+            errors.add(formatUnsupportedMessage(request.getParentPid(), parentObj.getResourceType()));
             return false;
         }
 

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
@@ -66,11 +66,11 @@ public class MemberOrderCsvExporter {
             MIME_TYPE_HEADER, DELETED_HEADER, ORDER_HEADER};
 
     private static final List<String> PARENT_REQUEST_FIELDS = Arrays.asList(
-            SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.RESOURCE_TYPE.name());
+            SearchFieldKey.ID.name(), SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.RESOURCE_TYPE.name());
 
     private static final List<String> MEMBER_REQUEST_FIELDS = Arrays.asList(
             SearchFieldKey.ID.name(), SearchFieldKey.TITLE.name(), SearchFieldKey.DATASTREAM.name(),
-            SearchFieldKey.STATUS.name(), SearchFieldKey.FILE_FORMAT_TYPE.name(),
+            SearchFieldKey.STATUS.name(), SearchFieldKey.FILE_FORMAT_TYPE.name(), SearchFieldKey.RESOURCE_TYPE.name(),
             SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.MEMBER_ORDER_ID.name());
 
     private SolrSearchService solrSearchService;
@@ -133,8 +133,7 @@ public class MemberOrderCsvExporter {
             printer.print(original.getFilename());
         }
         printer.print(object.getFileFormatType() == null ? "" : object.getFileFormatType().get(0));
-        var deleted = object.getStatus() == null ?
-                false : object.getStatus().contains(MARKED_FOR_DELETION);
+        var deleted = object.getStatus() != null && object.getStatus().contains(MARKED_FOR_DELETION);
         printer.print(deleted);
         printer.print(object.getMemberOrderId() == null ? "" : object.getMemberOrderId());
         printer.println();

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
@@ -42,6 +42,8 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatUnsupportedMessage;
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.supportsMemberOrdering;
 import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
 
 /**
@@ -162,9 +164,9 @@ public class MemberOrderCsvExporter {
             throw new NotFoundException("Unable to find requested record " + pid.getId()
                     + ", it either does not exist or is not accessible");
         }
-        if (!ResourceType.Work.nameEquals(parentRec.getResourceType())) {
-            throw new InvalidOperationForObjectType("Object " + pid.getId() + " of type " + parentRec.getResourceType()
-                    + " does not support member ordering");
+        var resourceType = ResourceType.valueOf(parentRec.getResourceType());
+        if (!supportsMemberOrdering(resourceType)) {
+            throw new InvalidOperationForObjectType(formatUnsupportedMessage(pid, resourceType));
         }
     }
 

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.processing;
+
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.search.api.SearchFieldKey;
+import edu.unc.lib.boxc.search.api.facets.CutoffFacet;
+import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
+import edu.unc.lib.boxc.search.api.requests.SearchRequest;
+import edu.unc.lib.boxc.search.api.requests.SearchState;
+import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
+import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
+
+/**
+ * Service which handles export of CSV representations of member order
+ *
+ * @author bbpennel
+ */
+public class MemberOrderCsvExporter {
+    private static final int DEFAULT_PAGE_SIZE = 10000;
+
+    public static final String OBJ_TYPE_HEADER = "Object Type";
+    public static final String PID_HEADER = "PID";
+    public static final String PARENT_PID_HEADER = "Parent PID";
+    public static final String TITLE_HEADER = "Title";
+    public static final String FILENAME_HEADER = "Filename";
+    public static final String DELETED_HEADER = "Deleted";
+    public static final String MIME_TYPE_HEADER = "MIME Type";
+    public static final String ORDER_HEADER = "Member Order";
+
+    public static final String[] CSV_HEADERS = new String[] {
+            PARENT_PID_HEADER, PID_HEADER, TITLE_HEADER, OBJ_TYPE_HEADER, FILENAME_HEADER,
+            MIME_TYPE_HEADER, DELETED_HEADER, ORDER_HEADER};
+
+    private static final List<String> PARENT_REQUEST_FIELDS = Arrays.asList(
+            SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.RESOURCE_TYPE.name());
+
+    private static final List<String> MEMBER_REQUEST_FIELDS = Arrays.asList(
+            SearchFieldKey.ID.name(), SearchFieldKey.TITLE.name(), SearchFieldKey.DATASTREAM.name(),
+            SearchFieldKey.STATUS.name(), SearchFieldKey.FILE_FORMAT_TYPE.name(),
+            SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.MEMBER_ORDER_ID.name());
+
+    private SolrSearchService solrSearchService;
+    private AccessControlService aclService;
+
+    /**
+     * Export order information for a list of pids in CSV format
+     * @param pids pids of objects to export
+     * @param agent user agent making the request
+     * @return path to the CSV file
+     */
+    public Path export(List<PID> pids, AgentPrincipals agent) throws IOException {
+        var csvPath = Files.createTempFile("member_order", ".csv");
+        var completedExport = false;
+        try (var csvPrinter = createCsvPrinter(csvPath)) {
+            for (PID parentPid : pids) {
+                aclService.assertHasAccess("Insufficient permissions to order members of " + parentPid.getId(),
+                        parentPid, agent.getPrincipals(), Permission.viewHidden);
+                var parentRec = getParentRecord(parentPid, agent);
+                assertParentRecordValid(parentPid, parentRec);
+
+                printRecords(csvPrinter, getChildrenRecords(parentRec, agent));
+            }
+            completedExport = true;
+        } catch (AccessRestrictionException | InvalidOperationForObjectType e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RepositoryException("Failed to export CSV", e);
+        } finally {
+            // Cleanup the csv file if it is incomplete
+            if (!completedExport) {
+                Files.deleteIfExists(csvPath);
+            }
+        }
+        return csvPath;
+    }
+
+    private CSVPrinter createCsvPrinter(Path csvPath) throws IOException {
+        var writer = Files.newBufferedWriter(csvPath);
+        return new CSVPrinter(writer, CSVFormat.DEFAULT
+                .withHeader(CSV_HEADERS));
+    }
+
+    private void printRecords(CSVPrinter csvPrinter, List<ContentObjectRecord> children) throws IOException {
+        for (var childRec : children) {
+            printRecord(csvPrinter, childRec);
+        }
+    }
+
+    // Print a single objects metadata to the CSV export
+    private void printRecord(CSVPrinter printer, ContentObjectRecord object) throws IOException {
+        printer.print(object.getAncestorPathFacet().getHighestTierNode().getSearchKey());
+        printer.print(object.getId());
+        printer.print(object.getTitle());
+        printer.print(object.getResourceType());
+        var original = object.getDatastreamObject(DatastreamType.ORIGINAL_FILE.getId());
+        if (original == null || StringUtils.isBlank(original.getFilename())) {
+            printer.print("");
+        } else {
+            printer.print(original.getFilename());
+        }
+        printer.print(object.getFileFormatType() == null ? "" : object.getFileFormatType().get(0));
+        var deleted = object.getStatus() == null ?
+                false : object.getStatus().contains(MARKED_FOR_DELETION);
+        printer.print(deleted);
+        printer.print(object.getMemberOrderId() == null ? "" : object.getMemberOrderId());
+        printer.println();
+    }
+
+    // Query for all immediate children/members of the specified record, in default sort order
+    private List<ContentObjectRecord> getChildrenRecords(ContentObjectRecord parentRec, AgentPrincipals agent) {
+        SearchState searchState = new SearchState();
+        searchState.setIgnoreMaxRows(true);
+        searchState.setRowsPerPage(DEFAULT_PAGE_SIZE);
+        CutoffFacet selectedPath = parentRec.getPath();
+        searchState.addFacet(selectedPath);
+        searchState.setSortType("default");
+        searchState.setResultFields(MEMBER_REQUEST_FIELDS);
+        var searchRequest = new SearchRequest(searchState, agent.getPrincipals());
+        return solrSearchService.getSearchResults(searchRequest).getResultList();
+    }
+
+    private ContentObjectRecord getParentRecord(PID pid, AgentPrincipals agent) {
+        var parentRequest = new SimpleIdRequest(pid, PARENT_REQUEST_FIELDS, agent.getPrincipals());
+        return solrSearchService.getObjectById(parentRequest);
+    }
+
+    private void assertParentRecordValid(PID pid, ContentObjectRecord parentRec) {
+        if (parentRec == null) {
+            throw new NotFoundException("Unable to find requested record " + pid.getId()
+                    + ", it either does not exist or is not accessible");
+        }
+        if (!ResourceType.Work.nameEquals(parentRec.getResourceType())) {
+            throw new InvalidOperationForObjectType("Object " + pid.getId() + " of type " + parentRec.getResourceType()
+                    + " does not support member ordering");
+        }
+    }
+
+    public void setSolrSearchService(SolrSearchService solrSearchService) {
+        this.solrSearchService = solrSearchService;
+    }
+
+    public void setAclService(AccessControlService aclService) {
+        this.aclService = aclService;
+    }
+}

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/exceptions/RestResponseEntityExceptionHandler.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/exceptions/RestResponseEntityExceptionHandler.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.boxc.web.services.rest.exceptions;
 
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -67,6 +68,12 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
     protected ResponseEntity<Object> handleObjectNotFound(RuntimeException ex, WebRequest request) {
         String bodyOfResponse = "Object not found";
         return handleExceptionInternal(ex, bodyOfResponse, new HttpHeaders(), HttpStatus.NOT_FOUND, request);
+    }
+
+    @ExceptionHandler(value = { InvalidOperationForObjectType.class })
+    protected ResponseEntity<Object> handleInvalidOperationForObjectType(RuntimeException ex, WebRequest request) {
+        String bodyOfResponse = "Unsupported operation for object type";
+        return handleExceptionInternal(ex, bodyOfResponse, new HttpHeaders(), HttpStatus.BAD_REQUEST, request);
     }
 
     @ExceptionHandler(value = { IllegalArgumentException.class })

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderController.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.rest.modify;
+
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidPidException;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Controller for interacting with member order
+ *
+ * @author bbpennel
+ */
+@Controller
+@RequestMapping(value = "/edit/memberOrder")
+public class MemberOrderController {
+    private static final Logger log = LoggerFactory.getLogger(MemberOrderController.class);
+    private static final String EXPORT_DATE_FORMAT = "yyyy_MM_dd_HH_mm_ss";
+    @Autowired
+    private MemberOrderCsvExporter memberOrderCsvExporter;
+
+    @RequestMapping(value = "export/csv", method = RequestMethod.GET)
+    public ResponseEntity<Object> exportCsv(@RequestParam("ids") String ids, HttpServletResponse response) {
+        if (StringUtils.isBlank(ids)) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        Path csvPath = null;
+        AgentPrincipals agent = AgentPrincipalsImpl.createFromThread();
+        try {
+            var pids = Arrays.stream(ids.split(",")).map(String::trim).map(PIDs::get).collect(Collectors.toList());
+            csvPath = memberOrderCsvExporter.export(pids, agent);
+            String filename = getExportFilename();
+            response.addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
+            response.addHeader("Content-Type", "text/csv");
+            Files.copy(csvPath, response.getOutputStream());
+            response.setStatus(HttpStatus.OK.value());
+            return null;
+        } catch (InvalidPidException | AccessRestrictionException | InvalidOperationForObjectType e) {
+            throw e;
+        } catch (RepositoryException | IOException e) {
+            log.error("Error exporting CSV for {}", agent.getUsername(), e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        } finally {
+            cleanupCsv(csvPath);
+        }
+    }
+
+    private void cleanupCsv(Path csvPath) {
+        if (csvPath != null) {
+            try {
+                Files.deleteIfExists(csvPath);
+            } catch (IOException e) {
+                log.warn("Failed to cleanup CSV file: " + e.getMessage());
+            }
+        }
+    }
+
+    private String getExportFilename() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(EXPORT_DATE_FORMAT)
+                .withZone(ZoneId.systemDefault());
+        return "member_order" + formatter.format(Instant.now()) + ".csv";
+    }
+}

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -389,6 +389,11 @@
         <property name="transactionManager" ref="transactionManager" />
         <property name="premisLoggerFactory" ref="premisLoggerFactory" />
     </bean>
+
+    <bean id="memberOrderCsvExporter" class="edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter">
+        <property name="aclService" ref="aclService" />
+        <property name="solrSearchService" ref="queryLayer" />
+    </bean>
     
     <bean id="binaryTransferService" class="edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl">
         <property name="storageLocationManager" ref="storageLocationManager" />

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.processing;
+
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
+import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
+import edu.unc.lib.boxc.search.solr.models.DatastreamImpl;
+import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
+import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bbpennel
+ */
+public class MemberOrderCsvExporterTest {
+    private static final String PARENT1_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String PARENT2_UUID = "ba70a1ee-fa7c-437f-a979-cc8b16599652";
+    private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
+    private static final String CHILD3_UUID = "8e0040b2-9951-48a3-9d65-780ae7106951";
+    private static final String COLLECTION_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    private static final String ADMIN_UNIT_UUID = "5158b962-9e59-4ed8-b920-fc948213efd3";
+
+    @Mock
+    private SolrSearchService solrSearchService;
+    @Mock
+    private AccessControlService aclService;
+    private AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+    private MemberOrderCsvExporter csvService;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        csvService = new MemberOrderCsvExporter();
+        csvService.setSolrSearchService(solrSearchService);
+        csvService.setAclService(aclService);
+    }
+
+    @Test
+    public void exportUnorderedObjectTest() throws Exception {
+        var parentRec = makeWorkRecord(PARENT1_UUID, "Work");
+        var rec1 = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.File, "File One",
+                "file1.txt", "text/plain", null);
+        var rec2 = makeRecord(CHILD2_UUID, PARENT1_UUID, ResourceType.File, "File Two",
+                "file2.png", "image/png", null);
+        mockParentResults(parentRec);
+        mockChildrenResults(rec1, rec2);
+
+        var resultPath = csvService.export(asPidList(PARENT1_UUID), agent);
+        var csvRecords = parseCsv(resultPath);
+        assertNumberOfEntries(2, csvRecords);
+        assertContainsEntry(csvRecords, CHILD1_UUID, PARENT1_UUID, "File One",
+                "file1.txt", "text/plain", false, null);
+        assertContainsEntry(csvRecords, CHILD2_UUID, PARENT1_UUID, "File Two",
+                "file2.png", "image/png", false, null);
+    }
+
+    @Test
+    public void exportPartiallyOrderedObjectTest() throws Exception {
+        var parentRec = makeWorkRecord(PARENT1_UUID, "Work");
+        var rec1 = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.File, "File One",
+                "file1.txt", "text/plain", 0);
+        var rec2 = makeRecord(CHILD2_UUID, PARENT1_UUID, ResourceType.File, "File Two",
+                "file2.png", "image/png", null);
+        mockParentResults(parentRec);
+        mockChildrenResults(rec1, rec2);
+
+        var resultPath = csvService.export(asPidList(PARENT1_UUID), agent);
+        var csvRecords = parseCsv(resultPath);
+        assertContainsEntry(csvRecords, CHILD1_UUID, PARENT1_UUID, "File One",
+                "file1.txt", "text/plain", false, 0);
+        assertContainsEntry(csvRecords, CHILD2_UUID, PARENT1_UUID, "File Two",
+                "file2.png", "image/png", false, null);
+        assertNumberOfEntries(2, csvRecords);
+    }
+
+    @Test
+    public void exportOrderedObjectWithDeletedChildTest() throws Exception {
+        var parentRec = makeWorkRecord(PARENT1_UUID, "Work");
+        var rec1 = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.File, "File One",
+                "file1.txt", "text/plain", 0);
+        var rec2 = makeRecord(CHILD2_UUID, PARENT1_UUID, ResourceType.File, "File Two",
+                "file2.png", "image/png", 1);
+        ((ContentObjectSolrRecord) rec2).setStatus(Arrays.asList(MARKED_FOR_DELETION));
+        mockParentResults(parentRec);
+        mockChildrenResults(rec1, rec2);
+
+        var resultPath = csvService.export(asPidList(PARENT1_UUID), agent);
+        var csvRecords = parseCsv(resultPath);
+        assertContainsEntry(csvRecords, CHILD1_UUID, PARENT1_UUID, "File One",
+                "file1.txt", "text/plain", false, 0);
+        assertContainsEntry(csvRecords, CHILD2_UUID, PARENT1_UUID, "File Two",
+                "file2.png", "image/png", true, 1);
+        assertNumberOfEntries(2, csvRecords);
+    }
+
+    @Test
+    public void exportMultipleOrderedObjectsTest() throws Exception {
+        var parent1Rec = makeWorkRecord(PARENT1_UUID, "Work 1");
+        var rec1 = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.File, "File One",
+                "file1.txt", "text/plain", 0);
+        var rec2 = makeRecord(CHILD2_UUID, PARENT1_UUID, ResourceType.File, "File Two",
+                "file2.png", "image/png", 1);
+        var parent2Rec = makeWorkRecord(PARENT2_UUID, "Work 2");
+        var rec3 = makeRecord(CHILD3_UUID, PARENT2_UUID, ResourceType.File, "File Three",
+                "file3.txt", "text/plain", 0);
+        mockParentResults(parent1Rec, parent2Rec);
+        when(solrSearchService.getSearchResults(any()))
+                .thenReturn(makeResultResponse(rec1, rec2))
+                .thenReturn(makeResultResponse(rec3));
+
+        var resultPath = csvService.export(asPidList(PARENT1_UUID, PARENT2_UUID), agent);
+        var csvRecords = parseCsv(resultPath);
+        assertContainsEntry(csvRecords, CHILD1_UUID, PARENT1_UUID, "File One",
+                "file1.txt", "text/plain", false, 0);
+        assertContainsEntry(csvRecords, CHILD2_UUID, PARENT1_UUID, "File Two",
+                "file2.png", "image/png", false, 1);
+        assertContainsEntry(csvRecords, CHILD3_UUID, PARENT2_UUID, "File Three",
+                "file3.txt", "text/plain", false, 0);
+        assertNumberOfEntries(3, csvRecords);
+    }
+
+    @Test
+    public void exportFileObjectOrderTest() throws Exception {
+        var rec = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.File, "File One",
+                "file1.txt", "text/plain", 0);
+        resourceTypeNotSupportedTest(rec);
+    }
+
+    @Test
+    public void exportAdminUnitOrderTest() throws Exception {
+        var rec = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.AdminUnit, "Administrivia",
+                null, null, null);
+        resourceTypeNotSupportedTest(rec);
+    }
+
+    @Test
+    public void exportCollectionOrderTest() throws Exception {
+        var rec = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.Collection, "Coll",
+                null, null, null);
+        resourceTypeNotSupportedTest(rec);
+    }
+
+    @Test
+    public void exportFolderOrderTest() throws Exception {
+        var rec = makeRecord(CHILD1_UUID, PARENT1_UUID, ResourceType.Folder, "Folding",
+                null, null, null);
+        resourceTypeNotSupportedTest(rec);
+    }
+
+    private void resourceTypeNotSupportedTest(ContentObjectRecord rec) throws Exception {
+        mockParentResults(rec);
+        try {
+            csvService.export(asPidList(CHILD1_UUID), agent);
+            fail();
+        } catch (InvalidOperationForObjectType e) {
+            assertEquals("Object 83c2d7f8-2e6b-4f0b-ab7e-7397969c0682 of type " + rec.getResourceType()
+                            + " does not support member ordering", e.getMessage());
+        }
+    }
+
+    @Test(expected = AccessRestrictionException.class)
+    public void exportInsufficientPermissionsTest() throws Exception {
+        doThrow(new AccessRestrictionException())
+                .when(aclService)
+                .assertHasAccess(anyString(), eq(PIDs.get(PARENT1_UUID)), any(), eq(Permission.viewHidden));
+        csvService.export(asPidList(PARENT1_UUID), agent);
+    }
+
+    private void mockChildrenResults(ContentObjectRecord... results) {
+        when(solrSearchService.getSearchResults(any())).thenReturn(makeResultResponse(results));
+    }
+
+    private SearchResultResponse makeResultResponse(ContentObjectRecord... results) {
+        var resp = new SearchResultResponse();
+        resp.setResultList(Arrays.asList(results));
+        resp.setResultCount(results.length);
+        return resp;
+    }
+
+    // Calls to get parent record will return the provided records, in order
+    private void mockParentResults(ContentObjectRecord parentRec, ContentObjectRecord... parentRecs) {
+        when(solrSearchService.getObjectById(any())).thenReturn(parentRec, parentRecs);
+    }
+
+    private void assertContainsEntry(List<CSVRecord> csvRecords, String uuid, String parentUuid,
+                                     String title, String filename, String mimetype, boolean deleted, Integer order) {
+        for (CSVRecord record : csvRecords) {
+            if (!uuid.equals(record.get(MemberOrderCsvExporter.PID_HEADER))) {
+                continue;
+            }
+            assertEquals(parentUuid, record.get(MemberOrderCsvExporter.PARENT_PID_HEADER));
+            assertEquals(ResourceType.File.name(), record.get(MemberOrderCsvExporter.OBJ_TYPE_HEADER));
+            assertEquals(title, record.get(MemberOrderCsvExporter.TITLE_HEADER));
+            assertEquals(filename, record.get(MemberOrderCsvExporter.FILENAME_HEADER));
+            assertEquals(mimetype, record.get(MemberOrderCsvExporter.MIME_TYPE_HEADER));
+            assertEquals(Boolean.toString(deleted), record.get(MemberOrderCsvExporter.DELETED_HEADER));
+            var expectOrder = order == null ? "" : order.toString();
+            assertEquals(expectOrder, record.get(MemberOrderCsvExporter.ORDER_HEADER));
+            return;
+        }
+        fail("No entry found for uuid " + uuid);
+    }
+
+    private void assertNumberOfEntries(int expected, List<CSVRecord> csvParser) throws IOException {
+        assertEquals(expected, csvParser.size());
+    }
+
+    private List<PID> asPidList(String... ids) {
+        return Arrays.stream(ids).map(PIDs::get).collect(Collectors.toList());
+    }
+
+    private List<CSVRecord> parseCsv(Path csvPath) throws IOException {
+        Reader reader = Files.newBufferedReader(csvPath);
+        return new CSVParser(reader, CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withHeader(MemberOrderCsvExporter.CSV_HEADERS)
+                .withTrim())
+                .getRecords();
+    }
+
+    private ContentObjectRecord makeWorkRecord(String uuid, String title) {
+        return makeRecord(uuid, COLLECTION_UUID, ResourceType.Work, title, null, null, null);
+    }
+
+    private ContentObjectRecord makeRecord(String uuid, String parentUuid, ResourceType resourceType, String title,
+                                           String filename, String mimetype, Integer order) {
+        var rec = new ContentObjectSolrRecord();
+        rec.setId(uuid);
+        rec.setAncestorPath(makeAncestorPath(parentUuid));
+        rec.setResourceType(resourceType.name());
+        rec.setTitle(title);
+        rec.setFileFormatType(Arrays.asList(mimetype));
+        rec.setMemberOrderId(order);
+        if (filename != null) {
+            var datastream = new DatastreamImpl(null, DatastreamType.ORIGINAL_FILE.getId(), 0l, mimetype,
+                    filename, null, null, null);
+            rec.setDatastream(Arrays.asList(datastream.toString()));
+        }
+        return rec;
+    }
+
+    private List<String> makeAncestorPath(String parentUuid) {
+        return Arrays.asList("1,collections", "2," + ADMIN_UNIT_UUID, "3," + COLLECTION_UUID, "4," + parentUuid);
+    }
+}

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
@@ -20,6 +20,7 @@ import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
 import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter;
@@ -117,6 +118,17 @@ public class MemberOrderControllerTest {
 
         mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
                 .andExpect(status().isForbidden())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvExportInvalidResourceTypeTest() throws Exception {
+        var ids = PARENT1_UUID;
+        when(csvExporter.export(eq(Arrays.asList(PIDs.get(PARENT1_UUID))), any(AgentPrincipals.class)))
+                .thenThrow(new InvalidOperationForObjectType());
+
+        mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
+                .andExpect(status().is4xxClientError())
                 .andReturn();
     }
 

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.rest.modify;
+
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/member-order-test-servlet.xml")
+public class MemberOrderControllerTest {
+    private static final String PARENT1_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String PARENT2_UUID = "ba70a1ee-fa7c-437f-a979-cc8b16599652";
+    private final static String USERNAME = "test_user";
+    private final static AccessGroupSet GROUPS = new AccessGroupSetImpl("adminGroup");
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private MemberOrderCsvExporter csvExporter;
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private MockMvc mvc;
+
+    @Before
+    public void init() throws Exception {
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+        GroupsThreadStore.storeUsername(USERNAME);
+        GroupsThreadStore.storeGroups(GROUPS);
+        tmpFolder.create();
+    }
+
+    @Test
+    public void memberOrderCsvExportSuccessTest() throws Exception {
+        var csvPath = tmpFolder.newFile().toPath();
+        var expectedContent = "some,csv,data,goes,here";
+        FileUtils.writeStringToFile(csvPath.toFile(), expectedContent, StandardCharsets.UTF_8);
+
+        var ids = PARENT1_UUID + "," + PARENT2_UUID;
+        when(csvExporter.export(eq(Arrays.asList(PIDs.get(PARENT1_UUID), PIDs.get(PARENT2_UUID))), any(AgentPrincipals.class)))
+                .thenReturn(csvPath);
+
+        MvcResult result = mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        var response = result.getResponse();
+        assertEquals(expectedContent, response.getContentAsString());
+    }
+
+    @Test
+    public void memberOrderCsvExportNoIdParamTest() throws Exception {
+        mvc.perform(get("/edit/memberOrder/export/csv"))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvExportEmptyIdParamTest() throws Exception {
+        mvc.perform(get("/edit/memberOrder/export/csv?ids="))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvExportAccessFailureTest() throws Exception {
+        var ids = PARENT1_UUID;
+        when(csvExporter.export(eq(Arrays.asList(PIDs.get(PARENT1_UUID))), any(AgentPrincipals.class)))
+                .thenThrow(new AccessRestrictionException());
+
+        mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
+                .andExpect(status().isForbidden())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvExportServerErrorTest() throws Exception {
+        var ids = PARENT1_UUID;
+        when(csvExporter.export(eq(Arrays.asList(PIDs.get(PARENT1_UUID))), any(AgentPrincipals.class)))
+                .thenThrow(new RepositoryException("Boom"));
+
+        mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
+                .andExpect(status().is5xxServerError())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvExportInvalidPidsTest() throws Exception {
+        var ids = "badpids,beingsubmitted";
+
+        mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+    }
+}

--- a/web-services-app/src/test/resources/member-order-test-servlet.xml
+++ b/web-services-app/src/test/resources/member-order-test-servlet.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan base-package="edu.unc.lib.boxc.web.services.rest.exceptions"/>
+    <context:component-scan resource-pattern="**/MemberOrderController*" base-package="edu.unc.lib.boxc.web.services.rest.modify"/>
+    
+    <bean id="memberOrderCsvExporter" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter" />
+    </bean>
+</beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3763

* Adds service and controller for generating a CSV document for viewing and reimporting member order
* Add handling of InvalidOperationForObjectType from controllers

Can be tested locally with direct requests:
```
https://localhost:8080/services/api/edit/memberOrder/export/csv?ids=1b9500f1-187e-4bfa-9b30-efe0ec50a8a3,6047d654-7102-4f94-8829-3fc3fc00b62d
```