### PR TITLE
BXC-3887 - Camel healthcheck endpoint

### DIFF
--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -135,6 +135,10 @@
         <artifactId>spring-expression</artifactId>
         <version>${spring.version}</version>
     </dependency>
+    <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc</artifactId>
+    </dependency>
     
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/http/HealthChecksController.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/http/HealthChecksController.java
@@ -1,18 +1,3 @@
-/**
- * Copyright 2008 The University of North Carolina at Chapel Hill
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package edu.unc.lib.boxc.services.camel.http;
 
 import org.apache.camel.CamelContext;

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/http/HealthChecksController.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/http/HealthChecksController.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.services.camel.http;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.health.HealthCheckHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * Controller for performing health checks on the application and camel context
+ *
+ * @author bbpennel
+ */
+@Controller
+public class HealthChecksController {
+    @Autowired
+    private CamelContext metaServicesRouter;
+
+    /**
+     * API endpoint which checks if the camel context is available.
+     * @return response code of 503 if camel is not started, 200 if it is
+     */
+    @RequestMapping(value = "/health/camelUp", method = RequestMethod.GET)
+    public @ResponseBody ResponseEntity<Object> isUpCheck() {
+        var resp = HealthCheckHelper.invoke(metaServicesRouter);
+        for (var result : resp) {
+            if (!HealthCheck.State.UP.equals(result.getState())) {
+                return new ResponseEntity<>(HttpStatus.SERVICE_UNAVAILABLE);
+            }
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/services-camel-app/src/main/webapp/WEB-INF/rest-servlet.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/rest-servlet.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright 2008 The University of North Carolina at Chapel Hill
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-            http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:mvc="http://www.springframework.org/schema/mvc"

--- a/services-camel-app/src/main/webapp/WEB-INF/rest-servlet.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/rest-servlet.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan base-package="edu.unc.lib.boxc.services.camel.http"/>
+</beans>

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -529,7 +529,7 @@
     </camel:camelContext>
     
     <!-- Initialize metaServicesRouter after the routes it depends on -->
-    <camel:camelContext id="MetaServicesRouter">
+    <camel:camelContext id="metaServicesRouter">
         <camel:package>edu.unc.lib.boxc.services.camel.routing</camel:package>
     </camel:camelContext>
     

--- a/services-camel-app/src/main/webapp/WEB-INF/web.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/web.xml
@@ -17,4 +17,18 @@
             /WEB-INF/service-context.xml
         </param-value>
     </context-param>
+
+    <servlet>
+        <servlet-name>rest</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>/WEB-INF/rest-servlet.xml</param-value>
+        </init-param>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>rest</servlet-name>
+        <url-pattern>/api/*</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/http/HealthChecksControllerTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/http/HealthChecksControllerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.boxc.services.camel.http;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.health.HealthCheck;
+import org.apache.camel.health.HealthCheckRegistry;
+import org.apache.camel.health.HealthCheckResultBuilder;
+import org.apache.camel.health.HealthCheckService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration("/health-check-test-context.xml")
+public class HealthChecksControllerTest {
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private CamelContext metaServicesRouter;
+    @Mock
+    private HealthCheckService healthCheckService;
+    private MockMvc mvc;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+
+        when(metaServicesRouter.hasService(HealthCheckService.class)).thenReturn(healthCheckService);
+    }
+
+    @Test
+    public void camelUpOkTest() throws Exception {
+        var healthCheck = mock(HealthCheck.class);
+        var checkResult = HealthCheckResultBuilder.on(healthCheck).up().build();
+        when(healthCheckService.getResults()).thenReturn(Arrays.asList(checkResult));
+
+        mvc.perform(get("/health/camelUp"))
+                .andExpect(status().isOk())
+                .andReturn();
+    }
+
+    @Test
+    public void camelUpUnavailableTest() throws Exception {
+        var healthCheck = mock(HealthCheck.class);
+        var checkResult = HealthCheckResultBuilder.on(healthCheck).down().build();
+        when(healthCheckService.getResults()).thenReturn(Arrays.asList(checkResult));
+
+        mvc.perform(get("/health/camelUp"))
+                .andExpect(status().isServiceUnavailable())
+                .andReturn();
+    }
+}

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/http/HealthChecksControllerTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/http/HealthChecksControllerTest.java
@@ -1,18 +1,3 @@
-/**
- * Copyright 2008 The University of North Carolina at Chapel Hill
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package edu.unc.lib.boxc.services.camel.http;
 
 import org.apache.camel.CamelContext;

--- a/services-camel-app/src/test/resources/health-check-test-context.xml
+++ b/services-camel-app/src/test/resources/health-check-test-context.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-    Copyright 2008 The University of North Carolina at Chapel Hill
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-            http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
--->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:mvc="http://www.springframework.org/schema/mvc"

--- a/services-camel-app/src/test/resources/health-check-test-context.xml
+++ b/services-camel-app/src/test/resources/health-check-test-context.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <bean id="metaServicesRouter" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="org.apache.camel.CamelContext" />
+    </bean>
+
+    <context:component-scan base-package="edu.unc.lib.boxc.services.camel.http"/>
+</beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3887
* Add api endpoint to services-camel to allow for HTTP requests to find out if camel is up and running. This will allow us to detect if the dcr-services-camel app hasn't started, or if it has started but the camel context is not available.
* Needed to add spring-webmvc for the controller and its test