### PR TITLE
Bxc 4062 assign thumbnail api

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
@@ -1,0 +1,30 @@
+package edu.unc.lib.boxc.operations.jms.thumbnail;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import edu.unc.lib.boxc.operations.jms.MessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Service for sending requests to update child object used as thumbnail
+ *
+ * @author snluong
+ */
+public class ThumbnailRequestSender extends MessageSender {
+    private static final Logger log = LoggerFactory.getLogger(ThumbnailRequestSender.class);
+    private static final ObjectWriter MAPPER = new ObjectMapper().writerFor(ThumbnailRequest.class);
+
+    /**
+     * Send a ThumbnailRequest to the configured JMS queue
+     * @param request
+     * @throws IOException
+     */
+    public void sendToQueue(ThumbnailRequest request) throws IOException {
+        String messageBody = MAPPER.writeValueAsString(request);
+        sendMessage(messageBody);
+        log.info("Job to update thumbnail has been queued for {}", request.getAgent().getUsername());
+    }
+}

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
@@ -25,6 +25,7 @@ public class ThumbnailRequestSender extends MessageSender {
     public void sendToQueue(ThumbnailRequest request) throws IOException {
         String messageBody = MAPPER.writeValueAsString(request);
         sendMessage(messageBody);
-        log.info("Job to update thumbnail has been queued for {}", request.getAgent().getUsername());
+        log.info("Job to update thumbnail has been queued for {} with file {}",
+                request.getAgent().getUsername(), request.getFilePidString());
     }
 }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/ImportThumbnailService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/ImportThumbnailService.java
@@ -8,6 +8,7 @@ import static org.apache.commons.io.FileUtils.copyInputStreamToFile;
 import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -40,7 +41,7 @@ public class ImportThumbnailService extends MessageSender {
         storagePath = Paths.get(sourceImagesDir);
     }
 
-    public void run(InputStream importStream, AgentPrincipals agent, String uuid, String mimeType) throws Exception {
+    public void run(InputStream importStream, AgentPrincipals agent, String uuid, String mimeType) throws IOException {
         PID pid = PIDs.get(uuid);
 
         aclService.assertHasAccess("User does not have permission to add/update collection thumbnails",

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -1,4 +1,4 @@
-package edu.unc.lib.boxc.web.services.rest;
+package edu.unc.lib.boxc.web.services.rest.modify;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,8 +28,8 @@ import edu.unc.lib.boxc.web.services.processing.ImportThumbnailService;
  *
  */
 @Controller
-public class EditThumbnailController {
-    private static final Logger log = LoggerFactory.getLogger(EditThumbnailController.class);
+public class ThumbnailController {
+    private static final Logger log = LoggerFactory.getLogger(ThumbnailController.class);
 
     @Autowired
     private ImportThumbnailService service;

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -64,8 +64,7 @@ public class ThumbnailController {
     @PostMapping(value = "/edit/displayThumbnail/{pid}")
     public @ResponseBody
     ResponseEntity<Object> importThumbnail(@PathVariable("pid") String pid,
-                                                     @RequestParam("file") MultipartFile thumbnailFile)
-            throws Exception {
+                                                     @RequestParam("file") MultipartFile thumbnailFile) {
 
         AgentPrincipals agent = AgentPrincipalsImpl.createFromThread();
         String mimeType = thumbnailFile.getContentType();

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import edu.unc.lib.boxc.auth.api.Permission;
-import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.model.api.ids.PID;

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -54,9 +54,16 @@ public class ThumbnailController {
     @Autowired
     private RepositoryObjectLoader repositoryObjectLoader;
 
+    /**
+     * This endpoint uploads a file to use as the thumbnail
+     * @param pid PID of object getting a thumbnail
+     * @param thumbnailFile file to use as thumbnail
+     * @return
+     * @throws Exception
+     */
     @PostMapping(value = "edit/displayThumbnail/{pid}")
     public @ResponseBody
-    ResponseEntity<Object> ImportThumbnail(@PathVariable("pid") String pid,
+    ResponseEntity<Object> importThumbnail(@PathVariable("pid") String pid,
                                                      @RequestParam("file") MultipartFile thumbnailFile)
             throws Exception {
 
@@ -84,13 +91,18 @@ public class ThumbnailController {
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 
-    @PutMapping(value = "/assignThumbnail/{pidString}")
+    /**
+     * This endpoint assigns a child file to use as the thumbnail for the parent work
+     * @param pidString ID of the file
+     * @return HTTP status
+     */
+    @PutMapping(value = "/edit/assignThumbnail/{pidString}")
     @ResponseBody
-    public ResponseEntity<Object> AssignThumbnail(@PathVariable("pidString") String pidString) {
+    public ResponseEntity<Object> assignThumbnail(@PathVariable("pidString") String pidString) {
         PID pid = PIDs.get(pidString);
 
         AccessGroupSet principals = getAgentPrincipals().getPrincipals();
-        aclService.assertHasAccess("Insufficient permissions to download access copy for " + pidString,
+        aclService.assertHasAccess("Insufficient permissions to assign thumbnail for " + pidString,
                 pid, principals, Permission.editDescription);
 
         var object = repositoryObjectLoader.getRepositoryObject(pid);
@@ -106,7 +118,7 @@ public class ThumbnailController {
         try {
             thumbnailRequestSender.sendToQueue(request);
         } catch (IOException e) {
-            log.error("Error assigning file {} as thumbnail: {}", request.getFilePidString(), e);
+            log.error("Error assigning file {} as thumbnail", request.getFilePidString(), e);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         return new ResponseEntity<>(HttpStatus.OK);

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -59,7 +59,6 @@ public class ThumbnailController {
      * @param pid PID of object getting a thumbnail
      * @param thumbnailFile file to use as thumbnail
      * @return
-     * @throws Exception
      */
     @PostMapping(value = "/edit/displayThumbnail/{pid}")
     public @ResponseBody

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -61,7 +61,7 @@ public class ThumbnailController {
      * @return
      * @throws Exception
      */
-    @PostMapping(value = "edit/displayThumbnail/{pid}")
+    @PostMapping(value = "/edit/displayThumbnail/{pid}")
     public @ResponseBody
     ResponseEntity<Object> importThumbnail(@PathVariable("pid") String pid,
                                                      @RequestParam("file") MultipartFile thumbnailFile)

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -426,6 +426,16 @@
     <bean id="downloadImageService" class="edu.unc.lib.boxc.web.services.processing.DownloadImageService">
         <property name="iiifBasePath" value="${iiif.base.url}"/>
     </bean>
+
+    <bean id="thumbnailRequestJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="${cdr.thumbnail.stream}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+
+    <bean id="thumbnailRequestSender" class="edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSender">
+        <property name="jmsTemplate" ref="thumbnailRequestJmsTemplate"/>
+    </bean>
     
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="edu.unc.lib.boxc.web.common.utils.SerializationUtil.injectSettings"/>

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -165,7 +165,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         var file = repositoryObjectFactory.createFileObject(pid, null);
         when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
 
-        mvc.perform(put("/assignThumbnail/" + filePidString))
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
@@ -181,7 +181,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
 
-        mvc.perform(put("/assignThumbnail/" + filePidString))
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
                 .andExpect(status().isForbidden())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
@@ -189,8 +189,8 @@ public class ThumbnailIT extends AbstractAPIIT {
 
     @Test
     public void assignThumbnailInvalidPidString() throws Exception {
-        var badPidString = "Not a pid";
-        mvc.perform(put("/assignThumbnail/" + badPidString))
+        var badPidString = "NotAPid";
+        mvc.perform(put("/edit/assignThumbnail/" + badPidString))
                 .andExpect(status().is4xxClientError())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
@@ -203,7 +203,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         var work = repositoryObjectFactory.createWorkObject(pid, null);
         when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
 
-        mvc.perform(put("/assignThumbnail/" + filePidString))
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
                 .andExpect(status().isBadRequest())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -30,14 +30,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.runner.Request;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -1,4 +1,4 @@
-package edu.unc.lib.boxc.web.services.rest;
+package edu.unc.lib.boxc.web.services.rest.modify;
 
 import static edu.unc.lib.boxc.auth.api.Permission.editDescription;
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.ATOM_NS;
@@ -54,7 +54,7 @@ import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
         @ContextConfiguration("/spring-test/cdr-client-container.xml"),
         @ContextConfiguration("/add-thumb-it-servlet.xml")
 })
-public class EditThumbIT extends AbstractAPIIT {
+public class ThumbnailIT extends AbstractAPIIT {
     private static final String USER_NAME = "user";
     private static final String ADMIN_GROUP = "adminGroup";
     private CollectionObject collection;

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -121,7 +121,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         FileInputStream input = new FileInputStream("src/test/resources/upload-files/burndown.png");
         MockMultipartFile thumbnailFile = new MockMultipartFile("file", "burndown.png", "image/png", IOUtils.toByteArray(input));
 
-        mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/displayThumbnail/" + collection.getPid().getUUID()))
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
                 .file(thumbnailFile))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
@@ -135,7 +135,7 @@ public class ThumbnailIT extends AbstractAPIIT {
     public void addCollectionThumbWrongFileType() throws Exception {
         MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
 
-        mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/displayThumbnail/" + collection.getPid().getUUID()))
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
                 .file(thumbnailFile))
                 .andExpect(status().is4xxClientError())
                 .andReturn();
@@ -150,7 +150,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
 
-        mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/displayThumbnail/" + collection.getPid().getUUID()))
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
                 .file(thumbnailFile))
                 .andExpect(status().isForbidden())
                 .andReturn();

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -12,7 +12,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.File;
@@ -20,18 +21,23 @@ import java.io.FileInputStream;
 import java.net.URI;
 import java.nio.file.Path;
 
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSender;
 import org.apache.commons.io.IOUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.runner.Request;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
@@ -44,7 +50,6 @@ import edu.unc.lib.boxc.model.api.objects.CollectionObject;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
 import edu.unc.lib.boxc.web.services.processing.ImportThumbnailService;
-import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
 
 /**
  * @author lfarrell
@@ -52,27 +57,32 @@ import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
 @ContextHierarchy({
         @ContextConfiguration("/spring-test/test-fedora-container.xml"),
         @ContextConfiguration("/spring-test/cdr-client-container.xml"),
-        @ContextConfiguration("/add-thumb-it-servlet.xml")
+        @ContextConfiguration("/thumb-it-servlet.xml")
 })
 public class ThumbnailIT extends AbstractAPIIT {
     private static final String USER_NAME = "user";
     private static final String ADMIN_GROUP = "adminGroup";
     private CollectionObject collection;
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
 
     @Captor
     private ArgumentCaptor<Document> docCaptor;
+    @Captor
+    private ArgumentCaptor<ThumbnailRequest> requestCaptor;
 
     @Autowired
     private ImportThumbnailService service;
     @Autowired
-    private AccessControlServiceImpl aclServices;
+    private AccessControlServiceImpl aclService;
     @Autowired
     private MessageSender messageSender;
     @Autowired
     private RepositoryObjectFactory repositoryObjectFactory;
+    @Autowired
+    private ThumbnailRequestSender thumbnailRequestSender;
 
     private File tempDir;
 
@@ -85,8 +95,8 @@ public class ThumbnailIT extends AbstractAPIIT {
 
     @BeforeEach
     public void setup() {
-        initMocks(this);
-        reset(messageSender);
+        closeable = openMocks(this);
+        reset(messageSender, thumbnailRequestSender);
 
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(ADMIN_GROUP);
 
@@ -95,6 +105,11 @@ public class ThumbnailIT extends AbstractAPIIT {
 
         setupContentRoot();
         collection = repositoryObjectFactory.createCollectionObject(null);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test
@@ -128,7 +143,7 @@ public class ThumbnailIT extends AbstractAPIIT {
     public void addCollectionThumbNoAccess() throws Exception {
         MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
 
-        doThrow(new AccessRestrictionException()).when(aclServices)
+        doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
 
         mvc.perform(MockMvcRequestBuilders.multipart(URI.create("/edit/displayThumbnail/" + collection.getPid().getUUID()))
@@ -137,6 +152,42 @@ public class ThumbnailIT extends AbstractAPIIT {
                 .andReturn();
 
         verify(messageSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void assignThumbnailSuccess() throws Exception {
+        var pid = makePid();
+        var filePidString = pid.getId();
+
+        mvc.perform(put("/assignThumbnail/" + filePidString))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        verify(thumbnailRequestSender).sendToQueue(requestCaptor.capture());
+        ThumbnailRequest request = requestCaptor.getValue();
+        assertEquals(filePidString, request.getFilePidString());
+    }
+
+    @Test
+    public void assignThumbnailNoAccess() throws Exception {
+        var pid = makePid();
+        var filePidString = pid.getId();
+        doThrow(new AccessRestrictionException()).when(aclService)
+                .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
+
+        mvc.perform(put("/assignThumbnail/" + filePidString))
+                .andExpect(status().isForbidden())
+                .andReturn();
+        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void assignThumbnailInvalidPidString() throws Exception {
+        var badPidString = "Not a pid";
+        mvc.perform(put("/assignThumbnail/" + badPidString))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
     }
 
     private byte[] textStream() {

--- a/web-services-app/src/test/resources/thumb-it-servlet.xml
+++ b/web-services-app/src/test/resources/thumb-it-servlet.xml
@@ -14,23 +14,28 @@
 
     <mvc:annotation-driven/>
 
-    <context:component-scan resource-pattern="**/EditThumbnailController*" base-package="edu.unc.lib.boxc.web.services.rest"/>
+    <context:component-scan base-package="edu.unc.lib.boxc.web.services.rest.exceptions"/>
+    <context:component-scan resource-pattern="**/ThumbnailController*" base-package="edu.unc.lib.boxc.web.services.rest.modify"/>
 
     <bean id="messageSender" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.boxc.operations.jms.MessageSender"/>
     </bean>
 
     <bean id="importThumbnailService" class="edu.unc.lib.boxc.web.services.processing.ImportThumbnailService">
-        <property name="aclService" ref="aclServices" />
+        <property name="aclService" ref="aclService" />
         <property name="messageSender" ref="messageSender" />
         <property name="sourceImagesDir" value="dataDir" />
     </bean>
 
-    <bean id="aclServices" class="org.mockito.Mockito" factory-method="mock">
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.boxc.auth.fcrepo.services.AccessControlServiceImpl"/>
     </bean>
 
     <bean id="dataDir" class="java.lang.String">
         <constructor-arg value="target"/>
+    </bean>
+
+    <bean id="thumbnailRequestSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSender" />
     </bean>
 </beans>


### PR DESCRIPTION
This PR introduces an API endpoint to assign a thumbnail from a child object to the parent object. To do this, I moved the existing thumbnail-related controller to the `modify` package and generalized the naming so I could add the new endpoint. There are also related tests and context files.

https://unclibrary.atlassian.net/browse/BXC-4062