### PR TITLE
BXC-4017 Add hidden cdm rights field

### DIFF
--- a/web-access-app/src/main/resources/modsExclusionXPaths.json
+++ b/web-access-app/src/main/resources/modsExclusionXPaths.json
@@ -6,4 +6,5 @@
   "//mods:originInfo/mods:dateIssued[@encoding=\"marc\"]",
   "//mods:identifier[@displayLabel=\"HookID\" and @type=\"local\"]",
   "//mods:physicalDescription/mods:note[@displayLabel=\"Container type\"]",
-  "//mods:identifier[@displayLabel=\"CONTENTdm number\" and @type=\"local\"]"]
+  "//mods:identifier[@displayLabel=\"CONTENTdm number\" and @type=\"local\"]",
+  "//mods:accessCondition[@type=\"use and reproduction\" and @displayLabel=\"CONTENTdm Usage Rights\"]"]


### PR DESCRIPTION
This adds a hidden field in order to retain legacy Usage Rights statements from CONTENTdm for cases when rights metadata has been supplemented with RightsStatements.org URIs.