### PR TITLE
BXC-3941 - UTC when indexing date fields

### DIFF
--- a/common-utils/src/main/java/edu/unc/lib/boxc/common/util/DateTimeUtil.java
+++ b/common-utils/src/main/java/edu/unc/lib/boxc/common/util/DateTimeUtil.java
@@ -26,7 +26,7 @@ public class DateTimeUtil {
             new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
 
     /**
-     * Parse a UTC formatted timestamp as a date
+     * Parse a UTC formatted timestamp as a date. Assumes UTC timezone if none specified in provided value
      * @param utcDate
      * @return
      */
@@ -42,7 +42,7 @@ public class DateTimeUtil {
      */
     protected static DateTime parseUTCToDateTime(String utcDate) {
         // TODO remove jodatime dependency. At the moment it is required for extensive ISO8601 parsing
-        Chronology chrono = GJChronology.getInstance();
+        Chronology chrono = GJChronology.getInstanceUTC();
         DateTime isoDT = ISODateTimeFormat.dateTimeParser().withChronology(chrono).withOffsetParsed()
                 .parseDateTime(utcDate);
         return isoDT.withZone(DateTimeZone.forID("UTC"));

--- a/common-utils/src/test/java/edu/unc/lib/boxc/common/util/DateTimeUtilTest.java
+++ b/common-utils/src/test/java/edu/unc/lib/boxc/common/util/DateTimeUtilTest.java
@@ -32,65 +32,44 @@ public class DateTimeUtilTest {
     }
 
     @Test
-    public void utcToDateTimeTest() throws Exception {
-        DateTime date = DateTimeUtil.parseUTCToDateTime("2001");
-        assertEquals(2001, date.getYear());
+    public void parseUTCToDateYearTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2001");
+        assertEquals("2001-01-01T00:00:00.000Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2001-05-08");
-        assertEquals(2001, date.getYear());
-        assertEquals(5, date.getMonthOfYear());
-        assertEquals(8, date.getDayOfMonth());
+    @Test
+    public void parseUTCToDateYyyymmddTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2001-05-08");
+        assertEquals("2001-05-08T00:00:00.000Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2002-02-01T12:13:14");
-        assertEquals(2002, date.getYear());
-        assertEquals(2, date.getMonthOfYear());
-        assertEquals(1, date.getDayOfMonth());
-        assertEquals(17, date.getHourOfDay());
-        assertEquals(13, date.getMinuteOfHour());
-        assertEquals(14, date.getSecondOfMinute());
+    @Test
+    public void parseUTCToDateTimestampUnspecifiedZoneTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2002-02-01T12:13:14");
+        assertEquals("2002-02-01T12:13:14.000Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14.005");
-        assertEquals(2004, date.getYear());
-        assertEquals(2, date.getMonthOfYear());
-        assertEquals(4, date.getDayOfMonth());
-        assertEquals(17, date.getHourOfDay());
-        assertEquals(13, date.getMinuteOfHour());
-        assertEquals(14, date.getSecondOfMinute());
-        assertEquals(5, date.getMillisOfSecond());
+    @Test
+    public void parseUTCToDateTimestampWithZoneTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2002-02-01T12:13:14-05:00");
+        assertEquals("2002-02-01T17:13:14.000Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14+04:00");
-        date = date.withZone(DateTimeZone.forID("UTC"));
-        assertEquals(2004, date.getYear());
-        assertEquals(2, date.getMonthOfYear());
-        assertEquals(4, date.getDayOfMonth());
-        assertEquals(8, date.getHourOfDay());
-        assertEquals(13, date.getMinuteOfHour());
-        assertEquals(14, date.getSecondOfMinute());
-        assertEquals(0, date.getMillisOfSecond());
+    @Test
+    public void parseUTCToDateTimestampUtcMilliTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2004-02-04T12:13:14.005Z");
+        assertEquals("2004-02-04T12:13:14.005Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14.005Z");
-        assertEquals(2004, date.getYear());
-        assertEquals(2, date.getMonthOfYear());
-        assertEquals(4, date.getDayOfMonth());
-        assertEquals(12, date.getHourOfDay());
-        assertEquals(13, date.getMinuteOfHour());
-        assertEquals(14, date.getSecondOfMinute());
-        assertEquals(5, date.getMillisOfSecond());
+    @Test
+    public void parseUTCToDateTimestampUtcMinuteTest() throws Exception {
+        var date = DateTimeUtil.parseUTCToDate("2004-02-04T12:13Z");
+        assertEquals("2004-02-04T12:13:00.000Z", DateTimeUtil.formatDateToUTC(date));
+    }
 
-        date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13Z");
-        assertEquals(2004, date.getYear());
-        assertEquals(2, date.getMonthOfYear());
-        assertEquals(4, date.getDayOfMonth());
-        assertEquals(12, date.getHourOfDay());
-        assertEquals(13, date.getMinuteOfHour());
-        assertEquals(0, date.getSecondOfMinute());
-        assertEquals(0, date.getMillisOfSecond());
-
-        try {
-            date = DateTimeUtil.parseUTCToDateTime("not even close");
-            fail();
-        } catch (IllegalArgumentException e) {
-        }
+    @Test(expected = IllegalArgumentException.class)
+    public void parseUTCToDateNotADateTest() throws Exception {
+        DateTimeUtil.parseUTCToDate("not a date");
     }
 
     @Test

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilter.java
@@ -1,25 +1,16 @@
 package edu.unc.lib.boxc.indexing.solr.filter;
 
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_EL;
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_LABEL;
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_TYPE;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
+import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
+import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
+import edu.unc.lib.boxc.indexing.solr.utils.JDOMQueryUtil;
+import edu.unc.lib.boxc.model.api.exceptions.FedoraException;
 import edu.unc.lib.boxc.model.api.objects.AdminUnit;
 import edu.unc.lib.boxc.model.api.objects.CollectionObject;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.rdf.DcElements;
+import edu.unc.lib.boxc.model.api.rdf.Ebucore;
+import edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil;
+import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.search.solr.services.TitleRetrievalService;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,15 +22,23 @@ import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
-import edu.unc.lib.boxc.indexing.solr.utils.JDOMQueryUtil;
-import edu.unc.lib.boxc.model.api.exceptions.FedoraException;
-import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.api.rdf.DcElements;
-import edu.unc.lib.boxc.model.api.rdf.Ebucore;
-import edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil;
-import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_EL;
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_LABEL;
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_TYPE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Filter which sets descriptive metadata information, generally pulled from MODS
@@ -52,7 +51,6 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
 
     private final Properties languageCodeMap;
     private final Map<String, String> rightsUriMap;
-    public final static String AFFIL_URI = "http://cdr.unc.edu/vocabulary/Affiliation";
     private final List<String> CREATOR_LIST = Arrays.asList("creator", "author", "interviewer", "interviewee");
     private final List<String> GENRE_ATTRIBUTES = Arrays.asList("authority", "authorityURI", "valueURI");
     private TitleRetrievalService titleRetrievalService;
@@ -705,9 +703,7 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
     }
 
     private String extractDateYear(Date date) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
-        return Integer.toString(calendar.get(Calendar.YEAR));
+        return Integer.toString(date.toInstant().atZone(ZoneOffset.UTC).getYear());
     }
 
     private boolean hasNodeValue(Element node) {

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
@@ -10,12 +10,12 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
 import edu.unc.lib.boxc.search.solr.services.TitleRetrievalService;
+import edu.unc.lib.boxc.search.solr.utils.DateFormatUtil;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.jdom2.Document;
@@ -41,8 +41,6 @@ import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
  *
  */
 public class SetDescriptiveMetadataFilterTest {
-
-    private static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM");
     private static final String PID_STRING = "uuid:07d9594f-310d-4095-ab67-79a1056e7430";
 
     @Mock
@@ -143,7 +141,8 @@ public class SetDescriptiveMetadataFilterTest {
         assertTrue(idb.getPublisher().contains("Knopf"));
         assertEquals(1, idb.getPublisher().size());
 
-        assertEquals("2006-04", dateFormat.format(idb.getDateCreated()));
+        assertEquals("2006-04-01T00:00:00.000Z", DateFormatUtil.formatter.format(idb.getDateCreated()));
+        assertEquals("2006", idb.getDateCreatedYear());
 
         assertEquals(4, idb.getRights().size());
         assertTrue(idb.getRights().contains("Copyright Not Evaluated"));
@@ -208,7 +207,7 @@ public class SetDescriptiveMetadataFilterTest {
 
         filter.filter(dip);
 
-        assertEquals("2006-05", dateFormat.format(idb.getDateCreated()));
+        assertEquals("2006-05-01T00:00:00.000Z", DateFormatUtil.formatter.format(idb.getDateCreated()));
         assertEquals("2006", idb.getDateCreatedYear());
     }
 
@@ -224,7 +223,7 @@ public class SetDescriptiveMetadataFilterTest {
 
         filter.filter(dip);
 
-        assertEquals("2006-03", dateFormat.format(idb.getDateCreated()));
+        assertEquals("2006-03-01T00:00:00.000Z", DateFormatUtil.formatter.format(idb.getDateCreated()));
         assertNull(idb.getDateCreatedYear());
     }
 
@@ -362,5 +361,19 @@ public class SetDescriptiveMetadataFilterTest {
         filter.filter(dip);
 
         assertEquals("uuid: 1234", idb.getTitle());
+    }
+
+    @Test
+    public void testDateCreatedYearBxc3941() throws Exception {
+        SAXBuilder builder = new SAXBuilder();
+        Document modsDoc = builder.build(new FileInputStream(new File(
+                "src/test/resources/datastream/dateCreatedYearIssue.xml")));
+        when(dip.getMods()).thenReturn(modsDoc.detachRootElement());
+
+        filter.filter(dip);
+
+        assertEquals("1862-01-01T00:00:00.000Z", DateFormatUtil.formatter.format(idb.getDateCreated()));
+        assertEquals("1862", idb.getDateCreatedYear());
+
     }
 }

--- a/indexing-solr/src/test/resources/datastream/dateCreatedYearIssue.xml
+++ b/indexing-solr/src/test/resources/datastream/dateCreatedYearIssue.xml
@@ -1,0 +1,10 @@
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3">
+    <mods:identifier displayLabel="CONTENTdm number" type="local">120</mods:identifier>
+    <mods:titleInfo>
+        <mods:title>Map of Hanover, Henrico, and and part of Chesterfield Counties, Virginia</mods:title>
+    </mods:titleInfo>
+    <mods:originInfo>
+        <mods:dateCreated>1862</mods:dateCreated>
+        <mods:dateCreated encoding="edtf" keyDate="yes">1862</mods:dateCreated>
+    </mods:originInfo>
+</mods:mods>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3941

* Treat incoming dates as being in UTC timezone when parsing unless otherwise specified. 
* When extracting year for dateCreatedYear, extract the year using an instant in UTC timezone to avoid getting the wrong year due to timezone conversions
* Change unit test to testing public method, and adjust expectations based on UTC being the default timezone.