### PR TITLE
BXC-3764 - Import member order via CSV

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/MessageSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/MessageSender.java
@@ -15,16 +15,11 @@
  */
 package edu.unc.lib.boxc.operations.jms;
 
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
-
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.Session;
-
 import org.jdom2.Document;
 import org.jdom2.output.XMLOutputter;
 import org.springframework.jms.core.JmsTemplate;
-import org.springframework.jms.core.MessageCreator;
+
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
 
 /**
  * A class to hold common helper methods for message senders
@@ -42,15 +37,12 @@ public class MessageSender {
     }
 
     public void sendMessage(String msgStr) {
-        jmsTemplate.send(new MessageCreator() {
-            @Override
-            public Message createMessage(Session session) throws JMSException {
-                // Committing the session to flush changes in long running threads
-                if (session.getTransacted()) {
-                    session.commit();
-                }
-                return session.createTextMessage(msgStr);
+        jmsTemplate.send(session -> {
+            // Committing the session to flush changes in long running threads
+            if (session.getTransacted()) {
+                session.commit();
             }
+            return session.createTextMessage(msgStr);
         });
     }
 

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/order/MemberOrderRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/order/MemberOrderRequestSender.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.jms.order;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import edu.unc.lib.boxc.operations.jms.MessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Service for sending requests to update member order
+ *
+ * @author bbpennel
+ */
+public class MemberOrderRequestSender extends MessageSender {
+    private static final Logger log = LoggerFactory.getLogger(MemberOrderRequestSender.class);
+    private static final ObjectWriter MAPPER = new ObjectMapper().writerFor(MultiParentOrderRequest.class);
+
+    /**
+     * Send a MultiParentOrderRequest to the configured JMS queue
+     * @param request
+     * @throws IOException
+     */
+    public void sendToQueue(MultiParentOrderRequest request) throws IOException {
+        String messageBody = MAPPER.writeValueAsString(request);
+        sendMessage(messageBody);
+        log.info("Job to update member order has been queued for {}", request.getAgent().getUsername());
+    }
+}

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/order/MemberOrderRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/order/MemberOrderRequestSenderTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.jms.order;
+
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author bbpennel
+ */
+public class MemberOrderRequestSenderTest {
+    private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
+    private final static String USERNAME = "test_user";
+    private final static String EMAIL = "test_user@example.com";
+    private final static AccessGroupSet GROUPS = new AccessGroupSetImpl("adminGroup");
+
+    @Mock
+    private JmsTemplate jmsTemplate;
+    private MemberOrderRequestSender requestSender;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        requestSender = new MemberOrderRequestSender();
+        requestSender.setJmsTemplate(jmsTemplate);
+    }
+
+    @Test
+    public void sendToQueueTest() throws Exception {
+        var request = new MultiParentOrderRequest();
+        var agent = new AgentPrincipalsImpl(USERNAME, GROUPS);
+        request.setAgent(agent);
+        request.setOperation(OrderOperationType.SET);
+        request.setEmail(EMAIL);
+        var parentToOrdered = Map.of(PARENT_UUID, Arrays.asList(CHILD1_UUID, CHILD2_UUID));
+        request.setParentToOrdered(parentToOrdered);
+
+        requestSender.sendToQueue(request);
+
+        verify(jmsTemplate).send(any());
+    }
+}

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -468,6 +468,37 @@
         <property name="patronAccessAssignmentService" ref="patronAccessAssignmentService" />
     </bean>
 
+    <!-- member ordering -->
+    <bean id="orderJobFactory" class="edu.unc.lib.boxc.operations.impl.order.OrderJobFactory">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+    </bean>
+
+    <bean id="pcdmMembershipService" class="edu.unc.lib.boxc.model.fcrepo.services.PcdmMembershipService">
+        <property name="sparqlQueryService" ref="sparqlQueryService" />
+    </bean>
+
+    <bean id="orderValidatorFactory" class="edu.unc.lib.boxc.operations.impl.order.OrderValidatorFactory">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="membershipService" ref="pcdmMembershipService" />
+    </bean>
+
+    <bean id="orderNotificationBuilder" class="edu.unc.lib.boxc.services.camel.order.OrderNotificationBuilder">
+    </bean>
+
+    <bean id="orderNotificationService" class="edu.unc.lib.boxc.services.camel.order.OrderNotificationService">
+        <property name="emailHandler" ref="emailHandler" />
+        <property name="orderNotificationBuilder" ref="orderNotificationBuilder" />
+    </bean>
+
+    <bean id="orderRequestProcessor" class="edu.unc.lib.boxc.services.camel.order.OrderRequestProcessor">
+        <property name="accessControlService" ref="aclService" />
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="orderJobFactory" ref="orderJobFactory" />
+        <property name="orderValidatorFactory" ref="orderValidatorFactory" />
+        <property name="orderNotificationService" ref="orderNotificationService" />
+    </bean>
+
     <!-- Camel contexts -->
 
     <camel:camelContext id="FcrepoTriplestoreIndexer">
@@ -520,5 +551,9 @@
     
     <camel:camelContext id="CdrUpdatePatronAccess">
         <camel:package>edu.unc.lib.boxc.services.camel.patronAccess</camel:package>
+    </camel:camelContext>
+
+    <camel:camelContext id="CdrMemberOrder">
+        <camel:package>edu.unc.lib.boxc.services.camel.order</camel:package>
     </camel:camelContext>
 </beans>

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvConstants.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvConstants.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.processing;
+
+/**
+ * Constants related to the CSV Member Order export
+ *
+ * @author bbpennel
+ */
+public class MemberOrderCsvConstants {
+    public static final String OBJ_TYPE_HEADER = "Object Type";
+    public static final String PID_HEADER = "PID";
+    public static final String PARENT_PID_HEADER = "Parent PID";
+    public static final String TITLE_HEADER = "Title";
+    public static final String FILENAME_HEADER = "Filename";
+    public static final String DELETED_HEADER = "Deleted";
+    public static final String MIME_TYPE_HEADER = "MIME Type";
+    public static final String ORDER_HEADER = "Member Order";
+
+    public static final String[] CSV_HEADERS = new String[] {
+            PARENT_PID_HEADER, PID_HEADER, TITLE_HEADER, OBJ_TYPE_HEADER, FILENAME_HEADER,
+            MIME_TYPE_HEADER, DELETED_HEADER, ORDER_HEADER};
+
+    private MemberOrderCsvConstants(){
+    }
+}

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvConstants.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvConstants.java
@@ -34,6 +34,6 @@ public class MemberOrderCsvConstants {
             PARENT_PID_HEADER, PID_HEADER, TITLE_HEADER, OBJ_TYPE_HEADER, FILENAME_HEADER,
             MIME_TYPE_HEADER, DELETED_HEADER, ORDER_HEADER};
 
-    private MemberOrderCsvConstants(){
+    private MemberOrderCsvConstants() {
     }
 }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporter.java
@@ -45,6 +45,7 @@ import java.util.List;
 import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatUnsupportedMessage;
 import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.supportsMemberOrdering;
 import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
+import static edu.unc.lib.boxc.web.services.processing.MemberOrderCsvConstants.CSV_HEADERS;
 
 /**
  * Service which handles export of CSV representations of member order
@@ -53,19 +54,6 @@ import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
  */
 public class MemberOrderCsvExporter {
     private static final int DEFAULT_PAGE_SIZE = 10000;
-
-    public static final String OBJ_TYPE_HEADER = "Object Type";
-    public static final String PID_HEADER = "PID";
-    public static final String PARENT_PID_HEADER = "Parent PID";
-    public static final String TITLE_HEADER = "Title";
-    public static final String FILENAME_HEADER = "Filename";
-    public static final String DELETED_HEADER = "Deleted";
-    public static final String MIME_TYPE_HEADER = "MIME Type";
-    public static final String ORDER_HEADER = "Member Order";
-
-    public static final String[] CSV_HEADERS = new String[] {
-            PARENT_PID_HEADER, PID_HEADER, TITLE_HEADER, OBJ_TYPE_HEADER, FILENAME_HEADER,
-            MIME_TYPE_HEADER, DELETED_HEADER, ORDER_HEADER};
 
     private static final List<String> PARENT_REQUEST_FIELDS = Arrays.asList(
             SearchFieldKey.ID.name(), SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.RESOURCE_TYPE.name());

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
@@ -41,9 +41,6 @@ import java.util.stream.Collectors;
  * @author bbpennel
  */
 public class MemberOrderCsvTransformer {
-    public MemberOrderCsvTransformer() {
-    }
-
     /**
      * Transform the provided CSV document into a request for setting the order of members of one or more containers.
      *
@@ -108,8 +105,7 @@ public class MemberOrderCsvTransformer {
     private static String getRequiredValue(CSVRecord csvRecord, String fieldName) {
         var value = csvRecord.get(fieldName);
         if (StringUtils.isBlank(value)) {
-            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
-                    + " does not specify a value for required field '" + fieldName + "'");
+            throw invalidRecordError(csvRecord, "does not specify a value for required field '" + fieldName + "'");
         }
         return value;
     }
@@ -120,8 +116,7 @@ public class MemberOrderCsvTransformer {
         try {
             return PIDs.get(value).getId();
         } catch (InvalidPidException e) {
-            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
-                    + " contains an invalid PID value for field '" + fieldName + "'.");
+            throw invalidRecordError(csvRecord, "contains an invalid PID value for field '" + fieldName + "'.");
         }
     }
 
@@ -131,14 +126,19 @@ public class MemberOrderCsvTransformer {
         try {
             var intVal = Integer.parseInt(value);
             if (intVal < 0) {
-                throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
-                        + " contains an invalid value for field '" + fieldName + "', it must be >= 0.");
+                throw invalidRecordError(csvRecord,
+                        "contains an invalid value for field '" + fieldName + "', it must be >= 0.");
             }
             return intVal;
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
-                    + " contains an invalid value for field '" + fieldName + "', it must be an integer.");
+            throw invalidRecordError(csvRecord,
+                    "contains an invalid value for field '" + fieldName + "', it must be an integer.");
         }
+    }
+
+    private static IllegalArgumentException invalidRecordError(CSVRecord csvRecord, String message) {
+        return new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
+                + " " + message);
     }
 
     private static CSVParser createCsvParser(Path csvPath) throws IOException {

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.processing;
+
+import edu.unc.lib.boxc.model.api.exceptions.InvalidPidException;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.order.MultiParentOrderRequest;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Service for transforming Member Order CSV to requests
+ *
+ * @author bbpennel
+ */
+public class MemberOrderCsvTransformer {
+    private MemberOrderCsvTransformer() {
+    }
+
+    /**
+     * Transform the provided CSV document into a request for setting the order of members of one or more containers.
+     *
+     * The CSV must contain at least the parent id, child id, and order id fields. Other fields are ignored.
+     *
+     * IllegalArgumentExceptions will be thrown if the values in the CSV are missing or invalid.
+     * @param csvPath Path to CSV document
+     * @return constructed request
+     * @throws IOException if the CSV cannot be parsed
+     */
+    public static MultiParentOrderRequest toSetRequest(Path csvPath) throws IOException {
+        var parentToChildren = parseCsvToMapping(csvPath);
+        var parentToOrdered = sortParentToChildren(parentToChildren);
+        var request = new MultiParentOrderRequest();
+        request.setParentToOrdered(parentToOrdered);
+        request.setOperation(OrderOperationType.SET);
+        return request;
+    }
+
+    // Parses the provided CSV file to produce a mapping of parent ids to children, in the order they appear
+    private static Map<String, List<SortableChildEntry>> parseCsvToMapping(Path csvPath) throws IOException {
+        var parentToChildren = new HashMap<String, List<SortableChildEntry>>();
+        try (var csvParser = createCsvParser(csvPath)) {
+            for (CSVRecord csvRecord : csvParser) {
+                var parentId = getRequiredPidValue(csvRecord, MemberOrderCsvConstants.PARENT_PID_HEADER);
+                var childId = getRequiredPidValue(csvRecord, MemberOrderCsvConstants.PID_HEADER);
+                var orderId = getOrderId(csvRecord);
+
+                var children = parentToChildren.computeIfAbsent(parentId, x -> new ArrayList<>());
+                children.add(new SortableChildEntry(childId, orderId));
+            }
+        }
+        return parentToChildren;
+    }
+
+    // Produces a map where keys are the parent id and values are lists of children ids sorted by the provided order id
+    private static Map<String, List<String>> sortParentToChildren(
+            Map<String, List<SortableChildEntry>> parentToUnsorted) {
+        var parentToChildren = new HashMap<String, List<String>>();
+        for (var parentEntry: parentToUnsorted.entrySet()) {
+            // Sort the children entries and get a list of children ids
+            var sorted = parentEntry.getValue().stream()
+                    .sorted(Comparator.comparingInt(c -> c.orderId))
+                    .map(c -> c.childId)
+                    .collect(Collectors.toList());
+            parentToChildren.put(parentEntry.getKey(), sorted);
+        }
+        return parentToChildren;
+    }
+
+    // Object to allow for sorting of children by their order ids
+    private static class SortableChildEntry {
+        private String childId;
+        private int orderId;
+
+        SortableChildEntry(String childId, int orderId) {
+            this.childId = childId;
+            this.orderId = orderId;
+        }
+    }
+
+    private static String getRequiredValue(CSVRecord csvRecord, String fieldName) {
+        var value = csvRecord.get(fieldName);
+        if (StringUtils.isBlank(value)) {
+            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
+                    + " does not specify a value for required field '" + fieldName + "'");
+        }
+        return value;
+    }
+
+    private static String getRequiredPidValue(CSVRecord csvRecord, String fieldName) {
+        var value = getRequiredValue(csvRecord, fieldName);
+        // Verifies that the value is a PID, and grab just the id
+        try {
+            return PIDs.get(value).getId();
+        } catch (InvalidPidException e) {
+            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
+                    + " contains an invalid PID value for field '" + fieldName + "'.");
+        }
+    }
+
+    private static int getOrderId(CSVRecord csvRecord) {
+        var fieldName = MemberOrderCsvConstants.ORDER_HEADER;
+        var value = getRequiredValue(csvRecord, fieldName);
+        try {
+            var intVal = Integer.parseInt(value);
+            if (intVal < 0) {
+                throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
+                        + " contains an invalid value for field '" + fieldName + "', it must be >= 0.");
+            }
+            return intVal;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Record " + csvRecord.getRecordNumber()
+                    + " contains an invalid value for field '" + fieldName + "', it must be an integer.");
+        }
+    }
+
+    private static CSVParser createCsvParser(Path csvPath) throws IOException {
+        Reader reader = Files.newBufferedReader(csvPath);
+        return new CSVParser(reader, CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .withAllowMissingColumnNames()
+                .withTrim());
+    }
+}

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformer.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * @author bbpennel
  */
 public class MemberOrderCsvTransformer {
-    private MemberOrderCsvTransformer() {
+    public MemberOrderCsvTransformer() {
     }
 
     /**
@@ -54,7 +54,7 @@ public class MemberOrderCsvTransformer {
      * @return constructed request
      * @throws IOException if the CSV cannot be parsed
      */
-    public static MultiParentOrderRequest toSetRequest(Path csvPath) throws IOException {
+    public MultiParentOrderRequest toRequest(Path csvPath) throws IOException {
         var parentToChildren = parseCsvToMapping(csvPath);
         var parentToOrdered = sortParentToChildren(parentToChildren);
         var request = new MultiParentOrderRequest();

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -394,6 +394,19 @@
         <property name="aclService" ref="aclService" />
         <property name="solrSearchService" ref="queryLayer" />
     </bean>
+
+    <bean id="memberOrderCsvTransformer" class="edu.unc.lib.boxc.web.services.processing.MemberOrderCsvTransformer">
+    </bean>
+
+    <bean id="importMemberOrderJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="${cdr.ordermembers.stream}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+
+    <bean id="memberOrderRequestSender" class="edu.unc.lib.boxc.operations.jms.order.MemberOrderRequestSender">
+        <property name="jmsTemplate" ref="importMemberOrderJmsTemplate"/>
+    </bean>
     
     <bean id="binaryTransferService" class="edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl">
         <property name="storageLocationManager" ref="storageLocationManager" />

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
@@ -233,17 +233,17 @@ public class MemberOrderCsvExporterTest {
     private void assertContainsEntry(List<CSVRecord> csvRecords, String uuid, String parentUuid,
                                      String title, String filename, String mimetype, boolean deleted, Integer order) {
         for (CSVRecord record : csvRecords) {
-            if (!uuid.equals(record.get(MemberOrderCsvExporter.PID_HEADER))) {
+            if (!uuid.equals(record.get(MemberOrderCsvConstants.PID_HEADER))) {
                 continue;
             }
-            assertEquals(parentUuid, record.get(MemberOrderCsvExporter.PARENT_PID_HEADER));
-            assertEquals(ResourceType.File.name(), record.get(MemberOrderCsvExporter.OBJ_TYPE_HEADER));
-            assertEquals(title, record.get(MemberOrderCsvExporter.TITLE_HEADER));
-            assertEquals(filename, record.get(MemberOrderCsvExporter.FILENAME_HEADER));
-            assertEquals(mimetype, record.get(MemberOrderCsvExporter.MIME_TYPE_HEADER));
-            assertEquals(Boolean.toString(deleted), record.get(MemberOrderCsvExporter.DELETED_HEADER));
+            assertEquals(parentUuid, record.get(MemberOrderCsvConstants.PARENT_PID_HEADER));
+            assertEquals(ResourceType.File.name(), record.get(MemberOrderCsvConstants.OBJ_TYPE_HEADER));
+            assertEquals(title, record.get(MemberOrderCsvConstants.TITLE_HEADER));
+            assertEquals(filename, record.get(MemberOrderCsvConstants.FILENAME_HEADER));
+            assertEquals(mimetype, record.get(MemberOrderCsvConstants.MIME_TYPE_HEADER));
+            assertEquals(Boolean.toString(deleted), record.get(MemberOrderCsvConstants.DELETED_HEADER));
             var expectOrder = order == null ? "" : order.toString();
-            assertEquals(expectOrder, record.get(MemberOrderCsvExporter.ORDER_HEADER));
+            assertEquals(expectOrder, record.get(MemberOrderCsvConstants.ORDER_HEADER));
             return;
         }
         fail("No entry found for uuid " + uuid);
@@ -261,7 +261,7 @@ public class MemberOrderCsvExporterTest {
         Reader reader = Files.newBufferedReader(csvPath);
         return new CSVParser(reader, CSVFormat.DEFAULT
                 .withFirstRecordAsHeader()
-                .withHeader(MemberOrderCsvExporter.CSV_HEADERS)
+                .withHeader(MemberOrderCsvConstants.CSV_HEADERS)
                 .withTrim())
                 .getRecords();
     }

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformerTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.processing;
+
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static edu.unc.lib.boxc.web.services.processing.MemberOrderCsvConstants.CSV_HEADERS;
+import static edu.unc.lib.boxc.web.services.processing.MemberOrderCsvConstants.ORDER_HEADER;
+import static edu.unc.lib.boxc.web.services.processing.MemberOrderCsvConstants.PARENT_PID_HEADER;
+import static edu.unc.lib.boxc.web.services.processing.MemberOrderCsvConstants.PID_HEADER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author bbpennel
+ */
+public class MemberOrderCsvTransformerTest {
+    private static final String PARENT1_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String PARENT2_UUID = "ba70a1ee-fa7c-437f-a979-cc8b16599652";
+    private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
+    private static final String CHILD3_UUID = "8e0040b2-9951-48a3-9d65-780ae7106951";
+    private static final String CHILD4_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Test
+    public void toSetRequestNoParentIdTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList("", CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, 1));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "does not specify a value for required field 'Parent PID'");
+        }
+    }
+
+    @Test
+    public void toSetRequestNoChildIdTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, "", "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, 1));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "does not specify a value for required field 'PID'");
+        }
+    }
+
+    @Test
+    public void toSetRequestParentNotPidTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList("whatever", CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, 1));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "contains an invalid PID value for field 'Parent PID'");
+        }
+    }
+
+    @Test
+    public void toSetRequestNoOrderIdTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, ""));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "does not specify a value for required field 'Member Order'");
+        }
+    }
+
+    @Test
+    public void toSetRequestOrderIdNotANumberTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, "hmm"));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "invalid value for field 'Member Order', it must be an integer");
+        }
+    }
+
+    @Test
+    public void toSetRequestOrderIdNegativeTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file.txt", "text/plain", false, -4));
+        var csvPath = writeCsvFile(entries);
+        try {
+            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertErrorMessageContains(e, "invalid value for field 'Member Order', it must be >= 0");
+        }
+    }
+
+    @Test
+    public void toSetRequestMultipleEntriesTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD1_UUID, "Title 1", ResourceType.File.name(),
+                "file1.txt", "text/plain", false, 2));
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD2_UUID, "Title 2", ResourceType.File.name(),
+                "file2.txt", "text/plain", false, 1));
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD3_UUID, "Title 3", ResourceType.File.name(),
+                "file3.txt", "text/plain", true, 5));
+        entries.add(Arrays.asList(PARENT2_UUID, CHILD4_UUID, "Title 4", ResourceType.File.name(),
+                "file4.txt", "text/plain", false, 0));
+        var csvPath = writeCsvFile(entries);
+
+        var request = MemberOrderCsvTransformer.toSetRequest(csvPath);
+        assertEquals(OrderOperationType.SET, request.getOperation());
+        var parentToOrder = request.getParentToOrdered();
+        var parent1Children = parentToOrder.get(PARENT1_UUID);
+        assertEquals(Arrays.asList(CHILD2_UUID, CHILD1_UUID, CHILD3_UUID), parent1Children);
+        var parent2Children = parentToOrder.get(PARENT2_UUID);
+        assertEquals(Arrays.asList(CHILD4_UUID), parent2Children);
+    }
+
+    @Test
+    public void toSetRequestMinimalColumnsTest() throws Exception {
+        var entries = new ArrayList<List<Object>>();
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD1_UUID, 2));
+        entries.add(Arrays.asList(PARENT1_UUID, CHILD2_UUID, 1));
+        var csvPath = writeCsvFile(entries, PARENT_PID_HEADER, PID_HEADER, ORDER_HEADER);
+
+        var request = MemberOrderCsvTransformer.toSetRequest(csvPath);
+        assertEquals(OrderOperationType.SET, request.getOperation());
+        var parentToOrder = request.getParentToOrdered();
+        var parent1Children = parentToOrder.get(PARENT1_UUID);
+        assertEquals(Arrays.asList(CHILD2_UUID, CHILD1_UUID), parent1Children);
+    }
+
+    private void assertErrorMessageContains(Exception e, String expected) {
+        assertTrue("Expected message:\n" + expected + "\nReceived:\n" + e.getMessage(),
+                e.getMessage().contains(expected));
+    }
+
+    private Path writeCsvFile(List<List<Object>> entries) throws IOException {
+        return writeCsvFile(entries, CSV_HEADERS);
+    }
+
+    private Path writeCsvFile(List<List<Object>> entries, String... headers) throws IOException {
+        var csvPath = tmpFolder.newFile().toPath();
+        try (var writer = Files.newBufferedWriter(csvPath);
+            var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT
+                .withHeader(headers))) {
+            for (var entry: entries) {
+                csvPrinter.printRecord(entry);
+            }
+        }
+        return csvPath;
+    }
+}

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvTransformerTest.java
@@ -19,6 +19,7 @@ import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -51,6 +52,12 @@ public class MemberOrderCsvTransformerTest {
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    private MemberOrderCsvTransformer transformer;
+
+    @Before
+    public void setup() {
+        transformer = new MemberOrderCsvTransformer();
+    }
 
     @Test
     public void toSetRequestNoParentIdTest() throws Exception {
@@ -59,7 +66,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, 1));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "does not specify a value for required field 'Parent PID'");
@@ -73,7 +80,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, 1));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "does not specify a value for required field 'PID'");
@@ -87,7 +94,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, 1));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "contains an invalid PID value for field 'Parent PID'");
@@ -101,7 +108,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, ""));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "does not specify a value for required field 'Member Order'");
@@ -115,7 +122,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, "hmm"));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "invalid value for field 'Member Order', it must be an integer");
@@ -129,7 +136,7 @@ public class MemberOrderCsvTransformerTest {
                 "file.txt", "text/plain", false, -4));
         var csvPath = writeCsvFile(entries);
         try {
-            MemberOrderCsvTransformer.toSetRequest(csvPath);
+            transformer.toRequest(csvPath);
             fail();
         } catch (IllegalArgumentException e) {
             assertErrorMessageContains(e, "invalid value for field 'Member Order', it must be >= 0");
@@ -149,7 +156,7 @@ public class MemberOrderCsvTransformerTest {
                 "file4.txt", "text/plain", false, 0));
         var csvPath = writeCsvFile(entries);
 
-        var request = MemberOrderCsvTransformer.toSetRequest(csvPath);
+        var request = transformer.toRequest(csvPath);
         assertEquals(OrderOperationType.SET, request.getOperation());
         var parentToOrder = request.getParentToOrdered();
         var parent1Children = parentToOrder.get(PARENT1_UUID);
@@ -165,7 +172,7 @@ public class MemberOrderCsvTransformerTest {
         entries.add(Arrays.asList(PARENT1_UUID, CHILD2_UUID, 1));
         var csvPath = writeCsvFile(entries, PARENT_PID_HEADER, PID_HEADER, ORDER_HEADER);
 
-        var request = MemberOrderCsvTransformer.toSetRequest(csvPath);
+        var request = transformer.toRequest(csvPath);
         assertEquals(OrderOperationType.SET, request.getOperation());
         var parentToOrder = request.getParentToOrdered();
         var parent1Children = parentToOrder.get(PARENT1_UUID);

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/MvcTestHelpers.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/MvcTestHelpers.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.web.services.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.fasterxml.jackson.databind.type.TypeFactory.defaultInstance;
+
+/**
+ * @author bbpennel
+ */
+public class MvcTestHelpers {
+    private MvcTestHelpers() {
+    }
+
+    public static Map<String, Object> getMapFromResponse(MvcResult result) throws Exception {
+        MapType type = defaultInstance().constructMapType(HashMap.class, String.class, Object.class);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(result.getResponse().getContentAsString(), type);
+    }
+}

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/AbstractAPIIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/AbstractAPIIT.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import edu.unc.lib.boxc.web.services.rest.MvcTestHelpers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -111,9 +112,7 @@ public abstract class AbstractAPIIT {
     }
 
     protected Map<String, Object> getMapFromResponse(MvcResult result) throws Exception {
-        MapType type = defaultInstance().constructMapType(HashMap.class, String.class, Object.class);
-        ObjectMapper mapper = new ObjectMapper();
-        return mapper.readValue(result.getResponse().getContentAsString(), type);
+        return MvcTestHelpers.getMapFromResponse(result);
     }
 
     protected byte[] makeRequestBody(Object details) throws Exception {

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/MemberOrderControllerTest.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.boxc.web.services.rest.modify;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
 import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
@@ -23,7 +25,11 @@ import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
 import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.order.MemberOrderRequestSender;
+import edu.unc.lib.boxc.operations.jms.order.MultiParentOrderRequest;
 import edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter;
+import edu.unc.lib.boxc.web.services.processing.MemberOrderCsvTransformer;
+import edu.unc.lib.boxc.web.services.rest.MvcTestHelpers;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,20 +37,30 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
+import static com.fasterxml.jackson.databind.type.TypeFactory.defaultInstance;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -64,6 +80,10 @@ public class MemberOrderControllerTest {
     private WebApplicationContext context;
     @Autowired
     private MemberOrderCsvExporter csvExporter;
+    @Autowired
+    private MemberOrderRequestSender requestSender;
+    @Autowired
+    private MemberOrderCsvTransformer csvTransformer;
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
 
@@ -71,6 +91,7 @@ public class MemberOrderControllerTest {
 
     @Before
     public void init() throws Exception {
+        reset(csvTransformer, csvExporter, requestSender);
         mvc = MockMvcBuilders
                 .webAppContextSetup(context)
                 .build();
@@ -150,5 +171,58 @@ public class MemberOrderControllerTest {
         mvc.perform(get("/edit/memberOrder/export/csv?ids=" + ids))
                 .andExpect(status().is4xxClientError())
                 .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvImportSuccessTest() throws Exception {
+        var generatedRequest = new MultiParentOrderRequest();
+        when(csvTransformer.toRequest(any())).thenReturn(generatedRequest);
+
+        MockMultipartFile importFile = new MockMultipartFile("file",
+                "some,csv,content".getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/memberOrder/import/csv"))
+                        .file(importFile))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        var respMap = MvcTestHelpers.getMapFromResponse(result);
+        assertEquals("import member order", respMap.get("action"));
+        verify(requestSender).sendToQueue(eq(generatedRequest));
+    }
+
+    @Test
+    public void memberOrderCsvImportInvalidInputTest() throws Exception {
+        when(csvTransformer.toRequest(any())).thenThrow(new IllegalArgumentException("this isn't right"));
+
+        MockMultipartFile importFile = new MockMultipartFile("file",
+                "some,csv,content".getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/memberOrder/import/csv"))
+                        .file(importFile))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+    }
+
+    @Test
+    public void memberOrderCsvImportReadFailureTest() throws Exception {
+        var generatedRequest = new MultiParentOrderRequest();
+        when(csvTransformer.toRequest(any())).thenReturn(generatedRequest);
+
+        doThrow(new IOException()).when(requestSender).sendToQueue(any());
+
+        MockMultipartFile importFile = new MockMultipartFile("file",
+                "some,csv,content".getBytes(StandardCharsets.UTF_8));
+
+        MvcResult result = mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/memberOrder/import/csv"))
+                        .file(importFile))
+                .andExpect(status().is5xxServerError())
+                .andReturn();
+    }
+
+    protected Map<String, Object> getMapFromResponse(MvcResult result) throws Exception {
+        MapType type = defaultInstance().constructMapType(HashMap.class, String.class, Object.class);
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(result.getResponse().getContentAsString(), type);
     }
 }

--- a/web-services-app/src/test/resources/member-order-test-servlet.xml
+++ b/web-services-app/src/test/resources/member-order-test-servlet.xml
@@ -36,4 +36,12 @@
     <bean id="memberOrderCsvExporter" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.boxc.web.services.processing.MemberOrderCsvExporter" />
     </bean>
+
+    <bean id="memberOrderCsvTransformer" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.web.services.processing.MemberOrderCsvTransformer" />
+    </bean>
+
+    <bean id="memberOrderRequestSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.operations.jms.order.MemberOrderRequestSender" />
+    </bean>
 </beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3764

* Enables updating member order via importing a CSV document
    * Adds service for turning CSV into MultiParentOrderRequest
    * Adds service for queuing these requests
    * Wires up all the services needed to perform this service
    * Adds API endpoint for doing the import
* Refactor some common constants/methods into helper classes for better access, plus some refactoring suggested by intellij