### PR TITLE
Bxc 3594 add collection id search

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
@@ -443,6 +443,11 @@ public class SearchStateFactory {
             searchState.addFacet(fileFormatCat);
         }
 
+        parameter = getParameter(request, SearchFieldKey.COLLECTION_ID.getUrlParam());
+        if (parameter != null && parameter.length() > 0) {
+            searchState.getSearchFields().put(SearchFieldKey.COLLECTION_ID.name(), parameter);
+        }
+
         //Store date added.
         RangePair dateAdded = new RangePair();
         parameter = getParameter(request, SearchFieldKey.DATE_ADDED.getUrlParam() + "Start");

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactoryTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactoryTest.java
@@ -254,4 +254,15 @@ public class SearchStateFactoryTest {
         SearchState searchState = searchStateFactory.createSearchState(parameters);
         assertFalse(searchState.getRangeFields().containsKey(SearchFieldKey.DATE_CREATED_YEAR.name()));
     }
+
+    @Test
+    public void extractAdvancedSearchCollectionIdRight() {
+        Map<String, String[]> parameters = new LinkedHashMap<>();
+        parameters.put("collectionId", new String[]{"40000"});
+
+        SearchState searchState = searchStateFactory.createSearchStateAdvancedSearch(parameters);
+        assertTrue(searchState.getSearchFields().containsKey(SearchFieldKey.COLLECTION_ID.name()));
+        assertEquals("40000", searchState.getSearchFields()
+                .get(SearchFieldKey.COLLECTION_ID.name()));
+    }
 }

--- a/static/css/cdrui_styles.css
+++ b/static/css/cdrui_styles.css
@@ -516,7 +516,7 @@ ul.fpfeed_list li {
 }
 
 .advsearch_text {
-	width: 320px;
+	width: 315px;
 	border: 1px solid #c8d8e0;
 	padding: 5px;
 	font-size: 12px;
@@ -549,6 +549,10 @@ ul.fpfeed_list li {
 
 #advsearch_submit:hover {
 	background-color: #862e03;
+}
+
+#advanced-search-form label {
+	width: 110px;
 }
 
 label {

--- a/static/css/cdrui_styles.css
+++ b/static/css/cdrui_styles.css
@@ -516,7 +516,7 @@ ul.fpfeed_list li {
 }
 
 .advsearch_text {
-	width: 315px;
+	width: 300px;
 	border: 1px solid #c8d8e0;
 	padding: 5px;
 	font-size: 12px;
@@ -552,7 +552,7 @@ ul.fpfeed_list li {
 }
 
 #advanced-search-form label {
-	width: 110px;
+	width: 125px;
 }
 
 label {

--- a/static/js/vue-cdr-access/src/components/filterTags.vue
+++ b/static/js/vue-cdr-access/src/components/filterTags.vue
@@ -37,7 +37,8 @@ const TYPES = {
     subject: 'Subject',
     subjectIndex: 'Subject',
     titleIndex: 'Title',
-    genre: 'Genre'
+    genre: 'Genre',
+    collectionId: 'Collection Number'
 }
 
 export default {

--- a/web-access-app/src/main/resources/search.properties
+++ b/web-access-app/src/main/resources/search.properties
@@ -1,7 +1,7 @@
 search.results.maxPerPage=2000
 #Fields which are searchable via keyword searches
-search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX,IDENTIFIER,COLLECTION_ID\
-,RLA_SITE_CODE,RLA_CATALOG_NUMBER,RLA_CONTEXT_1
+search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX,IDENTIFIER\
+,RLA_SITE_CODE,RLA_CATALOG_NUMBER,RLA_CONTEXT_1,COLLECTION_ID
 #Set to one higher than you want to display as the last value indicates whether the UI should show a "show more" link
 search.facet.facetsPerGroup=6
 search.facet.expandedFacetsPerGroup=20

--- a/web-access-app/src/main/resources/search.properties
+++ b/web-access-app/src/main/resources/search.properties
@@ -1,6 +1,6 @@
 search.results.maxPerPage=2000
 #Fields which are searchable via keyword searches
-search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX,IDENTIFIER\
+search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX,IDENTIFIER,COLLECTION_ID\
 ,RLA_SITE_CODE,RLA_CATALOG_NUMBER,RLA_CONTEXT_1
 #Set to one higher than you want to display as the last value indicates whether the UI should show a "show more" link
 search.facet.facetsPerGroup=6

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
@@ -26,7 +26,7 @@
 					<label for="subject">Subject</label> <input id="subject" name="${SearchFieldKey.SUBJECT_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 				<p class="clear has-text-weight-bold">
-					<label for="subject">Collection Number</label> <input id="collection_id" name="${SearchFieldKey.COLLECTION_ID.getUrlParam()}" class="advsearch_text" type="text" />
+					<label for="subject">Archival Collection ID</label> <input id="collection_id" name="${SearchFieldKey.COLLECTION_ID.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
 			</div>
 		</div>

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
@@ -46,7 +46,7 @@
 					</c:forEach>
 				</select>
 				
-				<p class="clear"><br /></p>
+				<p class="clear"><br /><br /></p>
 				<p class="clear has-text-weight-bold">
 					<label>Date Deposited</label> from <input aria-label="deposited-start-date" name="${SearchFieldKey.DATE_ADDED.getUrlParam()}Start" class="advsearch_date" type="text" />
 						 to <input aria-label="deposited-end-date" name="${SearchFieldKey.DATE_ADDED.getUrlParam()}End" class="advsearch_date" type="text" />

--- a/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
+++ b/web-access-app/src/main/webapp/WEB-INF/jsp/advancedSearch.jsp
@@ -25,6 +25,9 @@
 				<p class="clear has-text-weight-bold">
 					<label for="subject">Subject</label> <input id="subject" name="${SearchFieldKey.SUBJECT_INDEX.getUrlParam()}" class="advsearch_text" type="text" />
 				</p>
+				<p class="clear has-text-weight-bold">
+					<label for="subject">Collection Number</label> <input id="collection_id" name="${SearchFieldKey.COLLECTION_ID.getUrlParam()}" class="advsearch_text" type="text" />
+				</p>
 			</div>
 		</div>
 		<div class="twocol light shadowtop">


### PR DESCRIPTION
This PR adds a search by collection ID field to the advanced search. It also provides a filter tag at the top of the search results when the field is used.
![Screen Shot 2022-12-12 at 11 05 27 AM](https://user-images.githubusercontent.com/6546457/207094451-d85e1868-2580-4b33-8ce0-ff4abc5295d0.png)

https://jira.lib.unc.edu/browse/BXC-3594

