### PR TITLE
BXC-4207 - Loris retry connections

### DIFF
--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/controllers/LorisContentController.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/controllers/LorisContentController.java
@@ -124,7 +124,7 @@ public class LorisContentController extends AbstractSolrSearchController {
         if (this.hasAccess(pid, datastream)) {
             try {
                 response.addHeader("Access-Control-Allow-Origin", "*");
-                lorisContentService.getMetadata(id, datastream, response.getOutputStream(), response);
+                lorisContentService.getMetadata(id, response.getOutputStream(), response);
             } catch (IOException e) {
                 LOG.error("Error retrieving JP2 metadata content for {}", id, e);
             }

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/LorisContentService.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/services/LorisContentService.java
@@ -70,11 +70,11 @@ public class LorisContentService {
                 .build();
     }
 
-    public void getMetadata(String simplepid, String datastream, OutputStream outStream, HttpServletResponse response) {
-        getMetadata(simplepid, datastream, outStream, response, 1);
+    public void getMetadata(String simplepid, OutputStream outStream, HttpServletResponse response) {
+        getMetadata(simplepid, outStream, response, 1);
     }
 
-    public void getMetadata(String simplepid, String datastream, OutputStream outStream,
+    public void getMetadata(String simplepid, OutputStream outStream,
             HttpServletResponse response, int retryServerError) {
 
         StringBuilder path = new StringBuilder(getLorisPath());


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4207

* Perform loris retry in a loop rather than recursively so that the connections will close before the next try starts, which should prevent the retries from getting stuck waiting for a connection to come available. 
* Set a shorter max time to wait for a connection to become available
* Removed a parameter that wasn't actually used, it previously just thought it was used because it was passed into a recursive call to the same method.