### PR TITLE
Fix UV failing to load due to /record/record urls

### DIFF
--- a/static/js/vue-cdr-access/src/components/full_record/metadataDisplay.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/metadataDisplay.vue
@@ -36,7 +36,7 @@ export default {
 
     methods: {
         loadMetadata() {
-            get(`record/${this.uuid}/metadataView`).then((response) => {
+            get(`/record/${this.uuid}/metadataView`).then((response) => {
                 this.metadata = response.data;
                 this.hasLoaded = true;
             }).catch((error) => {

--- a/static/js/vue-cdr-access/src/components/full_record/player.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/player.vue
@@ -27,7 +27,7 @@ export default {
 
     methods: {
         viewer(viewer_type) {
-            return `record/${this.recordData.briefObject.id}/${viewer_type}Viewer`;
+            return `/record/${this.recordData.briefObject.id}/${viewer_type}Viewer`;
         }
     }
 }

--- a/static/js/vue-cdr-access/src/components/modalMetadata.vue
+++ b/static/js/vue-cdr-access/src/components/modalMetadata.vue
@@ -77,7 +77,7 @@ Displays the MODS descriptive record for an object inside of a modal
 
         methods: {
             loadMetadata() {
-                get(`record/${this.uuid}/metadataView`).then((response) => {
+                get(`/record/${this.uuid}/metadataView`).then((response) => {
                     this.metadata = response.data;
                     this.hasLoaded = true;
                 }).catch((error) => {


### PR DESCRIPTION
* Add a leading slash to record page requests to prevent browsers from occasionally getting confused and requesting /record/record/ paths