### PR TITLE
BXC-4150 - Full record search results from previous page when using breadcrumbs

### DIFF
--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -76,23 +76,27 @@ Top level component for full record pages with searching/browsing, including Adm
         name: 'displayWrapper',
 
         watch: {
-            '$route.query': {
-                handler(d) {
-                    if (!this.is_page_loading && this.container_info.resourceType !== 'File'
-                        && this.container_info.resourceType !== 'Work') {
-                        this.retrieveSearchResults();
+            '$route': {
+                handler(new_data, old_data) {
+                    let path_changed = new_data.path !== old_data.path;
+                    if (path_changed) {
+                        if (!this.is_page_loading) {
+                            // If the object being viewed has changed, then need to ensure search results
+                            // are requested after it finishes loading.
+                            this.getBriefObject().then(() => {
+                                if (this.needsSearchResults) {
+                                    this.retrieveSearchResults();
+                                }
+                            });
+                        }
+                    } else {
+                        if (!this.is_page_loading && this.needsSearchResults) {
+                            this.retrieveSearchResults();
+                        }
                     }
                 },
                 deep: true
-            },
-            '$route.path': {
-                handler(d) {
-                    if (!this.is_page_loading) {
-                        this.getBriefObject();
-                    }
-                },
-                deep: true
-            },
+            }
         },
 
         components: {
@@ -147,6 +151,11 @@ Top level component for full record pages with searching/browsing, including Adm
 
             showWidget() {
                 return this.record_list.length > 0;
+            },
+
+            needsSearchResults() {
+                return this.container_info.resourceType !== 'File'
+                    && this.container_info.resourceType !== 'Work';
             }
         },
 
@@ -174,7 +183,7 @@ Top level component for full record pages with searching/browsing, including Adm
                     link += '/';
                 }
 
-               get(`${link}json`).then((response) => {
+               return get(`${link}json`).then((response) => {
                     this.container_info = response.data;
                     this.pageEvent(response.data);
                     this.pageView(this.container_info.pageSubtitle)

--- a/static/js/vue-cdr-access/src/components/displayWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/displayWrapper.vue
@@ -78,19 +78,20 @@ Top level component for full record pages with searching/browsing, including Adm
         watch: {
             '$route': {
                 handler(new_data, old_data) {
+                    if (this.is_page_loading) {
+                        return;
+                    }
                     let path_changed = new_data.path !== old_data.path;
                     if (path_changed) {
-                        if (!this.is_page_loading) {
-                            // If the object being viewed has changed, then need to ensure search results
-                            // are requested after it finishes loading.
-                            this.getBriefObject().then(() => {
-                                if (this.needsSearchResults) {
-                                    this.retrieveSearchResults();
-                                }
-                            });
-                        }
+                        // If the object being viewed has changed, then need to ensure search results
+                        // are requested after it finishes loading.
+                        this.getBriefObject().then(() => {
+                            if (this.needsSearchResults) {
+                                this.retrieveSearchResults();
+                            }
+                        });
                     } else {
-                        if (!this.is_page_loading && this.needsSearchResults) {
+                        if (this.needsSearchResults) {
                             this.retrieveSearchResults();
                         }
                     }

--- a/static/js/vue-cdr-access/src/components/viewType.vue
+++ b/static/js/vue-cdr-access/src/components/viewType.vue
@@ -58,6 +58,8 @@ Buttons for switching display modes in a search result between gallery and list 
             if (this.paramExists('browse_type', current_url_params)) {
                 this.browse_type = current_url_params.browse_type;
                 sessionStorage.setItem('browse-type', this.browse_type);
+            } else {
+                this.browse_type = sessionStorage.getItem('browse-type');
             }
         }
     }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4150

* Fixes issue where clicking on a breadcrumb on a work page would cause the children of the work to display as children of the new object being viewed.
* Fix for the viewType button not indicating the gallery browse is active when it was loaded from the sessionStorage.