### PR TITLE
Bxc 4064 assign thumbnail

### DIFF
--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/Cdr.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/Cdr.java
@@ -137,6 +137,11 @@ public class Cdr {
     public static final Property unpublished = createProperty(
             "http://cdr.unc.edu/definitions/model#unpublished" );
 
+    /** Property which records which file should be used as thumbnail of the parent work
+     */
+    public static final Property useAsThumbnail = createProperty(
+            "http://cdr.unc.edu/definitions/model#useAsThumbnail" );
+
     /** Selector for identifying fields within descriptive metadata records which
      *  this vocabulary applies to.
      */

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -13,13 +13,13 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 public class ThumbnailRequest {
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
-    private PID filePid;
+    private String filePidString;
 
     public AgentPrincipals getAgent() { return agent; }
 
     public void setAgent(AgentPrincipals agent) { this.agent = agent; }
 
-    public PID getFilePid() { return filePid; }
+    public String getFilePidString() { return filePidString; }
 
-    public void setFilePid(PID filePid) { this.filePid = filePid; }
+    public void setFilePidString(String filePidString) { this.filePidString = filePidString; }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -3,7 +3,6 @@ package edu.unc.lib.boxc.operations.jms.thumbnail;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
-import edu.unc.lib.boxc.model.api.ids.PID;
 
 /**
  * Request object for setting a file as thumbnail for a work
@@ -15,11 +14,19 @@ public class ThumbnailRequest {
     private AgentPrincipals agent;
     private String filePidString;
 
-    public AgentPrincipals getAgent() { return agent; }
+    public AgentPrincipals getAgent() {
+        return agent;
+    }
 
-    public void setAgent(AgentPrincipals agent) { this.agent = agent; }
+    public void setAgent(AgentPrincipals agent) {
+        this.agent = agent;
+    }
 
-    public String getFilePidString() { return filePidString; }
+    public String getFilePidString() {
+        return filePidString;
+    }
 
-    public void setFilePidString(String filePidString) { this.filePidString = filePidString; }
+    public void setFilePidString(String filePidString) {
+        this.filePidString = filePidString;
+    }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.operations.jms.thumbnail;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
 
 /**
  * Request object for setting a file as thumbnail for a work
@@ -12,13 +13,13 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
 public class ThumbnailRequest {
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
-    private String filePid;
+    private PID filePid;
 
     public AgentPrincipals getAgent() { return agent; }
 
     public void setAgent(AgentPrincipals agent) { this.agent = agent; }
 
-    public String getFilePid() { return filePid; }
+    public PID getFilePid() { return filePid; }
 
-    public void setFilePid(String fileId) { this.filePid = filePid; }
+    public void setFilePid(PID filePid) { this.filePid = filePid; }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -1,0 +1,24 @@
+package edu.unc.lib.boxc.operations.jms.thumbnail;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+
+/**
+ * Request object for setting a file as thumbnail for a work
+ *
+ * @author snluong
+ */
+public class ThumbnailRequest {
+    @JsonDeserialize(as = AgentPrincipalsImpl.class)
+    private AgentPrincipals agent;
+    private String filePid;
+
+    public AgentPrincipals getAgent() { return agent; }
+
+    public void setAgent(AgentPrincipals agent) { this.agent = agent; }
+
+    public String getFilePid() { return filePid; }
+
+    public void setFilePid(String fileId) { this.filePid = filePid; }
+}

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSerializationHelper.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSerializationHelper.java
@@ -12,12 +12,12 @@ import java.io.IOException;
  * @author snluong
  */
 public class ThumbnailRequestSerializationHelper {
-    private static final ObjectWriter MULTI_WRITER;
-    private static final ObjectReader MULTI_READER;
+    private static final ObjectWriter REQUEST_WRITER;
+    private static final ObjectReader REQUEST_READER;
     static {
         ObjectMapper mapper = new ObjectMapper();
-        MULTI_WRITER = mapper.writerFor(ThumbnailRequest.class);
-        MULTI_READER = mapper.readerFor(ThumbnailRequest.class);
+        REQUEST_WRITER = mapper.writerFor(ThumbnailRequest.class);
+        REQUEST_READER = mapper.readerFor(ThumbnailRequest.class);
     }
 
     private ThumbnailRequestSerializationHelper() {
@@ -30,7 +30,7 @@ public class ThumbnailRequestSerializationHelper {
      * @throws IOException
      */
     public static String toJson(ThumbnailRequest request) throws IOException {
-        return MULTI_WRITER.writeValueAsString(request);
+        return REQUEST_WRITER.writeValueAsString(request);
     }
 
     /**
@@ -40,6 +40,6 @@ public class ThumbnailRequestSerializationHelper {
      * @throws IOException
      */
     public static ThumbnailRequest toRequest(String json) throws IOException {
-        return MULTI_READER.readValue(json);
+        return REQUEST_READER.readValue(json);
     }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSerializationHelper.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSerializationHelper.java
@@ -1,0 +1,45 @@
+package edu.unc.lib.boxc.operations.jms.thumbnail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import java.io.IOException;
+
+/**
+ * Helper methods for serializing and deserializing thumbnail requests
+ *
+ * @author snluong
+ */
+public class ThumbnailRequestSerializationHelper {
+    private static final ObjectWriter MULTI_WRITER;
+    private static final ObjectReader MULTI_READER;
+    static {
+        ObjectMapper mapper = new ObjectMapper();
+        MULTI_WRITER = mapper.writerFor(ThumbnailRequest.class);
+        MULTI_READER = mapper.readerFor(ThumbnailRequest.class);
+    }
+
+    private ThumbnailRequestSerializationHelper() {
+    }
+
+    /**
+     * Transform request into a JSON string
+     * @param request
+     * @return
+     * @throws IOException
+     */
+    public static String toJson(ThumbnailRequest request) throws IOException {
+        return MULTI_WRITER.writeValueAsString(request);
+    }
+
+    /**
+     * Transform JSON string to a ThumbnailRequest
+     * @param json
+     * @return
+     * @throws IOException
+     */
+    public static ThumbnailRequest toRequest(String json) throws IOException {
+        return MULTI_READER.readValue(json);
+    }
+}

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -322,6 +322,10 @@
         <groupId>org.apache.jena</groupId>
         <artifactId>jena-fuseki-main</artifactId>
     </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -1,28 +1,36 @@
 package edu.unc.lib.boxc.services.camel.thumbnails;
 
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
 /**
- * @author sharonluong
+ * @author snluong
  */
 public class ThumbnailRequestProcessor implements Processor {
     private RepositoryObjectLoader repositoryObjectLoader;
     private RepositoryObjectFactory repositoryObjectFactory;
+    private AccessControlService aclService;
 
     @Override
     public void process(Exchange exchange) throws Exception {
         var in = exchange.getIn();
-        var pidString = in.getHeader("file_pid").toString();
-        var file = repositoryObjectLoader.getFileObject(PIDs.get(pidString));
+        var request = ThumbnailRequestSerializationHelper.toRequest(in.toString());
+        var pid = PIDs.get(request.getFilePid());
+        var file = repositoryObjectLoader.getFileObject(pid);
         var work = file.getParent();
+        var agent = request.getAgent();
         // check permission? set up new permission?
+        aclService.assertHasAccess("User does not have permission to add/update work thumbnail",
+                pid, agent.getPrincipals(), Permission.editDescription);
 
-        repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file);
+        repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file.getResource());
     }
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
@@ -31,5 +39,9 @@ public class ThumbnailRequestProcessor implements Processor {
 
     public void setRepositoryObjectFactory(RepositoryObjectFactory repositoryObjectFactory) {
         this.repositoryObjectFactory = repositoryObjectFactory;
+    }
+
+    public void setAclService(AccessControlService aclService) {
+        this.aclService = aclService;
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -1,0 +1,35 @@
+package edu.unc.lib.boxc.services.camel.thumbnails;
+
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.rdf.Cdr;
+import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * @author sharonluong
+ */
+public class ThumbnailRequestProcessor implements Processor {
+    private RepositoryObjectLoader repositoryObjectLoader;
+    private RepositoryObjectFactory repositoryObjectFactory;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        var in = exchange.getIn();
+        var pidString = in.getHeader("file_pid").toString();
+        var file = repositoryObjectLoader.getFileObject(PIDs.get(pidString));
+        var work = file.getParent();
+        // check permission? set up new permission?
+
+        repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file);
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repositoryObjectLoader = repositoryObjectLoader;
+    }
+
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repositoryObjectFactory) {
+        this.repositoryObjectFactory = repositoryObjectFactory;
+    }
+}

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -8,7 +8,6 @@ import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -15,6 +15,8 @@ import org.apache.camel.Processor;
 import java.io.IOException;
 
 /**
+ * Processing requests to assign a thumbnail from a file to its parent work
+ *
  * @author snluong
  */
 public class ThumbnailRequestProcessor implements Processor {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -6,6 +6,8 @@ import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.Exchange;
@@ -18,7 +20,7 @@ public class ThumbnailRequestProcessor implements Processor {
     private RepositoryObjectLoader repositoryObjectLoader;
     private RepositoryObjectFactory repositoryObjectFactory;
     private AccessControlService aclService;
-    private IndexingService indexingService;
+    private IndexingMessageSender indexingMessageSender;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -28,14 +30,15 @@ public class ThumbnailRequestProcessor implements Processor {
         var file = repositoryObjectLoader.getFileObject(pid);
         var work = file.getParent();
         var agent = request.getAgent();
-        // check permission? set up new permission?
+
         aclService.assertHasAccess("User does not have permission to add/update work thumbnail",
                 pid, agent.getPrincipals(), Permission.editDescription);
 
         repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file.getResource());
 
         // send message to update solr
-        indexingService.reindexObject(agent, work.getPid());
+        indexingMessageSender.sendIndexingOperation(
+                agent.getUsername(), work.getPid(), IndexingActionType.UPDATE_DATASTREAMS);
     }
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
@@ -50,7 +53,7 @@ public class ThumbnailRequestProcessor implements Processor {
         this.aclService = aclService;
     }
 
-    public void setIndexingService(IndexingService indexingService) {
-        this.indexingService = indexingService;
+    public void setIndexingMessageSender(IndexingMessageSender indexingMessageSender) {
+        this.indexingMessageSender = indexingMessageSender;
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouter.java
@@ -1,0 +1,27 @@
+package edu.unc.lib.boxc.services.camel.thumbnails;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
+
+import static org.apache.camel.LoggingLevel.DEBUG;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Router for processing assigning thumbnails for works
+ *
+ * @author snluong
+ */
+public class ThumbnailRouter extends RouteBuilder {
+    private static final Logger log = getLogger(ThumbnailRouter.class);
+    @BeanInject(value = "thumbnailRequestProcessor")
+    private ThumbnailRequestProcessor thumbnailRequestProcessor;
+
+    @Override
+    public void configure() throws Exception {
+        from("{{cdr.thumbnails.stream.camel}}")
+                .routeId("DcrThumbnails")
+                .log(DEBUG, log, "Received thumbnail request")
+                .bean(thumbnailRequestProcessor);
+    }
+}

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/ProcessorTestHelper.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/ProcessorTestHelper.java
@@ -1,0 +1,19 @@
+package edu.unc.lib.boxc.services.camel;
+
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.apache.camel.model.ModelCamelContext;
+import org.springframework.context.support.AbstractApplicationContext;
+
+import java.util.UUID;
+
+/**
+ * Basic methods used in several Processor tests
+ *
+ * @author snluong
+ */
+public class ProcessorTestHelper {
+    public static PID makePid() {
+        return PIDs.get(UUID.randomUUID().toString());
+    }
+}

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/ProcessorTestHelper.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/ProcessorTestHelper.java
@@ -2,10 +2,13 @@ package edu.unc.lib.boxc.services.camel;
 
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import org.apache.camel.model.ModelCamelContext;
-import org.springframework.context.support.AbstractApplicationContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 
 import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Basic methods used in several Processor tests
@@ -15,5 +18,13 @@ import java.util.UUID;
 public class ProcessorTestHelper {
     public static PID makePid() {
         return PIDs.get(UUID.randomUUID().toString());
+    }
+
+    public static Exchange mockExchange(String body) {
+        var exchange = mock(Exchange.class);
+        var message = mock(Message.class);
+        when(exchange.getIn()).thenReturn(message);
+        when(message.getBody(String.class)).thenReturn(body);
+        return exchange;
     }
 }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
@@ -15,6 +15,7 @@ import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
 import edu.unc.lib.boxc.operations.jms.order.MultiParentOrderRequest;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequestSerializationHelper;
+import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.junit.Before;
@@ -142,7 +143,7 @@ public class OrderRequestProcessorTest {
     public void invalidRequestBodyTest() throws Exception {
         mockRequestAsValid();
 
-        var requestExchange = mockExchange("bad times");
+        var requestExchange = ProcessorTestHelper.mockExchange("bad times");
         try {
             processor.process(requestExchange);
             fail();
@@ -340,14 +341,6 @@ public class OrderRequestProcessorTest {
         request.setEmail(EMAIL);
         request.setOperation(OrderOperationType.SET);
         request.setParentToOrdered(parentToOrder);
-        return mockExchange(OrderRequestSerializationHelper.toJson(request));
-    }
-
-    private Exchange mockExchange(String body) {
-        var exchange = mock(Exchange.class);
-        var message = mock(Message.class);
-        when(exchange.getIn()).thenReturn(message);
-        when(message.getBody(String.class)).thenReturn(body);
-        return exchange;
+        return ProcessorTestHelper.mockExchange(OrderRequestSerializationHelper.toJson(request));
     }
 }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorTest.java
@@ -23,6 +23,7 @@ import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
+import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.jdom2.Document;
@@ -88,7 +89,7 @@ public class SolrUpdateProcessorTest {
         when(exchange.getIn()).thenReturn(msg);
         when(msg.getBody()).thenReturn(bodyDoc);
 
-        targetPid = makePid();
+        targetPid = ProcessorTestHelper.makePid();
     }
 
     @Test
@@ -177,15 +178,11 @@ public class SolrUpdateProcessorTest {
 
         List<PID> pids = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            PID pid = makePid();
+            PID pid = ProcessorTestHelper.makePid();
             pids.add(pid);
             children.addContent(new Element("pid", CDR_MESSAGE_NS)
                     .setText(pid.getRepositoryPath()));
         }
         return pids;
-    }
-
-    private PID makePid() {
-        return PIDs.get(UUID.randomUUID().toString());
     }
 }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
@@ -1,6 +1,7 @@
 package edu.unc.lib.boxc.services.camel.thumbnails;
 
 import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
@@ -9,7 +10,9 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import org.apache.jena.rdf.model.Resource;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
@@ -23,16 +26,20 @@ import org.jdom2.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.framework;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * @author snluong
@@ -54,30 +61,41 @@ public class ThumbnailProcessorTest {
 
     @Before
     public void init() throws IOException {
+        MockitoAnnotations.initMocks(this);
         processor = new ThumbnailRequestProcessor();
         processor.setAclService(accessControlService);
         processor.setIndexingMessageSender(indexingMessageSender);
         processor.setRepositoryObjectLoader(repositoryObjectLoader);
         processor.setRepositoryObjectFactory(repositoryObjectFactory);
-
-        exchange = createRequestExchange();
         filePid = ProcessorTestHelper.makePid();
         workPid = ProcessorTestHelper.makePid();
-
-        when(accessControlService.hasAccess(any(), any(), eq(Permission.editDescription))).thenReturn(true);
+        exchange = createRequestExchange();
     }
 
     @Test
     public void testUpdateThumbnail() throws Exception {
         var file = mock(FileObject.class);
+        var resource = mock(Resource.class);
         when(file.getPid()).thenReturn(filePid);
         var parentWork = mock(WorkObject.class);
         when(file.getParent()).thenReturn(parentWork);
+        when(file.getResource()).thenReturn(resource);
         when(parentWork.getPid()).thenReturn(workPid);
-        when(repositoryObjectLoader.getRepositoryObject(filePid)).thenReturn(file);
+        when(repositoryObjectLoader.getFileObject(filePid)).thenReturn(file);
 
         processor.process(exchange);
+        verify(repositoryObjectFactory).createExclusiveRelationship(eq(parentWork), eq(Cdr.useAsThumbnail), eq(file.getResource()));
         assertIndexingMessageSent();
+    }
+
+    @Test
+    public void insufficientPermissionsTest() {
+        Assertions.assertThrows(AccessRestrictionException.class, () -> {
+            doThrow(new AccessRestrictionException()).when(accessControlService)
+                .assertHasAccess(any(), any(PID.class), any(), eq(Permission.editDescription));
+
+            processor.process(exchange);
+        });
     }
 
     private void assertIndexingMessageSent() {
@@ -85,15 +103,10 @@ public class ThumbnailProcessorTest {
                 IndexingActionType.UPDATE_DATASTREAMS);
     }
 
-    private void assertIndexingMessageNotSent() {
-        verify(indexingMessageSender, never()).sendIndexingOperation(agent.getUsername(), workPid,
-                IndexingActionType.UPDATE_DATASTREAMS);
-    }
-
     private Exchange createRequestExchange() throws IOException {
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePid(filePid);
+        request.setFilePidString(filePid.toString());
         return ProcessorTestHelper.mockExchange(ThumbnailRequestSerializationHelper.toJson(request));
     }
 }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
@@ -13,23 +13,18 @@ import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import org.apache.jena.rdf.model.Resource;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import org.apache.camel.Exchange;
-import org.apache.camel.Message;
-import org.jdom2.Document;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 
@@ -67,7 +62,7 @@ public class ThumbnailProcessorTest {
 
     @Before
     public void init() throws IOException {
-        closeable = MockitoAnnotations.openMocks(this);
+        closeable = openMocks(this);
         processor = new ThumbnailRequestProcessor();
         processor.setAclService(accessControlService);
         processor.setIndexingMessageSender(indexingMessageSender);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
@@ -1,0 +1,99 @@
+package edu.unc.lib.boxc.services.camel.thumbnails;
+
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
+import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.jdom2.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.framework;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author snluong
+ */
+public class ThumbnailProcessorTest {
+    private ThumbnailRequestProcessor processor;
+    private PID filePid;
+    private PID workPid;
+    private final AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+    private Exchange exchange;
+    @Mock
+    private AccessControlService accessControlService;
+    @Mock
+    private IndexingMessageSender indexingMessageSender;
+    @Mock
+    private RepositoryObjectLoader repositoryObjectLoader;
+    @Mock
+    private RepositoryObjectFactory repositoryObjectFactory;
+
+    @Before
+    public void init() throws IOException {
+        processor = new ThumbnailRequestProcessor();
+        processor.setAclService(accessControlService);
+        processor.setIndexingMessageSender(indexingMessageSender);
+        processor.setRepositoryObjectLoader(repositoryObjectLoader);
+        processor.setRepositoryObjectFactory(repositoryObjectFactory);
+
+        exchange = createRequestExchange();
+        filePid = ProcessorTestHelper.makePid();
+        workPid = ProcessorTestHelper.makePid();
+
+        when(accessControlService.hasAccess(any(), any(), eq(Permission.editDescription))).thenReturn(true);
+    }
+
+    @Test
+    public void testUpdateThumbnail() throws Exception {
+        var file = mock(FileObject.class);
+        when(file.getPid()).thenReturn(filePid);
+        var parentWork = mock(WorkObject.class);
+        when(file.getParent()).thenReturn(parentWork);
+        when(parentWork.getPid()).thenReturn(workPid);
+        when(repositoryObjectLoader.getRepositoryObject(filePid)).thenReturn(file);
+
+        processor.process(exchange);
+        assertIndexingMessageSent();
+    }
+
+    private void assertIndexingMessageSent() {
+        verify(indexingMessageSender).sendIndexingOperation(agent.getUsername(), workPid,
+                IndexingActionType.UPDATE_DATASTREAMS);
+    }
+
+    private void assertIndexingMessageNotSent() {
+        verify(indexingMessageSender, never()).sendIndexingOperation(agent.getUsername(), workPid,
+                IndexingActionType.UPDATE_DATASTREAMS);
+    }
+
+    private Exchange createRequestExchange() throws IOException {
+        var request = new ThumbnailRequest();
+        request.setAgent(agent);
+        request.setFilePid(filePid);
+        return ProcessorTestHelper.mockExchange(ThumbnailRequestSerializationHelper.toJson(request));
+    }
+}

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -1,7 +1,56 @@
 package edu.unc.lib.boxc.services.camel.thumbnails;
 
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
+import org.apache.camel.BeanInject;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.junit.Test;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
 /**
- * @author sharonluong
+ * @author snluong
  */
-public class ThumbnailRouterTest {
+public class ThumbnailRouterTest extends CamelSpringTestSupport {
+    private AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+    @BeanInject(value = "thumbnailRequestProcessor")
+    private ThumbnailRequestProcessor processor;
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("/service-context.xml", "/thumbnails-context.xml");
+    }
+    @Test
+    public void requestSentTest() throws Exception {
+        createContext("DcrThumbnails");
+        var pid = ProcessorTestHelper.makePid();
+
+        var request = new ThumbnailRequest();
+        request.setAgent(agent);
+        request.setFilePid(pid);
+        var body = ThumbnailRequestSerializationHelper.toJson(request);
+        template.sendBody(body);
+
+        verify(processor).process(any());
+    }
+
+    private void createContext(String routeName) throws Exception {
+        context.getRouteDefinition(routeName).adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+
+        context.start();
+    }
 }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -8,6 +8,8 @@ import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.BeanInject;
 import org.apache.camel.Endpoint;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
@@ -22,6 +24,8 @@ import static org.mockito.Mockito.verify;
  */
 public class ThumbnailRouterTest extends CamelSpringTestSupport {
     private AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
     @BeanInject(value = "thumbnailRequestProcessor")
     private ThumbnailRequestProcessor processor;
     @Override
@@ -35,10 +39,8 @@ public class ThumbnailRouterTest extends CamelSpringTestSupport {
 
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePid(pid);
+        request.setFilePidString(pid.toString());
         var body = ThumbnailRequestSerializationHelper.toJson(request);
-        Endpoint endpoint = context.getEndpoint("direct:start");
-        template.setDefaultEndpoint(endpoint);
         template.sendBody(body);
 
         verify(processor).process(any());

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -7,7 +7,6 @@ import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.BeanInject;
-import org.apache.camel.Endpoint;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.AdviceWithRouteBuilder;

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -1,0 +1,7 @@
+package edu.unc.lib.boxc.services.camel.thumbnails;
+
+/**
+ * @author sharonluong
+ */
+public class ThumbnailRouterTest {
+}

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -3,11 +3,11 @@ package edu.unc.lib.boxc.services.camel.thumbnails;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.BeanInject;
+import org.apache.camel.Endpoint;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.junit.Test;
@@ -37,6 +37,8 @@ public class ThumbnailRouterTest extends CamelSpringTestSupport {
         request.setAgent(agent);
         request.setFilePid(pid);
         var body = ThumbnailRequestSerializationHelper.toJson(request);
+        Endpoint endpoint = context.getEndpoint("direct:start");
+        template.setDefaultEndpoint(endpoint);
         template.sendBody(body);
 
         verify(processor).process(any());

--- a/services-camel-app/src/test/resources/thumbnails-config.properties
+++ b/services-camel-app/src/test/resources/thumbnails-config.properties
@@ -1,0 +1,2 @@
+cdr.thumbnails.stream=direct:start
+cdr.thumbnails.stream.camel=direct:start

--- a/services-camel-app/src/test/resources/thumbnails-context.xml
+++ b/services-camel-app/src/test/resources/thumbnails-context.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+        http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <bean id="thumbnailRequestProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.services.camel.thumbnails.ThumbnailRequestProcessor" />
+    </bean>
+
+    <camel:camelContext id="DcrThumbnails">
+        <camel:package>edu.unc.lib.boxc.services.camel.thumbnails</camel:package>
+    </camel:camelContext>
+
+</beans>

--- a/services-camel-app/src/test/resources/thumbnails-context.xml
+++ b/services-camel-app/src/test/resources/thumbnails-context.xml
@@ -11,6 +11,10 @@
         <constructor-arg value="edu.unc.lib.boxc.services.camel.thumbnails.ThumbnailRequestProcessor" />
     </bean>
 
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:thumbnails-config.properties"/>
+    </bean>
+
     <camel:camelContext id="DcrThumbnails">
         <camel:package>edu.unc.lib.boxc.services.camel.thumbnails</camel:package>
     </camel:camelContext>

--- a/services-camel-app/src/test/resources/thumbnails-context.xml
+++ b/services-camel-app/src/test/resources/thumbnails-context.xml
@@ -15,6 +15,10 @@
         <property name="location" value="classpath:thumbnails-config.properties"/>
     </bean>
 
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:thumbnails-config.properties"/>
+    </bean>
+
     <camel:camelContext id="DcrThumbnails">
         <camel:package>edu.unc.lib.boxc.services.camel.thumbnails</camel:package>
     </camel:camelContext>


### PR DESCRIPTION
This PR creates a workflow to assign a thumbnail from a file to its parent work via a router and processor. It also has associated tests, context and properties files, and a test helper file with some helper methods. Some of these methods are used in other tests but i just updated an OrderMember test to use them to see if it would work.

https://jira.lib.unc.edu/browse/BXC-4063