### PR TITLE
BXC-4231 - Fix run enhancements only queuing first 20 items

### DIFF
--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/RunEnhancementsService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/RunEnhancementsService.java
@@ -86,7 +86,7 @@ public class RunEnhancementsService {
 
                     // Page through results for requests to run enhancements of large folders
                     long totalResults = -1;
-                    int cnt = 0;
+                    int count = 0;
                     do {
                         SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);
                         if (totalResults == -1) {
@@ -98,10 +98,10 @@ public class RunEnhancementsService {
                         }
                         for (ContentObjectRecord metadata : resultResponse.getResultList()) {
                             createMessage(metadata, agent.getUsername(), force);
-                            cnt++;
+                            count++;
                         }
-                        LOG.debug("Queued {} out of {} items for enhancements", cnt, totalResults);
-                    } while(cnt < totalResults);
+                        LOG.debug("Queued {} out of {} items for enhancements", count, totalResults);
+                    } while(count < totalResults);
                 } else {
                     LOG.debug("Queueing a file object for enhancements: {}", pid);
                     SimpleIdRequest searchRequest = new SimpleIdRequest(pid, agent.getPrincipals());

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/RunEnhancementsService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/RunEnhancementsService.java
@@ -75,22 +75,35 @@ public class RunEnhancementsService {
                     SearchState searchState = new SearchState();
                     searchState.addFacet(new GenericFacet(SearchFieldKey.RESOURCE_TYPE, ResourceType.File.name()));
                     searchState.setResultFields(resultsFieldList);
+                    searchState.setRowsPerPage(1000);
+                    searchState.setIgnoreMaxRows(true);
 
                     SearchRequest searchRequest = new SearchRequest();
                     searchRequest.setAccessGroups(agent.getPrincipals());
                     searchRequest.setSearchState(searchState);
                     searchRequest.setRootPid(pid);
                     searchRequest.setApplyCutoffs(false);
-                    SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);
 
-                    for (ContentObjectRecord metadata : resultResponse.getResultList()) {
-                        createMessage(metadata, agent.getUsername(), force);
-                    }
-
-                    // Add the root container itself
-                    ContentObjectRecord rootContainer = resultResponse.getSelectedContainer();
-                    createMessage(rootContainer, agent.getUsername(), force);
+                    // Page through results for requests to run enhancements of large folders
+                    long totalResults = -1;
+                    int cnt = 0;
+                    do {
+                        SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);
+                        if (totalResults == -1) {
+                            totalResults = resultResponse.getResultCount();
+                            LOG.debug("Found {} items to queue for enhancement run", totalResults);
+                            // Add the root container itself
+                            ContentObjectRecord rootContainer = resultResponse.getSelectedContainer();
+                            createMessage(rootContainer, agent.getUsername(), force);
+                        }
+                        for (ContentObjectRecord metadata : resultResponse.getResultList()) {
+                            createMessage(metadata, agent.getUsername(), force);
+                            cnt++;
+                        }
+                        LOG.debug("Queued {} out of {} items for enhancements", cnt, totalResults);
+                    } while(cnt < totalResults);
                 } else {
+                    LOG.debug("Queueing a file object for enhancements: {}", pid);
                     SimpleIdRequest searchRequest = new SimpleIdRequest(pid, agent.getPrincipals());
                     ContentObjectRecord metadata = queryLayer.getObjectById(searchRequest);
                     createMessage(metadata, agent.getUsername(), force);


### PR DESCRIPTION
Relates to https://jira.lib.unc.edu/browse/BXC-4231
* Fix run enhancements action only queuing the first 20 children by setting an explicit page size and then paging through the results