### PR TITLE
BXC-4065 add delete to thumbnail request and process accordingly

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -10,9 +10,12 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
  * @author snluong
  */
 public class ThumbnailRequest {
+    public static String ASSIGN = "assign";
+    public static String DELETE = "delete";
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
     private String filePidString;
+    private String action;
 
     public AgentPrincipals getAgent() {
         return agent;
@@ -28,5 +31,13 @@ public class ThumbnailRequest {
 
     public void setFilePidString(String filePidString) {
         this.filePidString = filePidString;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
     }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
@@ -25,7 +25,7 @@ public class ThumbnailRequestSender extends MessageSender {
     public void sendToQueue(ThumbnailRequest request) throws IOException {
         String messageBody = MAPPER.writeValueAsString(request);
         sendMessage(messageBody);
-        log.info("Job to update thumbnail has been queued for {} with file {}",
-                request.getAgent().getUsername(), request.getFilePidString());
+        log.info("Job to {} thumbnail has been queued for {} with file {}",
+                request.getAction(), request.getAgent().getUsername(), request.getFilePidString());
     }
 }

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSenderTest.java
@@ -1,0 +1,58 @@
+package edu.unc.lib.boxc.operations.jms.thumbnail;
+
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.jms.core.JmsTemplate;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * @author sharonluong
+ */
+public class ThumbnailRequestSenderTest {
+    @Mock
+    private JmsTemplate jmsTemplate;
+    private ThumbnailRequestSender thumbnailRequestSender;
+    private AutoCloseable closeable;
+    private final AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+
+    @BeforeEach
+    public void setup() {
+        closeable = openMocks(this);
+        thumbnailRequestSender = new ThumbnailRequestSender();
+        thumbnailRequestSender.setJmsTemplate(jmsTemplate);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void sendToQueueTest() throws IOException {
+        var filePidString = makePid().toString();
+        var request = new ThumbnailRequest();
+        request.setAgent(agent);
+        request.setFilePidString(filePidString);
+        request.setAction(ThumbnailRequest.ASSIGN);
+
+        thumbnailRequestSender.sendToQueue(request);
+        verify(jmsTemplate).send(any());
+    }
+
+    public static PID makePid() {
+        return PIDs.get(UUID.randomUUID().toString());
+    }
+}

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -8,11 +8,13 @@ import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
+import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequest;
 import edu.unc.lib.boxc.operations.jms.thumbnail.ThumbnailRequestSerializationHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Processing requests to assign a thumbnail from a file to its parent work
@@ -30,6 +32,7 @@ public class ThumbnailRequestProcessor implements Processor {
         var in = exchange.getIn();
         var request = ThumbnailRequestSerializationHelper.toRequest(in.getBody(String.class));
         var agent = request.getAgent();
+        var action = request.getAction();
         var pid = PIDs.get(request.getFilePidString());
 
         aclService.assertHasAccess("User does not have permission to add/update work thumbnail",
@@ -38,7 +41,11 @@ public class ThumbnailRequestProcessor implements Processor {
         var file = repositoryObjectLoader.getFileObject(pid);
         var work = file.getParent();
 
-        repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file.getResource());
+        if (Objects.equals(action, ThumbnailRequest.ASSIGN)) {
+            repositoryObjectFactory.createExclusiveRelationship(work, Cdr.useAsThumbnail, file.getResource());
+        } else if ( Objects.equals(action, ThumbnailRequest.DELETE)) {
+            repositoryObjectFactory.deleteProperty(work, Cdr.useAsThumbnail);
+        }
 
         // send message to update solr
         indexingMessageSender.sendIndexingOperation(

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
@@ -73,7 +73,7 @@ public class ThumbnailProcessorTest {
         workPid = ProcessorTestHelper.makePid();
         resource = mock(Resource.class);
         parentWork = mock(WorkObject.class);
-        
+
         var file = mock(FileObject.class);
         when(file.getPid()).thenReturn(filePid);
         when(file.getParent()).thenReturn(parentWork);


### PR DESCRIPTION
This PR adds the "action" param to Thumbnail request so that either "assign" or "delete" requests may use the same structure. The processor now processes both types of requests. A test was also added.

https://unclibrary.atlassian.net/browse/BXC-4065