### PR TITLE
BXC-4066 - Prevent CDM Rights statements from getting indexed

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilter.java
@@ -463,8 +463,10 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
                 String modsRightsStatement = rightsEl.getTextTrim();
                 boolean hasUrl = !StringUtils.isBlank(href);
                 boolean hasRightsText = !StringUtils.isBlank(modsRightsStatement);
+                var displayLabel = rightsEl.getAttributeValue("displayLabel");
+                var disallowedLabel = displayLabel == null || displayLabel.equalsIgnoreCase("CONTENTdm Usage Rights");
 
-                if (!hasRightsText && !hasUrl) {
+                if ((!hasRightsText && !hasUrl) || disallowedLabel) {
                     continue;
                 }
 

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
@@ -10,6 +10,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
@@ -91,12 +93,7 @@ public class SetDescriptiveMetadataFilterTest {
 
     @Test
     public void testInventory() throws Exception {
-        SAXBuilder builder = new SAXBuilder();
-        Document modsDoc = builder.build(new FileInputStream(new File(
-                "src/test/resources/datastream/inventoryMods.xml")));
-        when(dip.getMods()).thenReturn(modsDoc.detachRootElement());
-
-        filter.filter(dip);
+        runFilterOnInventoryMods();
 
         assertEquals("Paper title", idb.getTitle());
         assertNull(idb.getOtherTitle());
@@ -144,24 +141,6 @@ public class SetDescriptiveMetadataFilterTest {
         assertEquals("2006-04-01T00:00:00.000Z", DateFormatUtil.formatter.format(idb.getDateCreated()));
         assertEquals("2006", idb.getDateCreatedYear());
 
-        assertEquals(4, idb.getRights().size());
-        assertTrue(idb.getRights().contains("Copyright Not Evaluated"));
-        assertTrue(idb.getRights().contains("For copyright information or permissions questions, see our " +
-                "intellectual property statement https://library.unc.edu/wilson/research/perm/"));
-        assertTrue(idb.getRights().contains("Copyright Not Evaluated"));
-        assertTrue(idb.getRightsOaiPmh().contains("More Random Rights"));
-
-        assertEquals(2, idb.getRightsUri().size());
-        assertTrue(idb.getRightsUri().contains("https://rightsstatements.org/vocab/CNE/1.0/"));
-        assertTrue(idb.getRightsUri().contains("https://creativecommons.org/licenses/by-sa/3.0/us/"));
-
-        assertEquals(6, idb.getRightsOaiPmh().size());
-        assertTrue(idb.getRightsOaiPmh().contains("http://rightsstatements.org/vocab/CNE/1.0/"));
-        assertTrue(idb.getRightsOaiPmh().contains("http://creativecommons.org/licenses/by-sa/3.0/us/"));
-        assertTrue(idb.getRightsOaiPmh().contains("Copyright Not Evaluated"));
-        assertTrue(idb.getRightsOaiPmh().contains("Attribution-ShareAlike 3.0 United States (CC BY-SA 3.0 US)"));
-        assertTrue(idb.getRightsOaiPmh().contains("More Random Rights"));
-
         assertTrue(idb.getOtherSubject().contains("Germany"));
         assertTrue(idb.getOtherSubject().contains("Canada"));
         assertTrue(idb.getOtherSubject().contains("Explorer"));
@@ -193,6 +172,49 @@ public class SetDescriptiveMetadataFilterTest {
         assertEquals(2, exhibits.size());
         assertTrue(exhibits.contains("Wonderful Exhibit|https://digital-exhibit.lib.unc.edu"));
         assertTrue(exhibits.contains("https://no-url-label-digital-exhibit.lib.unc.edu|https://no-url-label-digital-exhibit.lib.unc.edu"));
+    }
+
+    private void runFilterOnInventoryMods() throws Exception {
+        SAXBuilder builder = new SAXBuilder();
+        Document modsDoc = builder.build(Files.newInputStream(
+                Paths.get("src/test/resources/datastream/inventoryMods.xml")));
+        when(dip.getMods()).thenReturn(modsDoc.detachRootElement());
+
+        filter.filter(dip);
+    }
+
+    @Test
+    public void testRightsFromInventory() throws Exception {
+        runFilterOnInventoryMods();
+
+        assertTrue(idb.getRights().contains("Copyright Not Evaluated"));
+        assertTrue(idb.getRights().contains("For copyright information or permissions questions, see our " +
+                "intellectual property statement https://library.unc.edu/wilson/research/perm/"));
+        assertTrue(idb.getRights().contains("Copyright Not Evaluated"));
+        assertTrue(idb.getRights().contains("More Random Rights"));
+        assertEquals(4, idb.getRights().size(), "Incorrect number of rights: " + idb.getRights());
+    }
+
+    @Test
+    public void testRightsUriFromInventory() throws Exception {
+        runFilterOnInventoryMods();
+
+        assertTrue(idb.getRightsUri().contains("https://rightsstatements.org/vocab/CNE/1.0/"));
+        assertTrue(idb.getRightsUri().contains("https://creativecommons.org/licenses/by-sa/3.0/us/"));
+        assertEquals(2, idb.getRightsUri().size(), "Incorrect number of rightsUris: " + idb.getRightsUri());
+    }
+
+    @Test
+    public void testRightsOaiPmhFromInventory() throws Exception {
+        runFilterOnInventoryMods();
+
+        assertTrue(idb.getRightsOaiPmh().contains("http://rightsstatements.org/vocab/CNE/1.0/"));
+        assertTrue(idb.getRightsOaiPmh().contains("http://creativecommons.org/licenses/by-sa/3.0/us/"));
+        assertTrue(idb.getRightsOaiPmh().contains("Copyright Not Evaluated"));
+        assertTrue(idb.getRightsOaiPmh().contains("Attribution-ShareAlike 3.0 United States (CC BY-SA 3.0 US)"));
+        assertTrue(idb.getRightsOaiPmh().contains("More Random Rights"));
+        assertTrue(idb.getRightsOaiPmh().contains("For copyright information or permissions questions, see our intellectual property statement https://library.unc.edu/wilson/research/perm/"));
+        assertEquals(6, idb.getRightsOaiPmh().size(), "Incorrect number of rightsOaiPmh: " + idb.getRightsOaiPmh());
     }
 
     /*

--- a/indexing-solr/src/test/resources/datastream/inventoryMods.xml
+++ b/indexing-solr/src/test/resources/datastream/inventoryMods.xml
@@ -175,4 +175,7 @@
   <mods:accessCondition displayLabel="Rights" type="use and reproduction"
                         xlink:href="https://random.url/rights/text/">Random Rights</mods:accessCondition>
   <mods:accessCondition displayLabel="Rights" type="use and reproduction">More Random Rights</mods:accessCondition>
+  <mods:accessCondition displayLabel="CONTENTdm Usage Rights" type="use and reproduction">CDM Rights</mods:accessCondition>
+  <mods:accessCondition type="use and reproduction">No label</mods:accessCondition>
+  <mods:accessCondition displayLabel="Rights">No type</mods:accessCondition>
 </mods:mods>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4066

* Prevent CDM Rights statements from getting indexed
* Also split out the rights related assertions into their own tests so they are easier to detect issues with.