### PR TITLE
BXC-4229 - Remove download button from the top of the work full record page

### DIFF
--- a/static/js/vue-cdr-access/src/components/full_record/restrictedContent.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/restrictedContent.vue
@@ -12,20 +12,19 @@
         <div v-if="hasPermission(recordData, 'editDescription')" class="actionlink">
             <a class="edit button action" :href="editDescriptionUrl(recordData.briefObject.id)"><i class="fa fa-edit"></i> {{ $t('full_record.edit') }}</a>
         </div>
-        <template v-if="recordData.dataFileUrl">
+        <template v-if="recordData.resourceType === 'File'">
             <template v-if="hasPermission(recordData, 'viewOriginal')">
-                <file-download v-if="recordData.resourceType === 'File' || recordData.resourceType === 'Work'"
-                               :download-link="downloadLink"
+                <file-download :download-link="downloadLink"
                                :brief-object="recordData.briefObject"></file-download>
-                <div class="actionlink" v-if="recordData.resourceType === 'File'">
+                <div class="actionlink">
                     <a class="button view action" :href="recordData.dataFileUrl">
                         <i class="fa fa-search" aria-hidden="true"></i> View</a>
                 </div>
             </template>
-            <div v-else-if="fieldExists(recordData.briefObject.embargoDate)" class="noaction">
-                {{ $t('full_record.available_date', { available_date: formatDate(recordData.briefObject.embargoDate) }) }}
-            </div>
         </template>
+        <div v-if="fieldExists(recordData.briefObject.embargoDate) && !hasPermission(recordData, 'viewOriginal')" class="noaction">
+            {{ $t('full_record.available_date', { available_date: formatDate(recordData.briefObject.embargoDate) }) }}
+        </div>
     </div>
 </template>
 

--- a/static/js/vue-cdr-access/tests/unit/restrictedContent.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/restrictedContent.spec.js
@@ -435,7 +435,7 @@ describe('restrictedContent.vue', () => {
         expect(wrapper.find('a.view').exists()).toBe(false);
     });
 
-    it('displays a download button for works with the proper permissions', async () => {
+    it('does not display a download button for works even with the viewOriginal permissions', async () => {
         const updated_data = cloneDeep(record);
         updated_data.dataFileUrl = 'content/4db695c0-5fd5-4abf-9248-2e115d43f57d';
         updated_data.resourceType = 'Work';
@@ -443,7 +443,7 @@ describe('restrictedContent.vue', () => {
         await wrapper.setProps({
             recordData: updated_data
         });
-        expect(wrapper.findComponent({ name: 'fileDownload' }).exists()).toBe(true);
+        expect(wrapper.findComponent({ name: 'fileDownload' }).exists()).toBe(false);
     });
 
     it('displays a download button for files with the proper permissions', async () => {
@@ -468,10 +468,22 @@ describe('restrictedContent.vue', () => {
         expect(wrapper.findComponent({ name: 'fileDownload' }).exists()).toBe(false);
     });
 
-    it('displays embargo information', async () => {
+    it('displays embargo information for files', async () => {
         const updated_data = cloneDeep(record);
         updated_data.briefObject.embargoDate = '2199-12-31T20:34:01.799Z';
         updated_data.dataFileUrl = 'content/4db695c0-5fd5-4abf-9248-2e115d43f57d';
+        updated_data.briefObject.permissions = [];
+        await wrapper.setProps({
+            recordData: updated_data
+        });
+        expect(wrapper.find('.noaction').text()).toEqual('Available after 2199-12-31');
+    });
+
+    it('displays embargo information for works', async () => {
+        const updated_data = cloneDeep(record);
+        updated_data.briefObject.embargoDate = '2199-12-31T20:34:01.799Z';
+        updated_data.dataFileUrl = 'content/4db695c0-5fd5-4abf-9248-2e115d43f57d';
+        updated_data.resourceType = 'Work';
         updated_data.briefObject.permissions = [];
         await wrapper.setProps({
             recordData: updated_data


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4229

* Remove download button from the top of the work full record page
* Separate embargo displaying logic from download button logic, since a work can be embargoed.