### PR TITLE
BXC-4177 - Don't show download link for works without primary objects

### DIFF
--- a/static/js/vue-cdr-access/src/components/full_record/restrictedContent.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/restrictedContent.vue
@@ -10,18 +10,20 @@
         <div v-if="hasPermission(recordData, 'editDescription')" class="actionlink">
             <a class="edit button" :href="editDescriptionUrl(recordData.briefObject.id)"><i class="fa fa-edit"></i> {{ $t('full_record.edit') }}</a>
         </div>
-        <template v-if="fieldExists(recordData.dataFileUrl) && hasPermission(recordData, 'viewOriginal')">
-            <div class="actionlink download">
-                <a class="download button" :href="downloadLink"><i class="fa fa-download"></i> {{ $t('full_record.download') }}</a>
-            </div>
-            <div v-if="recordData.resourceType === 'File'" class="actionlink">
-                <a class="button view" :href="recordData.dataFileUrl">
-                    <i class="fa fa-search" aria-hidden="true"></i> View</a>
+        <template v-if="recordData.dataFileUrl">
+            <template v-if="hasPermission(recordData, 'viewOriginal')">
+                <div class="actionlink download">
+                    <a class="download button" :href="downloadLink"><i class="fa fa-download"></i> {{ $t('full_record.download') }}</a>
+                </div>
+                <div v-if="recordData.resourceType === 'File'" class="actionlink">
+                    <a class="button view" :href="recordData.dataFileUrl">
+                        <i class="fa fa-search" aria-hidden="true"></i> View</a>
+                </div>
+            </template>
+            <div v-else-if="fieldExists(recordData.briefObject.embargoDate)" class="noaction">
+                {{ $t('full_record.available_date', { available_date: formatDate(recordData.briefObject.embargoDate) }) }}
             </div>
         </template>
-        <div v-else-if="fieldExists(recordData.briefObject.embargoDate) && fieldExists(recordData.dataFileUrl)" class="noaction">
-            {{ $t('full_record.available_date', { available_date: formatDate(recordData.briefObject.embargoDate) }) }}
-        </div>
     </div>
 </template>
 

--- a/static/js/vue-cdr-access/tests/unit/restrictedContent.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/restrictedContent.spec.js
@@ -417,6 +417,16 @@ describe('restrictedContent.vue', () => {
         expect(wrapper.find('a.download').exists()).toBe(true);
     });
 
+    it('does not show download or embargo buttons if there is no dataFileUrl', async () => {
+        const updated_data = cloneDeep(record);
+        updated_data.dataFileUrl = "";
+        await wrapper.setProps({
+            recordData: updated_data
+        });
+        expect(wrapper.find('a.download').exists()).toBe(false);
+        expect(wrapper.find('.noaction').exists()).toBe(false);
+    });
+
     it('does not show a download option does not have download permissions', async () => {
         const updated_data = cloneDeep(record);
         updated_data.briefObject.permissions = [];


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4177

* Don't show download button if the dataFileUri is empty (including an empty string, which is what we get in production).