### PR TITLE
Bxc 3808 file ordering facet

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
@@ -60,17 +60,7 @@ public class SetContentStatusFilter implements IndexDocumentFilter{
         }
 
         if (obj instanceof WorkObject) {
-            if (resc.hasProperty(Cdr.primaryObject)) {
-                status.add(FacetConstants.HAS_PRIMARY_OBJECT);
-            } else {
-                status.add(FacetConstants.NO_PRIMARY_OBJECT);
-            }
-
-            if (resc.hasProperty(Cdr.memberOrder)) {
-                status.add(FacetConstants.MEMBERS_ARE_ORDERED);
-            } else {
-                status.add(FacetConstants.MEMBERS_ARE_UNORDERED);
-            }
+            addWorkObjectStatuses(status, resc);
         }
 
         if (obj instanceof FileObject) {
@@ -81,5 +71,19 @@ public class SetContentStatusFilter implements IndexDocumentFilter{
         }
 
         return status;
+    }
+
+    private void addWorkObjectStatuses(List<String> status, Resource resource) {
+        if (resource.hasProperty(Cdr.primaryObject)) {
+            status.add(FacetConstants.HAS_PRIMARY_OBJECT);
+        } else {
+            status.add(FacetConstants.NO_PRIMARY_OBJECT);
+        }
+
+        if (resource.hasProperty(Cdr.memberOrder)) {
+            status.add(FacetConstants.MEMBERS_ARE_ORDERED);
+        } else {
+            status.add(FacetConstants.MEMBERS_ARE_UNORDERED);
+        }
     }
 }

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
@@ -65,6 +65,12 @@ public class SetContentStatusFilter implements IndexDocumentFilter{
             } else {
                 status.add(FacetConstants.NO_PRIMARY_OBJECT);
             }
+
+            if (resc.hasProperty(Cdr.memberOrder)) {
+                status.add(FacetConstants.MEMBERS_ARE_ORDERED);
+            } else {
+                status.add(FacetConstants.MEMBERS_ARE_UNORDERED);
+            }
         }
 
         if (obj instanceof FileObject) {

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
@@ -165,4 +165,29 @@ public class SetContentStatusFilterTest {
 
         verify(idb).setContentStatus(listCaptor.capture());
     }
+
+    @Test
+    public void testWorkWithMemberOrder() {
+        when(dip.getContentObject()).thenReturn(workObj);
+        when(workObj.getResource()).thenReturn(resc);
+        when(resc.hasProperty(Cdr.memberOrder)).thenReturn(true);
+
+        filter.filter(dip);
+
+        verify(idb).setContentStatus(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_ORDERED));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_UNORDERED));
+    }
+
+    @Test
+    public void testWorkWithoutMemberOrder() {
+        when(dip.getContentObject()).thenReturn(workObj);
+        when(workObj.getResource()).thenReturn(resc);
+
+        filter.filter(dip);
+
+        verify(idb).setContentStatus(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_UNORDERED));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_ORDERED));
+    }
 }

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/FacetConstants.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/FacetConstants.java
@@ -36,4 +36,6 @@ public abstract class FacetConstants {
     public static final String INHERITED_PATRON_SETTINGS = "Inherited Patron Settings";
     public static final String PUBLIC_ACCESS = "Public Access";
     public static final String STAFF_ONLY_ACCESS = "Staff-Only Access";
+    public static final String MEMBERS_ARE_ORDERED = "Members Are Ordered";
+    public static final String MEMBERS_ARE_UNORDERED = "Members Are Unordered";
 }

--- a/static/js/admin/src/ResultObject.js
+++ b/static/js/admin/src/ResultObject.js
@@ -31,7 +31,7 @@ define('ResultObject', [ 'jquery', 'jquery-ui', 'underscore', 'ModalLoadingOverl
 
 		if (tags.length > 0) {
 			this.metadata.tags = tags.filter(function(d) {
-				return !/^(has|not|no.primary|public.access)/i.test(d);
+				return !/^(has|not|no.primary|public.access|members.are.unordered)/i.test(d);
 			}).map(function(d) {
 				var tagValue;
 

--- a/static/member_order_csv.html
+++ b/static/member_order_csv.html
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html lang="en">
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<link href="/static/css/reset.css" type="text/css" rel="stylesheet">
+<link href="/static/css/cdrui_styles.css" type="text/css" rel="stylesheet">
+<meta content="Digital Collections Repository" name="description">
+<meta content="Digital Collections Repository" name="keywords">
+<meta content="noindex, nofollow" name="robots">
+<link type="image/x-icon" href="/static/images/favicon.ico" rel="shortcut icon">
+<title>Digital Collections Repository</title>
+</head>
+<body>
+  <h1>Update Member Order via CSV</h1>
+<form method="POST" action="/services/api/edit/memberOrder/import/csv" enctype="multipart/form-data">
+  <input type="file" id="file" name="file">
+  <input type="submit" value="Submit">
+</form>
+</body>
+</html>


### PR DESCRIPTION
This adds the ability to filter by member ordering in the content facets, and adds a "members-are-ordered" tag to the works whose members are ordered.
https://jira.lib.unc.edu/browse/BXC-3808

![Screen Shot 2022-10-26 at 2 20 38 PM](https://user-images.githubusercontent.com/6546457/198111759-e4a2d6e1-cf42-4ec1-a456-eed4996add1e.png)
