### PR TITLE
BXC-4072 - Fix move operations between admin units

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsJob.java
@@ -93,6 +93,7 @@ public class MoveObjectsJob implements Runnable {
                     moveObject(movePid);
                 }
             } catch (Exception e) {
+                log.error("Failed to perform move job to destination {}", destinationPid, e);
                 tx.cancel(e);
             } finally {
                 tx.close();

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsService.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.operations.impl.move;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ public class MoveObjectsService {
     private TransactionManager transactionManager;
     private OperationsMessageSender operationsMessageSender;
     private ObjectPathFactory objectPathFactory;
+    private PremisLoggerFactory premisLoggerFactory;
     private boolean asynchronous;
     private ExecutorService moveExecutor;
 
@@ -69,6 +71,7 @@ public class MoveObjectsService {
         job.setTransactionManager(transactionManager);
         job.setOperationsMessageSender(operationsMessageSender);
         job.setObjectPathFactory(objectPathFactory);
+        job.setPremisLoggerFactory(premisLoggerFactory);
 
         if (asynchronous) {
             log.info("User {} is queueing move operation {} of {} objects to destination {}",
@@ -150,6 +153,10 @@ public class MoveObjectsService {
      */
     public void setObjectPathFactory(ObjectPathFactory objectPathFactory) {
         this.objectPathFactory = objectPathFactory;
+    }
+
+    public void setPremisLoggerFactory(PremisLoggerFactory premisLoggerFactory) {
+        this.premisLoggerFactory = premisLoggerFactory;
     }
 
     /**

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -80,6 +80,7 @@
         <property name="transactionManager" ref="transactionManager" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="premisLoggerFactory" ref="premisLoggerFactory" />
         <property name="asynchronous" value="true" />
         <property name="moveExecutor" ref="moveExecutor" />
     </bean>

--- a/web-services-app/src/test/resources/move-objects-it-servlet.xml
+++ b/web-services-app/src/test/resources/move-objects-it-servlet.xml
@@ -21,6 +21,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="premisLoggerFactory" ref="premisLoggerFactory" />
         <property name="transactionManager" ref="transactionManager" />
     </bean>
     


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4072

* Inject missing premisLoggerFactory into service and job, which was causing a NPE when moving works between admin units because that includes an extra premis event