### PR TITLE
BXC-4163 - Support requeuing failed longleaf jobs

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafRouter.java
@@ -49,7 +49,7 @@ public class LongleafRouter extends RouteBuilder {
             .log(LoggingLevel.DEBUG, log, "Queuing ${headers[CamelFcrepoUri]} for registration to longleaf")
             .to("sjms:register.longleaf?transacted=true");
 
-        from("{{longleaf.register.consumer}}")
+        from("{{longleaf.register.consumer}}", "activemq://activemq:queue:longleaf.register.batch")
             .routeId("RegisterLongleafProcessing")
             .startupOrder(3)
             .log(LoggingLevel.DEBUG, log, "Processing batch of longleaf registrations")
@@ -62,7 +62,7 @@ public class LongleafRouter extends RouteBuilder {
             .process(getUrisProcessor)
             .to("sjms:deregister.longleaf?transacted=true");
 
-        from("{{longleaf.deregister.consumer}}")
+        from("{{longleaf.deregister.consumer}}", "activemq://activemq:queue:longleaf.deregister.batch")
             .routeId("DeregisterLongleafProcessing")
             .startupOrder(1)
             .log(LoggingLevel.DEBUG, log, "Processing batch of longleaf deregistrations")


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4163
* Add additional activemq routes which feed into the longleaf batch register/deregister tasks, since we cannot easily move failed batch messages from the dead letter queue into an sjms batching end point