### PR TITLE
Parse dimensions as ints so that comparisons will be done numerically…

### DIFF
--- a/static/js/vue-cdr-access/src/mixins/fileDownloadUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/fileDownloadUtils.js
@@ -11,7 +11,6 @@ export default {
 
         getOriginalFile(brief_object) {
             const original_file =  brief_object.datastream.find(file => file.startsWith('original_file'));
-            console.log(original_file)
             if (original_file === undefined) {
                 return undefined;
             }
@@ -21,7 +20,7 @@ export default {
 
         largestImageEdge(brief_object) {
             const file_info = this.getOriginalFile(brief_object).split('|');
-            const edge_sizes = file_info[file_info.length - 1].split('x');
+            const edge_sizes = file_info[file_info.length - 1].split('x').map(x => parseInt(x));
             return edge_sizes[0] > edge_sizes[1] ? edge_sizes[0] : edge_sizes[1];
         },
 


### PR DESCRIPTION
Parse dimensions as ints so that comparisons will be done numerically instead of alphabetically, otherwise given dimension 700x1200, the 700 dimension is returned as the larger dimension and we don't get any smaller download sizes