### PR TITLE
BXC-3585 - Download requests for work IDs behavior

### DIFF
--- a/web-access-app/src/test/java/edu/unc/lib/boxc/web/access/controllers/FedoraContentControllerIT.java
+++ b/web-access-app/src/test/java/edu/unc/lib/boxc/web/access/controllers/FedoraContentControllerIT.java
@@ -1,20 +1,19 @@
 package edu.unc.lib.boxc.web.access.controllers;
 
-import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
-import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getTechnicalMetadataPid;
-import static edu.unc.lib.boxc.model.fcrepo.test.TestHelper.makePid;
-import static edu.unc.lib.boxc.web.common.services.FedoraContentService.CONTENT_DISPOSITION;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.io.File;
-import java.net.URI;
-
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
+import edu.unc.lib.boxc.search.api.models.Datastream;
+import edu.unc.lib.boxc.search.solr.models.DatastreamImpl;
+import edu.unc.lib.boxc.web.common.services.SolrQueryLayerService;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,16 +31,23 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
-import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
-import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
-import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
-import edu.unc.lib.boxc.auth.api.Permission;
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+
+import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getTechnicalMetadataPid;
+import static edu.unc.lib.boxc.model.fcrepo.test.TestHelper.makePid;
+import static edu.unc.lib.boxc.web.common.services.FedoraContentService.CONTENT_DISPOSITION;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  *
@@ -63,6 +69,8 @@ public class FedoraContentControllerIT {
     private RepositoryObjectFactory repositoryObjectFactory;
     @Autowired
     private AccessControlService accessControlService;
+    @Autowired
+    private SolrQueryLayerService queryLayer;
 
     protected MockMvc mvc;
     @Autowired
@@ -85,9 +93,23 @@ public class FedoraContentControllerIT {
 
     }
 
+    private ContentObjectRecord mockSolrRecord(PID pid) {
+        var contentRecord = mock(ContentObjectRecord.class);
+        when(contentRecord.getId()).thenReturn(pid.getId());
+        when(queryLayer.getObjectById(any())).thenReturn(contentRecord);
+        return contentRecord;
+    }
+
+    private Datastream makeDatastream() {
+        return new DatastreamImpl(null, DatastreamType.ORIGINAL_FILE.getId(), 0l, "text/plain",
+                "file.txt", "txt", null, null);
+    }
+
     @Test
     public void testGetDatastream() throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(makeDatastream()));
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(makeContentUri(BINARY_CONTENT), "file.txt", "text/plain", null, null);
@@ -108,6 +130,8 @@ public class FedoraContentControllerIT {
     @Test
     public void testGetDatastreamDownload() throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(makeDatastream()));
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(makeContentUri(BINARY_CONTENT), "file.txt", "text/plain", null, null);
@@ -129,6 +153,8 @@ public class FedoraContentControllerIT {
     @Test
     public void testGetDatastreamNoFilename() throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(makeDatastream()));
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(makeContentUri(BINARY_CONTENT), null, "text/plain", null, null);
@@ -150,6 +176,8 @@ public class FedoraContentControllerIT {
     @Test
     public void testGetDatastreamInsufficientPermissions() throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(makeDatastream()));
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(makeContentUri(BINARY_CONTENT), null, "text/plain", null, null);
@@ -177,6 +205,10 @@ public class FedoraContentControllerIT {
 
     private void testGetMultipleDatastreams(String requestPath) throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        var fitsDs = new DatastreamImpl(null, TECHNICAL_METADATA.getId(), 0l, "application/xml",
+                "fits.xml", "xml", null, null);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(makeDatastream(), fitsDs));
 
         String content = "<fits>content</fits>";
 
@@ -208,6 +240,10 @@ public class FedoraContentControllerIT {
     @Test
     public void testGetAdministrativeDatastreamNoPermissions() throws Exception {
         PID filePid = makePid();
+        var contentRecord = mockSolrRecord(filePid);
+        var fitsDs = new DatastreamImpl(null, TECHNICAL_METADATA.getId(), 0l, "application/xml",
+                "fits.xml", "xml", null, null);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(fitsDs));
 
         String content = "<fits>content</fits>";
 
@@ -252,6 +288,33 @@ public class FedoraContentControllerIT {
         mvc.perform(get("/content/" + objPid.getId()))
                 .andExpect(status().isBadRequest())
                 .andReturn();
+    }
+
+    @Test
+    public void testGetDatastreamFromWork() throws Exception {
+        PID workPid = makePid();
+        var contentRecord = mockSolrRecord(workPid);
+        PID filePid = makePid();
+        var childOriginal = new DatastreamImpl(filePid.getId(), DatastreamType.ORIGINAL_FILE.getId(), 0l, "text/plain",
+                "file.txt", "txt", null, null);
+        when(contentRecord.getDatastreamObjects()).thenReturn(Arrays.asList(childOriginal));
+
+        var workObj = repositoryObjectFactory.createWorkObject(workPid, null);
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(makeContentUri(BINARY_CONTENT), "file.txt", "text/plain", null, null);
+        workObj.addMember(fileObj);
+
+        MvcResult result = mvc.perform(get("/content/" + workPid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("inline; filename=\"file.txt\"", response.getHeader(CONTENT_DISPOSITION));
     }
 
     private URI makeContentUri(String content) throws Exception {

--- a/web-access-app/src/test/resources/fedora-content-it-servlet.xml
+++ b/web-access-app/src/test/resources/fedora-content-it-servlet.xml
@@ -15,6 +15,22 @@
     <mvc:annotation-driven/>
 
     <context:component-scan resource-pattern="**/FedoraContentController*" base-package="edu.unc.lib.boxc.web.access.controllers"/>
+
+    <bean id="facetFieldFactory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.search.solr.services.FacetFieldFactory" />
+    </bean>
+
+    <bean id="solrSettings" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SolrSettings" />
+    </bean>
+
+    <bean id="searchSettings" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SearchSettings" />
+    </bean>
+
+    <bean id="solrSearchService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.web.common.services.SolrQueryLayerService" />
+    </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.boxc.web.common.services.FedoraContentService">
         <property name="accessControlService" ref="aclService" />

--- a/web-access-app/src/test/resources/fedora-content-it-servlet.xml
+++ b/web-access-app/src/test/resources/fedora-content-it-servlet.xml
@@ -15,22 +15,6 @@
     <mvc:annotation-driven/>
 
     <context:component-scan resource-pattern="**/FedoraContentController*" base-package="edu.unc.lib.boxc.web.access.controllers"/>
-
-    <bean id="facetFieldFactory" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.boxc.search.solr.services.FacetFieldFactory" />
-    </bean>
-
-    <bean id="solrSettings" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SolrSettings" />
-    </bean>
-
-    <bean id="searchSettings" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SearchSettings" />
-    </bean>
-
-    <bean id="solrSearchService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.boxc.web.common.services.SolrQueryLayerService" />
-    </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.boxc.web.common.services.FedoraContentService">
         <property name="accessControlService" ref="aclService" />


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3585

* Requests to download the original_file for a work now return a 400 response, rather than sometimes returning the contents of the primary object. Downloading original_files must now be done using the file id (which is how it is used in the UI already). This is also consistent with the behavior of the `services/api/file/pid/original_file` endpoint.