### PR TITLE
Bxc 4004 adjust sort in work

### DIFF
--- a/static/js/public/fullRecord.js
+++ b/static/js/public/fullRecord.js
@@ -174,7 +174,7 @@ define('fullRecord', ['module', 'jquery', 'JP2Viewer', 'StructureView', 'dataTab
 			bLengthChange: false, // Remove option to show different number of results
 			columnDefs: column_defs,
 			language: { search: '', searchPlaceholder: 'Search within this work' },
-			order: [[1, 'asc']],
+			order: [], // do not set initial sort in case there is member order
 			rowCallback: function(row, data) {
 				if (showBadge(data).markDeleted) {
 					$(row).addClass('deleted');

--- a/static/js/public/fullRecord.js
+++ b/static/js/public/fullRecord.js
@@ -149,7 +149,7 @@ define('fullRecord', ['module', 'jquery', 'JP2Viewer', 'StructureView', 'dataTab
 
 		$childFilesTable.DataTable({
 			ajax: {
-				url: '/listJson/' + $childFilesTable.attr('data-pid') + "?rows=2000",
+				url: '/listJson/' + $childFilesTable.attr('data-pid') + "?rows=10",
 				dataSrc: function(d) {
 					return d.metadata;
 				},

--- a/static/js/public/fullRecord.js
+++ b/static/js/public/fullRecord.js
@@ -159,7 +159,9 @@ define('fullRecord', ['module', 'jquery', 'JP2Viewer', 'StructureView', 'dataTab
 					d.anywhere = d.search['value'];
 					d.length = 10;
 					d.rollup = false;
-					d.sort = sorts[d.order[0]['column'] - 1] + ',' + sortOrder[d.order[0]['dir']];
+					if (d.order[0] !== undefined) {
+						d.sort = sorts[d.order[0]['column'] - 1] + ',' + sortOrder[d.order[0]['dir']];
+					}
 				},
 				dataFilter: function(data){
 					let json = JSON.parse(data);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4004

This PR removes the initial title sort so that results come back as is from solr. This would reflect the member order if it was set. It also fixes the fact that solr was returning up to 2000 results at once. Now it returns 10 to match the pagination in datatables.