### PR TITLE
BXC-4298 - add displayDate to archives description template

### DIFF
--- a/static/js/xmleditor/templates/archives.xml
+++ b/static/js/xmleditor/templates/archives.xml
@@ -7,6 +7,7 @@
   <mods:identifier displayLabel="Digital Folder Number" type="local" />
   <mods:originInfo>
     <mods:dateCreated encoding="edtf" />
+    <mods:displayDate />
   </mods:originInfo>
   <mods:relatedItem type="original">
     <mods:identifier displayLabel="Source Media Identifier" />


### PR DESCRIPTION
adds the new mods:displayDate field to the archives description template in the admin ui