### PR TITLE
BXC-3752 - Move serialization of order into a helper method

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/order/MemberOrderHelper.java
@@ -70,4 +70,13 @@ public class MemberOrderHelper {
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toList());
     }
+
+    /**
+     * Serialize a list of PIDs for storage in the repository
+     * @param pids list of PIDs
+     * @return String containing pids as an order field value.
+     */
+    public static String serializeOrder(List<PID> pids) {
+        return pids.stream().map(PID::getId).collect(Collectors.joining("|"));
+    }
 }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderJob.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.operations.api.order.MemberOrderHelper;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +31,7 @@ public class RemoveFromOrderJob implements Runnable {
         // subtract children from original order
         memberOrder.removeAll(childrenToRemove);
         // transform PIDs into UUIDs
-        var updatedOrder = memberOrder.stream().map(PID::getId).collect(Collectors.joining("|"));
+        var updatedOrder = MemberOrderHelper.serializeOrder(memberOrder);
         log.debug("Updating order property for {} to {}", request.getParentPid(), updatedOrder);
         repositoryObjectFactory.createExclusiveRelationship(workObject, Cdr.memberOrder, updatedOrder);
     }

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJob.java
@@ -4,6 +4,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.operations.api.order.MemberOrderHelper;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,7 @@ public class SetOrderJob implements Runnable {
     @Override
     public void run() {
         var parentObject = repositoryObjectLoader.getRepositoryObject(request.getParentPid());
-        var order = request.getOrderedChildren().stream().map(PID::getId).collect(Collectors.joining("|"));
+        var order = MemberOrderHelper.serializeOrder(request.getOrderedChildren());
         log.debug("Updating order property for {} to {}", request.getParentPid(), order);
         repositoryObjectFactory.createExclusiveRelationship(parentObject, Cdr.memberOrder, order);
     }


### PR DESCRIPTION
Part of https://jira.lib.unc.edu/browse/BXC-3752

* Perform serialization of member order via a helper method, so it can be reused in chompb