### PR TITLE
Switch back to showing full thumbnail

### DIFF
--- a/static/css/cdrui_styles.css
+++ b/static/css/cdrui_styles.css
@@ -92,7 +92,7 @@
 .thumbnail .thumbnail-viewer {
 	background-position: center center;
 	background-repeat: no-repeat;
-	background-size: cover;
+	background-size: contain;
 	width: 64px;
 	height: 64px;
 }


### PR DESCRIPTION

* Switch back to showing full thumbnail (but still resolve the issue where the thumbnail was overlapping the text below it in the related items list)