### PR TITLE
BXC-4187 remove label form field

### DIFF
--- a/static/templates/admin/addFileForm.html
+++ b/static/templates/admin/addFileForm.html
@@ -1,12 +1,8 @@
 <iframe id="upload_file_frame" name="upload_file_frame" height="0" width="0" style="display: none;"></iframe>
 <form id="create_simple_object_form" method="post" action="/services/api/edit/ingest/<%= pid %>" enctype="multipart/form-data" target="upload_file_container" class="edit_form create_simple_object_form">
-    <p>Add a file to this work.  If no label is provided, the filename will be used.</p>
+    <p>Add a file to this work.</p>
     <p class="size-note">(Maximum upload size is 1.5gb)</p>
     <h3>Add File</h3>
-    <div class="form_field">
-        <label>Label</label>
-        <input name="name" size="40"/>
-    </div>
     <div class="form_field">
         <label>File*</label>
         <input type="file" id="data_file" name="file"/>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-4187
This PR removed the label form field from the Add File pop up:
![Screen Shot 2023-07-20 at 10 58 47 AM](https://github.com/UNC-Libraries/box-c/assets/6546457/53ebc969-1d30-4414-9661-8dd5c6771142)
