### PR TITLE
BXC-3922 - Use longs for deposit cleanup delay

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/CleanupDepositJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/CleanupDepositJob.java
@@ -37,6 +37,7 @@ public class CleanupDepositJob extends AbstractDepositJob {
 
     private IngestSourceManager sourceManager;
 
+    // Redis expects to receive ints for its delays
     private int statusKeysExpireSeconds;
 
     public CleanupDepositJob() {

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/work/DepositSupervisor.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/work/DepositSupervisor.java
@@ -144,28 +144,28 @@ public class DepositSupervisor implements WorkerListener {
 
     private long actionMonitorDelay = 1000l;
 
-    private int cleanupDelaySeconds;
+    private long cleanupDelaySeconds;
 
-    private int unavailableDelaySeconds;
+    private long unavailableDelaySeconds;
 
     private boolean isQuieted;
 
     // Visible for testing
     protected ActionMonitoringTask actionMonitoringTask;
 
-    public int getCleanupDelaySeconds() {
+    public long getCleanupDelaySeconds() {
         return cleanupDelaySeconds;
     }
 
-    public void setCleanupDelaySeconds(int cleanupDelaySeconds) {
+    public void setCleanupDelaySeconds(long cleanupDelaySeconds) {
         this.cleanupDelaySeconds = cleanupDelaySeconds;
     }
 
-    public int getUnavailableDelaySeconds() {
+    public long getUnavailableDelaySeconds() {
         return unavailableDelaySeconds;
     }
 
-    public void setUnavailableDelaySeconds(int unavailableDelaySeconds) {
+    public void setUnavailableDelaySeconds(long unavailableDelaySeconds) {
         this.unavailableDelaySeconds = unavailableDelaySeconds;
     }
 
@@ -882,7 +882,7 @@ public class DepositSupervisor implements WorkerListener {
             Job cleanJob = makeJob(CleanupDepositJob.class, depositUUID);
             LOG.info("Queuing {} for deposit {}",
                     cleanJob.getClassName(), depositUUID);
-            enqueueJob(cleanJob, status, 1000 * this.getCleanupDelaySeconds());
+            enqueueJob(cleanJob, status, 1000l * this.getCleanupDelaySeconds());
         }
     }
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3922
* Switch cleanup delay to using long instead of int everywhere, to avoid overflow issues for long delays in milliseconds