### PR TITLE
Bxc 3811 adjust codeclimate thresholds 2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,11 +34,11 @@ checks:
     config:
       threshold: 4
   similar-code:
-    enabled: false
+    enabled: true
     config:
       threshold: # language-specific defaults. an override will affect all languages.
   identical-code:
-    enabled: false
+    enabled: true
     config:
       threshold: # language-specific defaults. an override will affect all languages.
 
@@ -58,6 +58,7 @@ plugins:
     config:
       languages:
         java:
+          mass_threshold: 50
 
 exclude_patterns:
   - "static/js/lib/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,47 @@
 version: "2"
+
+hecks:
+  argument-count:
+    enabled: true
+    config:
+      threshold: 4
+  complex-logic:
+    enabled: true
+    config:
+      threshold: 4
+  file-lines:
+    enabled: true
+    config:
+      threshold: 250
+  method-complexity:
+    enabled: true
+    config:
+      threshold: 5
+  method-count:
+    enabled: true
+    config:
+      threshold: 20
+  method-lines:
+    enabled: true
+    config:
+      threshold: 25
+  nested-control-flow:
+    enabled: true
+    config:
+      threshold: 4
+  return-statements:
+    enabled: true
+    config:
+      threshold: 4
+  similar-code:
+    enabled: true
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+  identical-code:
+    enabled: true
+    config:
+      threshold: # language-specific defaults. an override will affect all languages.
+
 plugins:
   # checkstyle is disabled until we figure out
   # how to incorporate our file suppressions config.

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,7 +4,7 @@ hecks:
   argument-count:
     enabled: true
     config:
-      threshold: 4
+      threshold: 7
   complex-logic:
     enabled: true
     config:
@@ -12,19 +12,19 @@ hecks:
   file-lines:
     enabled: true
     config:
-      threshold: 250
+      threshold: 500
   method-complexity:
     enabled: true
     config:
-      threshold: 5
+      threshold: 25
   method-count:
     enabled: true
     config:
-      threshold: 20
+      threshold: 50 #40-50
   method-lines:
     enabled: true
     config:
-      threshold: 25
+      threshold: 100 #100-150
   nested-control-flow:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -54,7 +54,7 @@ plugins:
   pmd:
     enabled: true
   duplication:
-    enabled: false
+    enabled: true
     config:
       languages:
         java:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,7 +24,7 @@ checks:
   method-lines:
     enabled: true
     config:
-      threshold: 100 #100-150
+      threshold: 150 #100-150
   nested-control-flow:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -56,7 +56,7 @@ plugins:
   duplication:
     enabled: true
     config:
-      count_threshold: 4
+      count_threshold: 5
 
 exclude_patterns:
   - "static/js/lib/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,11 +34,11 @@ checks:
     config:
       threshold: 4
   similar-code:
-    enabled: true
+    enabled: false
     config:
       threshold: # language-specific defaults. an override will affect all languages.
   identical-code:
-    enabled: true
+    enabled: false
     config:
       threshold: # language-specific defaults. an override will affect all languages.
 
@@ -53,6 +53,12 @@ plugins:
     enabled: true
   pmd:
     enabled: true
+  duplication:
+    enabled: false
+    config:
+      languages:
+        java:
+
 exclude_patterns:
   - "static/js/lib/"
   - "static/js/admin/performance_visualizations/assets/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -56,9 +56,7 @@ plugins:
   duplication:
     enabled: true
     config:
-      languages:
-        java:
-          mass_threshold: 45
+      count_threshold: 4
 
 exclude_patterns:
   - "static/js/lib/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,7 +46,7 @@ plugins:
   # checkstyle is disabled until we figure out
   # how to incorporate our file suppressions config.
   checkstyle:
-    enabled: true
+    enabled: false
     config:
       file: "common-utils/src/main/resources/checkstyle/checkstyle.xml"
   sonar-java:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -46,7 +46,7 @@ plugins:
   # checkstyle is disabled until we figure out
   # how to incorporate our file suppressions config.
   checkstyle:
-    enabled: false
+    enabled: true
     # config:
     #   file: "common-utils/src/main/resources/checkstyle/checkstyle.xml"
   sonar-java:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,11 +20,11 @@ checks:
   method-count:
     enabled: true
     config:
-      threshold: 50 #40-50
+      threshold: 50
   method-lines:
     enabled: true
     config:
-      threshold: 150 #100-150
+      threshold: 150
   nested-control-flow:
     enabled: true
     config:
@@ -43,8 +43,7 @@ checks:
       threshold: # language-specific defaults. an override will affect all languages.
 
 plugins:
-  # checkstyle is disabled until we figure out
-  # how to incorporate our file suppressions config.
+  # there are 16,000+ errors/warnings when checkstyle is enabled
   checkstyle:
     enabled: false
     config:
@@ -53,10 +52,14 @@ plugins:
     enabled: true
   pmd:
     enabled: true
+  # duplication plugin affects similar-code and identical-code
   duplication:
     enabled: true
     config:
       count_threshold: 5
+      languages:
+        java:
+          mass_threshold: 40 # default threshold
 
 exclude_patterns:
   - "static/js/lib/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -47,8 +47,8 @@ plugins:
   # how to incorporate our file suppressions config.
   checkstyle:
     enabled: true
-    # config:
-    #   file: "common-utils/src/main/resources/checkstyle/checkstyle.xml"
+    config:
+      file: "common-utils/src/main/resources/checkstyle/checkstyle.xml"
   sonar-java:
     enabled: true
   pmd:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,6 @@
 version: "2"
 
-hecks:
+checks:
   argument-count:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -58,7 +58,7 @@ plugins:
     config:
       languages:
         java:
-          mass_threshold: 50
+          mass_threshold: 45
 
 exclude_patterns:
   - "static/js/lib/"

--- a/common-utils/src/main/resources/checkstyle/checkstyle-suppressions.xml
+++ b/common-utils/src/main/resources/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
-     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+     "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+     "https://checkstyle.orgm/dtds/suppressions_1_2.dtd">
 <suppressions>
     <suppress checks=".*" files="/fcrepo/" />
     <suppress checks=".*" files="/fcrepo-cdr-fesl/" />

--- a/common-utils/src/main/resources/checkstyle/checkstyle.xml
+++ b/common-utils/src/main/resources/checkstyle/checkstyle.xml
@@ -72,7 +72,6 @@
         
         <!-- Relaxes syntax options for JavaDoc comments -->
         <module name="JavadocMethod">
-            <!-- whether to allow documented exceptions that are not declared if they are a subclass of java.lang.RuntimeException -->
             <property name="allowMissingParamTags" value="true" />
             <property name="allowMissingReturnTag" value="true" />
         </module>

--- a/common-utils/src/main/resources/checkstyle/checkstyle.xml
+++ b/common-utils/src/main/resources/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN"
+    "https://checkstyle.or/dtds/configuration_1_2.dtd">
 <!-- Checkstyle configuration that checks the Fedora coding conventions from: 
     - the Fedora FcRepo4 Code Style Guide https://wiki.duraspace.org/display/FF/Code+Style+Guide 
     - some best practices Checkstyle is very configurable. Be sure to read the 
@@ -18,19 +18,26 @@
         http://checkstyle.sourceforge.net/property_types.html
     -->
 <module name="Checker">
+    <property name="severity" value="warning"/>
     
     <!-- Suppress 
         The fcrepo based suppression file disables JavaDoc checks in unit test and IT test files.
         It also disables indentation checking, e.g. 4 spaces for all java files
     -->
     <module name="SuppressionFilter">
-        <property name="file" value="${checkstyle.suppressions.file}"/>
+        <property name="file" value="common-utils/src/main/resources/checkstyle/checkstyle-suppressions.xml"/>
     </module>
     
     <!-- Checks that there are no tab characters ('\t') in the source code. -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true" />
         <property name="fileExtensions" value="css,java,js,jsp,xml,xsl" />
+    </module>
+
+    <!-- Checks for long lines. -->
+    <module name="LineLength">
+        <property name="fileExtensions" value="java"/>
+        <property name="max" value="120"/>
     </module>
     
     <!-- License Header module disabled in favor of license-maven-plugin -->
@@ -44,11 +51,6 @@
         
         <!-- Check that finds import statements that use the * notation. -->
         <module name="AvoidStarImport" />
-        
-        <!-- Checks for long lines. -->
-        <module name="LineLength">
-            <property name="max" value="120"/>
-        </module>
         
         <!-- Write Javadocs for public methods and classes. Keep it short and to 
             the point /** * @author Joe Developer * @date MMM DD, YYYY */ public class 
@@ -70,11 +72,8 @@
         
         <!-- Relaxes syntax options for JavaDoc comments -->
         <module name="JavadocMethod">
-            <property name="scope" value="public" />
             <!-- whether to allow documented exceptions that are not declared if they are a subclass of java.lang.RuntimeException -->
-            <property name="allowUndeclaredRTE" value="true" /> 
             <property name="allowMissingParamTags" value="true" />
-            <property name="allowMissingThrowsTags" value="true" />
             <property name="allowMissingReturnTag" value="true" />
         </module>
         

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <maven.surefire.version>2.22.1</maven.surefire.version>
         <compiler.plugin.version>3.8.0</compiler.plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
-        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <maven-scm-provider-svnjava.version>2.1.2</maven-scm-provider-svnjava.version>


### PR DESCRIPTION
[https://jira.lib.unc.edu/browse/BXC-3811](https://jira.lib.unc.edu/browse/BXC-3811)

This PR includes adjustments to codeclimate check thresholds and changes to checkstyles. The checkstyles plugin works when enabled but codeclimate has a fit because there are 16k+ errors.

- added checks to codeclimate
- adjusted check thresholds to reduce issues (fixed 811 of 1558 issues)
- added duplication plugin to modify similar-code and identical-code thresholds
- updated checkstyle and checkstyle-suppressions config
- checkstyle.xml: incorporated file suppression config, moved modules, added/removed properties and comments
- updated maven-checkstyle-plugin version