### PR TITLE
BXC-3792 remove job validator code and moving methods to helpers

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -18,6 +18,12 @@ package edu.unc.lib.boxc.operations.api.order;
 import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.ids.PID;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 /**
  * Helpers for member order operations
  *
@@ -45,5 +51,34 @@ public class MemberOrderHelper {
     public static String formatUnsupportedMessage(PID pid, ResourceType resourceType) {
         return "Object " + pid.getId() + " of type " + resourceType.name()
                 + " does not support member ordering";
+    }
+
+    /**
+     *
+     * @param parentId UUID of parent object
+     * @param reason reason child objects may not be ordered
+     * @param problemPids PIDs of child objects that are not valid to be ordered
+     * @return formatted error message
+     */
+    public static String formatErrorMessage(String parentId, String reason, Collection<PID> problemPids) {
+        return "Invalid request to set order for " + parentId
+                + ", " + reason + ": "
+                + problemPids.stream().map(PID::getId).collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Produces a map of pids to number of times the pid appears and collects duplicates
+     * @param pids list of PIDs
+     * @return list of duplicate PIDs
+     */
+    public static List<PID> computeDuplicates(List<PID> pids) {
+        // Produces a map of pids to number of times the pid appears
+        return pids.stream().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+                .entrySet()
+                .stream()
+                // filter to all the pids that appear more than once
+                .filter(e -> e.getValue() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
     }
 }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -61,7 +61,10 @@ public class MemberOrderHelper {
      * @param problemPids PIDs of child objects that are not valid to be ordered
      * @return formatted error message
      */
-    public static String formatErrorMessage(OrderOperationType type, String parentId, String reason, Collection<PID> problemPids) {
+    public static String formatErrorMessage(OrderOperationType type,
+                                            String parentId,
+                                            String reason,
+                                            Collection<PID> problemPids) {
         return "Invalid request to " + type + " order for " + parentId
                 + ", " + reason + ": "
                 + problemPids.stream().map(PID::getId).collect(Collectors.joining(", "));

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -17,6 +17,7 @@ package edu.unc.lib.boxc.operations.api.order;
 
 import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 
 import java.util.Collection;
 import java.util.List;
@@ -60,8 +61,8 @@ public class MemberOrderHelper {
      * @param problemPids PIDs of child objects that are not valid to be ordered
      * @return formatted error message
      */
-    public static String formatErrorMessage(String parentId, String reason, Collection<PID> problemPids) {
-        return "Invalid request to set order for " + parentId
+    public static String formatErrorMessage(OrderOperationType type, String parentId, String reason, Collection<PID> problemPids) {
+        return "Invalid request to " + type + " order for " + parentId
                 + ", " + reason + ": "
                 + problemPids.stream().map(PID::getId).collect(Collectors.joining(", "));
     }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactory.java
@@ -49,6 +49,12 @@ public class OrderValidatorFactory {
             validator.setRequest(request);
             return validator;
         }
+        case REMOVE_FROM: {
+            var validator = new RemoveFromOrderValidator();
+            validator.setRepositoryObjectLoader(repositoryObjectLoader);
+            validator.setRequest(request);
+            return validator;
+        }
         default:
             throw new UnsupportedOperationException("Unable to determine validator for request " + request);
         }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
@@ -16,8 +16,8 @@
 package edu.unc.lib.boxc.operations.impl.order;
 
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
-import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.operations.api.order.OrderValidator;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class RemoveFromOrderValidator implements OrderValidator {
         var requestPidSet = new HashSet<>(request.getOrderedChildren());
         if (requestPidSet.size() < request.getOrderedChildren().size()) {
             var duplicates = computeDuplicates(request.getOrderedChildren());
-            errors.add(formatErrorMessage(parentId, "it contained duplicate member IDs", duplicates));
+            errors.add(formatErrorMessage(OrderOperationType.REMOVE_FROM, parentId, "it contained duplicate member IDs", duplicates));
         }
 
         return errors.isEmpty();

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
@@ -59,7 +59,8 @@ public class RemoveFromOrderValidator implements OrderValidator {
         var requestPidSet = new HashSet<>(request.getOrderedChildren());
         if (requestPidSet.size() < request.getOrderedChildren().size()) {
             var duplicates = computeDuplicates(request.getOrderedChildren());
-            errors.add(formatErrorMessage(OrderOperationType.REMOVE_FROM, parentId, "it contained duplicate member IDs", duplicates));
+            errors.add(formatErrorMessage(OrderOperationType.REMOVE_FROM,
+                    parentId, "it contained duplicate member IDs", duplicates));
         }
 
         return errors.isEmpty();

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidator.java
@@ -15,30 +15,26 @@
  */
 package edu.unc.lib.boxc.operations.impl.order;
 
-import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.operations.api.order.OrderValidator;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatUnsupportedMessage;
 import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.supportsMemberOrdering;
-import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatErrorMessage;
 import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.computeDuplicates;
+import static edu.unc.lib.boxc.operations.api.order.MemberOrderHelper.formatErrorMessage;
 
 /**
- * Validator for a request to set order. This is a stateful class, and will only validate once per instance.
- * @author bbpennel
+ * Validator for a request to remove member(s) from order of a work
+ * @author snluong
  */
-public class SetOrderValidator implements OrderValidator {
+public class RemoveFromOrderValidator implements OrderValidator {
     private RepositoryObjectLoader repositoryObjectLoader;
-    private MembershipService membershipService;
     private OrderRequest request;
     private Boolean result;
     private List<String> errors = new ArrayList<>();
@@ -66,30 +62,7 @@ public class SetOrderValidator implements OrderValidator {
             errors.add(formatErrorMessage(parentId, "it contained duplicate member IDs", duplicates));
         }
 
-        var members = membershipService.listMembers(request.getParentPid());
-        var membersNotInRequest = difference(members, requestPidSet);
-        if (!membersNotInRequest.isEmpty()) {
-            errors.add(formatErrorMessage(parentId,
-                    "the following members were expected but not listed", membersNotInRequest));
-        }
-
-        var requestedNotInMembers = difference(requestPidSet, members);
-        if (!requestedNotInMembers.isEmpty()) {
-            errors.add(formatErrorMessage(parentId, "the following IDs are not members", requestedNotInMembers));
-        }
-
         return errors.isEmpty();
-    }
-
-    /**
-     * @param setOne
-     * @param setTwo
-     * @return the difference from (setOne - setTwo)
-     */
-    private static Set<PID> difference(Collection<PID> setOne, Collection<PID> setTwo) {
-        Set<PID> result = new HashSet<>(setOne);
-        result.removeAll(setTwo);
-        return result;
     }
 
     @Override
@@ -99,10 +72,6 @@ public class SetOrderValidator implements OrderValidator {
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
         this.repositoryObjectLoader = repositoryObjectLoader;
-    }
-
-    public void setMembershipService(MembershipService membershipService) {
-        this.membershipService = membershipService;
     }
 
     public void setRequest(OrderRequest request) {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
@@ -19,6 +19,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.operations.api.order.OrderValidator;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.ArrayList;
@@ -63,19 +64,19 @@ public class SetOrderValidator implements OrderValidator {
         var requestPidSet = new HashSet<>(request.getOrderedChildren());
         if (requestPidSet.size() < request.getOrderedChildren().size()) {
             var duplicates = computeDuplicates(request.getOrderedChildren());
-            errors.add(formatErrorMessage(parentId, "it contained duplicate member IDs", duplicates));
+            errors.add(formatErrorMessage(OrderOperationType.SET, parentId, "it contained duplicate member IDs", duplicates));
         }
 
         var members = membershipService.listMembers(request.getParentPid());
         var membersNotInRequest = difference(members, requestPidSet);
         if (!membersNotInRequest.isEmpty()) {
-            errors.add(formatErrorMessage(parentId,
+            errors.add(formatErrorMessage(OrderOperationType.SET, parentId,
                     "the following members were expected but not listed", membersNotInRequest));
         }
 
         var requestedNotInMembers = difference(requestPidSet, members);
         if (!requestedNotInMembers.isEmpty()) {
-            errors.add(formatErrorMessage(parentId, "the following IDs are not members", requestedNotInMembers));
+            errors.add(formatErrorMessage(OrderOperationType.SET, parentId, "the following IDs are not members", requestedNotInMembers));
         }
 
         return errors.isEmpty();

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidator.java
@@ -64,7 +64,8 @@ public class SetOrderValidator implements OrderValidator {
         var requestPidSet = new HashSet<>(request.getOrderedChildren());
         if (requestPidSet.size() < request.getOrderedChildren().size()) {
             var duplicates = computeDuplicates(request.getOrderedChildren());
-            errors.add(formatErrorMessage(OrderOperationType.SET, parentId, "it contained duplicate member IDs", duplicates));
+            errors.add(formatErrorMessage(OrderOperationType.SET,
+                    parentId, "it contained duplicate member IDs", duplicates));
         }
 
         var members = membershipService.listMembers(request.getParentPid());
@@ -76,7 +77,8 @@ public class SetOrderValidator implements OrderValidator {
 
         var requestedNotInMembers = difference(requestPidSet, members);
         if (!requestedNotInMembers.isEmpty()) {
-            errors.add(formatErrorMessage(OrderOperationType.SET, parentId, "the following IDs are not members", requestedNotInMembers));
+            errors.add(formatErrorMessage(OrderOperationType.SET,
+                    parentId, "the following IDs are not members", requestedNotInMembers));
         }
 
         return errors.isEmpty();

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
@@ -15,10 +15,8 @@
  */
 package edu.unc.lib.boxc.operations.impl.order;
 
-import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,8 +33,6 @@ import static org.junit.Assert.assertTrue;
 public class OrderValidatorFactoryTest {
     private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
-    private PID parentPid;
-    private PID child1Pid;
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
     @Mock
@@ -49,8 +45,6 @@ public class OrderValidatorFactoryTest {
         factory = new OrderValidatorFactory();
         factory.setMembershipService(membershipService);
         factory.setRepositoryObjectLoader(repositoryObjectLoader);
-        parentPid = PIDs.get(PARENT_UUID);
-        child1Pid = PIDs.get(CHILD1_UUID);
     }
 
     @Test
@@ -63,5 +57,11 @@ public class OrderValidatorFactoryTest {
     public void forClearOrderRequestTest() {
         var request = OrderRequestFactory.createRequest(OrderOperationType.CLEAR, PARENT_UUID);
         assertTrue(factory.createValidator(request) instanceof ClearOrderValidator);
+    }
+
+    @Test
+    public void forRemoveFromOrderRequestTest() {
+        var request = OrderRequestFactory.createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID, Arrays.asList(CHILD1_UUID));
+        assertTrue(factory.createValidator(request) instanceof RemoveFromOrderValidator);
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromJobTest.java
@@ -22,7 +22,7 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
-import edu.unc.lib.boxc.operations.test.OrderJobTestHelper;
+import edu.unc.lib.boxc.operations.test.OrderTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +37,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import static edu.unc.lib.boxc.operations.test.OrderTestHelper.createRequest;
 
 /**
  * @author snluong
@@ -74,7 +76,7 @@ public class RemoveFromJobTest {
 
     @Test
     public void removeOneChildFromMemberOrder() {
-        var request = OrderJobTestHelper.createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID, CHILD1_UUID);
+        var request = createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID, CHILD1_UUID);
         var job = orderJobFactory.createJob(request);
         job.run();
         assertMemberOrderSetWithValue(CHILD2_UUID + "|" + CHILD3_UUID);
@@ -82,7 +84,7 @@ public class RemoveFromJobTest {
 
     @Test
     public void removeChildrenFromMemberOrder() {
-        var request = OrderJobTestHelper.createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID, CHILD1_UUID, CHILD2_UUID);
+        var request = createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID, CHILD1_UUID, CHILD2_UUID);
         var job = orderJobFactory.createJob(request);
         job.run();
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
@@ -29,8 +29,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.mockParentType;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.assertHasErrors;
@@ -90,7 +92,19 @@ public class RemoveFromOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors(validator,"Invalid request to set order for " + PARENT_UUID
+        assertHasErrors(validator,"Invalid request to REMOVE_FROM order for " + PARENT_UUID
                 + ", it contained duplicate member IDs: " + CHILD1_UUID);
+    }
+
+    @Test
+    public void validRequestTest(){
+        when(membershipService.listMembers(parentPid)).thenReturn(Arrays.asList(child1Pid, child2Pid, child3Pid));
+
+        var request = OrderRequestFactory.createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID,
+                List.of(CHILD1_UUID));
+        validator.setRequest(request);
+
+        assertTrue(validator.isValid());
+        assertTrue(validator.getErrors().isEmpty());
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.operations.impl.order;
+
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.services.MembershipService;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import edu.unc.lib.boxc.operations.test.OrderTestHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+import static edu.unc.lib.boxc.operations.test.OrderTestHelper.mockParentType;
+import static edu.unc.lib.boxc.operations.test.OrderTestHelper.assertHasErrors;
+
+/**
+ * @author snluong
+ */
+public class RemoveFromOrderValidatorTest {
+    private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
+    private static final String CHILD3_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    @Mock
+    private RepositoryObjectLoader repositoryObjectLoader;
+    @Mock
+    private MembershipService membershipService;
+    private PID parentPid;
+    private PID child1Pid;
+    private PID child2Pid;
+    private PID child3Pid;
+    @Mock
+    private RepositoryObject parentObj;
+    private RemoveFromOrderValidator validator;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        validator = new RemoveFromOrderValidator();
+        validator.setRepositoryObjectLoader(repositoryObjectLoader);
+
+        parentPid = PIDs.get(PARENT_UUID);
+        child1Pid = PIDs.get(CHILD1_UUID);
+        child2Pid = PIDs.get(CHILD2_UUID);
+        child3Pid = PIDs.get(CHILD3_UUID);
+        when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentObj);
+        mockParentType(parentObj, ResourceType.Work);
+    }
+
+    @Test
+    public void targetNotAWorkTest() {
+        OrderTestHelper.mockParentType(parentObj, ResourceType.AdminUnit);
+        var request = OrderRequestFactory.createRequest(OrderOperationType.SET, PARENT_UUID,
+                Arrays.asList(CHILD1_UUID, CHILD2_UUID));
+        validator.setRequest(request);
+
+        assertFalse(validator.isValid());
+        assertHasErrors(validator,
+                "Object " + PARENT_UUID + " of type AdminUnit does not support member ordering");
+    }
+
+    @Test
+    public void duplicateIdsTest() {
+        when(membershipService.listMembers(parentPid)).thenReturn(Arrays.asList(child1Pid, child2Pid, child3Pid));
+
+        var request = OrderRequestFactory.createRequest(OrderOperationType.REMOVE_FROM, PARENT_UUID,
+                Arrays.asList(CHILD1_UUID, CHILD2_UUID, CHILD1_UUID));
+        validator.setRequest(request);
+
+        assertFalse(validator.isValid());
+        assertHasErrors(validator,"Invalid request to set order for " + PARENT_UUID
+                + ", it contained duplicate member IDs: " + CHILD1_UUID);
+    }
+}

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJobTest.java
@@ -22,7 +22,7 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
-import edu.unc.lib.boxc.operations.test.OrderJobTestHelper;
+import edu.unc.lib.boxc.operations.test.OrderTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -67,7 +67,7 @@ public class SetOrderJobTest {
 
     @Test
     public void singleChildTest() {
-        var request = OrderJobTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD1_UUID);
+        var request = OrderTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD1_UUID);
         var job = orderJobFactory.createJob(request);
         job.run();
 
@@ -76,7 +76,7 @@ public class SetOrderJobTest {
 
     @Test
     public void multipleChildrenTest() {
-        var request = OrderJobTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD1_UUID, CHILD2_UUID, CHILD3_UUID);
+        var request = OrderTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD1_UUID, CHILD2_UUID, CHILD3_UUID);
         var job = orderJobFactory.createJob(request);
         job.run();
 
@@ -85,7 +85,7 @@ public class SetOrderJobTest {
 
     @Test
     public void multipleChildrenAlternateOrderTest() {
-        var request = OrderJobTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD2_UUID, CHILD3_UUID, CHILD1_UUID);
+        var request = OrderTestHelper.createRequest(OrderOperationType.SET, PARENT_UUID, CHILD2_UUID, CHILD3_UUID, CHILD1_UUID);
         var job = orderJobFactory.createJob(request);
         job.run();
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
@@ -96,7 +96,7 @@ public class SetOrderValidatorTest {
         assertFalse(validator.isValid());
         assertHasErrors(
                 validator,
-                "Invalid request to set order for " + PARENT_UUID
+                "Invalid request to SET order for " + PARENT_UUID
                 + ", the following IDs are not members: " + CHILD1_UUID + ", " + CHILD2_UUID);
     }
 
@@ -111,7 +111,7 @@ public class SetOrderValidatorTest {
         assertFalse(validator.isValid());
         assertHasErrors(
                 validator,
-                "Invalid request to set order for " + PARENT_UUID
+                "Invalid request to SET order for " + PARENT_UUID
                 + ", the following members were expected but not listed: " + CHILD1_UUID + ", " + CHILD3_UUID);
     }
 
@@ -126,9 +126,9 @@ public class SetOrderValidatorTest {
         assertFalse(validator.isValid());
         assertHasErrors(
                 validator,
-                "Invalid request to set order for " + PARENT_UUID
+                "Invalid request to SET order for " + PARENT_UUID
                         + ", the following members were expected but not listed: " + CHILD1_UUID,
-                "Invalid request to set order for " + PARENT_UUID
+                "Invalid request to SET order for " + PARENT_UUID
                         + ", the following IDs are not members: " + CHILD2_UUID);
     }
 
@@ -141,7 +141,7 @@ public class SetOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors(validator,"Invalid request to set order for " + PARENT_UUID
+        assertHasErrors(validator,"Invalid request to SET order for " + PARENT_UUID
                 + ", it contained duplicate member IDs: " + CHILD1_UUID);
     }
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
@@ -30,10 +30,11 @@ import org.mockito.MockitoAnnotations;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
+import static edu.unc.lib.boxc.operations.test.OrderTestHelper.assertHasErrors;
+import static edu.unc.lib.boxc.operations.test.OrderTestHelper.mockParentType;
 
 /**
  * @author bbpennel
@@ -68,22 +69,20 @@ public class SetOrderValidatorTest {
         child2Pid = PIDs.get(CHILD2_UUID);
         child3Pid = PIDs.get(CHILD3_UUID);
         when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentObj);
-        mockParentType(ResourceType.Work);
-    }
-
-    private void mockParentType(ResourceType resourceType) {
-        when(parentObj.getResourceType()).thenReturn(resourceType);
+        mockParentType(parentObj, ResourceType.Work);
     }
 
     @Test
     public void targetNotAWorkTest() throws Exception {
-        mockParentType(ResourceType.AdminUnit);
+        mockParentType(parentObj, ResourceType.AdminUnit);
         var request = OrderRequestFactory.createRequest(OrderOperationType.SET, PARENT_UUID,
                 Arrays.asList(CHILD1_UUID, CHILD2_UUID));
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors("Object " + PARENT_UUID + " of type AdminUnit does not support member ordering");
+        assertHasErrors(
+                validator,
+                "Object " + PARENT_UUID + " of type AdminUnit does not support member ordering");
     }
 
     @Test
@@ -95,7 +94,9 @@ public class SetOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors("Invalid request to set order for " + PARENT_UUID
+        assertHasErrors(
+                validator,
+                "Invalid request to set order for " + PARENT_UUID
                 + ", the following IDs are not members: " + CHILD1_UUID + ", " + CHILD2_UUID);
     }
 
@@ -108,7 +109,9 @@ public class SetOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors("Invalid request to set order for " + PARENT_UUID
+        assertHasErrors(
+                validator,
+                "Invalid request to set order for " + PARENT_UUID
                 + ", the following members were expected but not listed: " + CHILD1_UUID + ", " + CHILD3_UUID);
     }
 
@@ -122,6 +125,7 @@ public class SetOrderValidatorTest {
 
         assertFalse(validator.isValid());
         assertHasErrors(
+                validator,
                 "Invalid request to set order for " + PARENT_UUID
                         + ", the following members were expected but not listed: " + CHILD1_UUID,
                 "Invalid request to set order for " + PARENT_UUID
@@ -137,7 +141,7 @@ public class SetOrderValidatorTest {
         validator.setRequest(request);
 
         assertFalse(validator.isValid());
-        assertHasErrors("Invalid request to set order for " + PARENT_UUID
+        assertHasErrors(validator,"Invalid request to set order for " + PARENT_UUID
                 + ", it contained duplicate member IDs: " + CHILD1_UUID);
     }
 
@@ -163,11 +167,5 @@ public class SetOrderValidatorTest {
 
         assertTrue(validator.isValid());
         assertTrue(validator.getErrors().isEmpty());
-    }
-
-    private void assertHasErrors(String... expected) {
-        var msg = "Expected errors:\n[" + String.join(",", expected) + "]\nbut errors were:\n" + validator.getErrors();
-        assertTrue(msg, validator.getErrors().containsAll(Arrays.asList(expected)));
-        assertEquals(msg, expected.length, validator.getErrors().size());
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/test/OrderTestHelper.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/test/OrderTestHelper.java
@@ -15,19 +15,37 @@
  */
 package edu.unc.lib.boxc.operations.test;
 
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.operations.api.order.OrderValidator;
 import edu.unc.lib.boxc.operations.impl.order.OrderRequestFactory;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 
 import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 /**
  * Helper methods for all OrderJob related tests
  * @author snluong
  */
-public class OrderJobTestHelper {
+public class OrderTestHelper {
     public static OrderRequest createRequest(OrderOperationType operationType, String parentUuid, String... children) {
         return OrderRequestFactory.createRequest(
                 operationType, parentUuid, Arrays.asList(children));
+    }
+
+    public static void mockParentType(RepositoryObject parentObj, ResourceType resourceType) {
+        when(parentObj.getResourceType()).thenReturn(resourceType);
+    }
+
+    public static void assertHasErrors(OrderValidator validator, String... expected) {
+        var msg = "Expected errors:\n[" + String.join(",", expected) + "]\nbut errors were:\n" + validator.getErrors();
+        assertTrue(msg, validator.getErrors().containsAll(Arrays.asList(expected)));
+        assertEquals(msg, expected.length, validator.getErrors().size());
     }
 }


### PR DESCRIPTION
This PR adds a validator for the RemoveFromOrderJob. In doing so, methods in common with SetOrderJob and its validators/tests were moved to helpers as well.
https://jira.lib.unc.edu/browse/BXC-3792