### PR TITLE
Bxc 4063 clear thumbnail api

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequest.java
@@ -14,7 +14,7 @@ public class ThumbnailRequest {
     public static String DELETE = "delete";
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
-    private String filePidString;
+    private String pidString;
     private String action;
 
     public AgentPrincipals getAgent() {
@@ -25,12 +25,12 @@ public class ThumbnailRequest {
         this.agent = agent;
     }
 
-    public String getFilePidString() {
-        return filePidString;
+    public String getPidString() {
+        return pidString;
     }
 
-    public void setFilePidString(String filePidString) {
-        this.filePidString = filePidString;
+    public void setPidString(String filePidString) {
+        this.pidString = filePidString;
     }
 
     public String getAction() {

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSender.java
@@ -26,6 +26,6 @@ public class ThumbnailRequestSender extends MessageSender {
         String messageBody = MAPPER.writeValueAsString(request);
         sendMessage(messageBody);
         log.info("Job to {} thumbnail has been queued for {} with file {}",
-                request.getAction(), request.getAgent().getUsername(), request.getFilePidString());
+                request.getAction(), request.getAgent().getUsername(), request.getPidString());
     }
 }

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/thumbnail/ThumbnailRequestSenderTest.java
@@ -45,7 +45,7 @@ public class ThumbnailRequestSenderTest {
         var filePidString = makePid().toString();
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePidString(filePidString);
+        request.setPidString(filePidString);
         request.setAction(ThumbnailRequest.ASSIGN);
 
         thumbnailRequestSender.sendToQueue(request);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRequestProcessor.java
@@ -33,7 +33,7 @@ public class ThumbnailRequestProcessor implements Processor {
         var request = ThumbnailRequestSerializationHelper.toRequest(in.getBody(String.class));
         var agent = request.getAgent();
         var action = request.getAction();
-        var pid = PIDs.get(request.getFilePidString());
+        var pid = PIDs.get(request.getPidString());
 
         aclService.assertHasAccess("User does not have permission to add/update work thumbnail",
                 pid, agent.getPrincipals(), Permission.editDescription);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailProcessorTest.java
@@ -125,7 +125,7 @@ public class ThumbnailProcessorTest {
     private Exchange createRequestExchange(String action) throws IOException {
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePidString(filePid.toString());
+        request.setPidString(filePid.toString());
         request.setAction(action);
         return ProcessorTestHelper.mockExchange(ThumbnailRequestSerializationHelper.toJson(request));
     }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/thumbnails/ThumbnailRouterTest.java
@@ -38,7 +38,7 @@ public class ThumbnailRouterTest extends CamelSpringTestSupport {
 
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePidString(pid.toString());
+        request.setPidString(pid.toString());
         var body = ThumbnailRequestSerializationHelper.toJson(request);
         template.sendBody(body);
 

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailController.java
@@ -112,11 +112,11 @@ public class ThumbnailController {
         var agent = AgentPrincipalsImpl.createFromThread();
         var request = new ThumbnailRequest();
         request.setAgent(agent);
-        request.setFilePidString(pidString);
+        request.setPidString(pidString);
         try {
             thumbnailRequestSender.sendToQueue(request);
         } catch (IOException e) {
-            log.error("Error assigning file {} as thumbnail", request.getFilePidString(), e);
+            log.error("Error assigning file {} as thumbnail", request.getPidString(), e);
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
         return new ResponseEntity<>(HttpStatus.OK);

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 
@@ -116,94 +117,137 @@ public class ThumbnailIT extends AbstractAPIIT {
         closeable.close();
     }
 
+//    @Test
+//    public void addEditThumbnail() throws Exception {
+//        FileInputStream input = new FileInputStream("src/test/resources/upload-files/burndown.png");
+//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "burndown.png", "image/png", IOUtils.toByteArray(input));
+//
+//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+//                .file(thumbnailFile))
+//                .andExpect(status().is2xxSuccessful())
+//                .andReturn();
+//
+//        verify(messageSender).sendMessage(docCaptor.capture());
+//        Document msgDoc = docCaptor.getValue();
+//        assertMessageValues(msgDoc, collection.getPid());
+//    }
+//
+//    @Test
+//    public void addCollectionThumbWrongFileType() throws Exception {
+//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
+//
+//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+//                .file(thumbnailFile))
+//                .andExpect(status().is4xxClientError())
+//                .andReturn();
+//
+//        verify(messageSender, never()).sendMessage(any(Document.class));
+//    }
+//
+//    @Test
+//    public void addCollectionThumbNoAccess() throws Exception {
+//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
+//
+//        doThrow(new AccessRestrictionException()).when(aclService)
+//                .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
+//
+//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+//                .file(thumbnailFile))
+//                .andExpect(status().isForbidden())
+//                .andReturn();
+//
+//        verify(messageSender, never()).sendMessage(any(Document.class));
+//    }
+//
+//    @Test
+//    public void assignThumbnailSuccess() throws Exception {
+//        var pid = makePid();
+//        var filePidString = pid.getId();
+//        var file = repositoryObjectFactory.createFileObject(pid, null);
+//        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
+//
+//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+//                .andExpect(status().is2xxSuccessful())
+//                .andReturn();
+//
+//        verify(thumbnailRequestSender).sendToQueue(requestCaptor.capture());
+//        ThumbnailRequest request = requestCaptor.getValue();
+//        assertEquals(filePidString, request.getFilePidString());
+//    }
+//
+//    @Test
+//    public void assignThumbnailNoAccess() throws Exception {
+//        var pid = makePid();
+//        var filePidString = pid.getId();
+//        doThrow(new AccessRestrictionException()).when(aclService)
+//                .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
+//
+//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+//                .andExpect(status().isForbidden())
+//                .andReturn();
+//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+//    }
+//
+//    @Test
+//    public void assignThumbnailInvalidPidString() throws Exception {
+//        var badPidString = "NotAPid";
+//        mvc.perform(put("/edit/assignThumbnail/" + badPidString))
+//                .andExpect(status().is4xxClientError())
+//                .andReturn();
+//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+//    }
+//
+//    @Test
+//    public void assignThumbnailPidIsNotAFile() throws Exception {
+//        var pid = makePid();
+//        var filePidString = pid.getId();
+//        var work = repositoryObjectFactory.createWorkObject(pid, null);
+//        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
+//
+//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+//                .andExpect(status().isBadRequest())
+//                .andReturn();
+//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+//    }
+
     @Test
-    public void addEditThumbnail() throws Exception {
-        FileInputStream input = new FileInputStream("src/test/resources/upload-files/burndown.png");
-        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "burndown.png", "image/png", IOUtils.toByteArray(input));
-
-        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-                .file(thumbnailFile))
-                .andExpect(status().is2xxSuccessful())
-                .andReturn();
-
-        verify(messageSender).sendMessage(docCaptor.capture());
-        Document msgDoc = docCaptor.getValue();
-        assertMessageValues(msgDoc, collection.getPid());
-    }
-
-    @Test
-    public void addCollectionThumbWrongFileType() throws Exception {
-        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
-
-        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-                .file(thumbnailFile))
-                .andExpect(status().is4xxClientError())
-                .andReturn();
-
-        verify(messageSender, never()).sendMessage(any(Document.class));
-    }
-
-    @Test
-    public void addCollectionThumbNoAccess() throws Exception {
-        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
-
-        doThrow(new AccessRestrictionException()).when(aclService)
-                .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
-
-        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-                .file(thumbnailFile))
-                .andExpect(status().isForbidden())
-                .andReturn();
-
-        verify(messageSender, never()).sendMessage(any(Document.class));
-    }
-
-    @Test
-    public void assignThumbnailSuccess() throws Exception {
+    public void deleteThumbnailSuccess() throws Exception {
         var pid = makePid();
-        var filePidString = pid.getId();
-        var file = repositoryObjectFactory.createFileObject(pid, null);
-        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
-
-        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+        var workPidString = pid.getId();
+        var work = repositoryObjectFactory.createWorkObject(pid, null);
+        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
+        mvc.perform(put("/edit/deleteThumbnail/" + workPidString))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
         verify(thumbnailRequestSender).sendToQueue(requestCaptor.capture());
         ThumbnailRequest request = requestCaptor.getValue();
-        assertEquals(filePidString, request.getFilePidString());
+        assertEquals(workPidString, request.getPidString());
     }
 
     @Test
-    public void assignThumbnailNoAccess() throws Exception {
+    public void deleteThumbnailNoAccess() throws Exception {
         var pid = makePid();
-        var filePidString = pid.getId();
+        var workPidString = pid.getId();
+        var work = repositoryObjectFactory.createWorkObject(pid, null);
+        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
 
-        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
-                .andExpect(status().isForbidden())
+        mvc.perform(put("/edit/deleteThumbnail/" + workPidString))
+                .andExpect(status().is2xxSuccessful())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
     }
 
     @Test
-    public void assignThumbnailInvalidPidString() throws Exception {
-        var badPidString = "NotAPid";
-        mvc.perform(put("/edit/assignThumbnail/" + badPidString))
-                .andExpect(status().is4xxClientError())
-                .andReturn();
-        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
-    }
-
-    @Test
-    public void assignThumbnailPidIsNotAFile() throws Exception {
+    public void deleteThumbnailPidIsNotAWork() throws Exception {
         var pid = makePid();
         var filePidString = pid.getId();
-        var work = repositoryObjectFactory.createWorkObject(pid, null);
-        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
+        var file = repositoryObjectFactory.createFileObject(pid, null);
+        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
 
-        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+        mvc.perform(put("/edit/deleteThumbnail/" + filePidString))
                 .andExpect(status().isBadRequest())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ThumbnailIT.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -117,98 +118,98 @@ public class ThumbnailIT extends AbstractAPIIT {
         closeable.close();
     }
 
-//    @Test
-//    public void addEditThumbnail() throws Exception {
-//        FileInputStream input = new FileInputStream("src/test/resources/upload-files/burndown.png");
-//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "burndown.png", "image/png", IOUtils.toByteArray(input));
-//
-//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-//                .file(thumbnailFile))
-//                .andExpect(status().is2xxSuccessful())
-//                .andReturn();
-//
-//        verify(messageSender).sendMessage(docCaptor.capture());
-//        Document msgDoc = docCaptor.getValue();
-//        assertMessageValues(msgDoc, collection.getPid());
-//    }
-//
-//    @Test
-//    public void addCollectionThumbWrongFileType() throws Exception {
-//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
-//
-//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-//                .file(thumbnailFile))
-//                .andExpect(status().is4xxClientError())
-//                .andReturn();
-//
-//        verify(messageSender, never()).sendMessage(any(Document.class));
-//    }
-//
-//    @Test
-//    public void addCollectionThumbNoAccess() throws Exception {
-//        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
-//
-//        doThrow(new AccessRestrictionException()).when(aclService)
-//                .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
-//
-//        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
-//                .file(thumbnailFile))
-//                .andExpect(status().isForbidden())
-//                .andReturn();
-//
-//        verify(messageSender, never()).sendMessage(any(Document.class));
-//    }
-//
-//    @Test
-//    public void assignThumbnailSuccess() throws Exception {
-//        var pid = makePid();
-//        var filePidString = pid.getId();
-//        var file = repositoryObjectFactory.createFileObject(pid, null);
-//        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
-//
-//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
-//                .andExpect(status().is2xxSuccessful())
-//                .andReturn();
-//
-//        verify(thumbnailRequestSender).sendToQueue(requestCaptor.capture());
-//        ThumbnailRequest request = requestCaptor.getValue();
-//        assertEquals(filePidString, request.getFilePidString());
-//    }
-//
-//    @Test
-//    public void assignThumbnailNoAccess() throws Exception {
-//        var pid = makePid();
-//        var filePidString = pid.getId();
-//        doThrow(new AccessRestrictionException()).when(aclService)
-//                .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
-//
-//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
-//                .andExpect(status().isForbidden())
-//                .andReturn();
-//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
-//    }
-//
-//    @Test
-//    public void assignThumbnailInvalidPidString() throws Exception {
-//        var badPidString = "NotAPid";
-//        mvc.perform(put("/edit/assignThumbnail/" + badPidString))
-//                .andExpect(status().is4xxClientError())
-//                .andReturn();
-//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
-//    }
-//
-//    @Test
-//    public void assignThumbnailPidIsNotAFile() throws Exception {
-//        var pid = makePid();
-//        var filePidString = pid.getId();
-//        var work = repositoryObjectFactory.createWorkObject(pid, null);
-//        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
-//
-//        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
-//                .andExpect(status().isBadRequest())
-//                .andReturn();
-//        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
-//    }
+    @Test
+    public void addEditThumbnail() throws Exception {
+        FileInputStream input = new FileInputStream("src/test/resources/upload-files/burndown.png");
+        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "burndown.png", "image/png", IOUtils.toByteArray(input));
+
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+                .file(thumbnailFile))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        verify(messageSender).sendMessage(docCaptor.capture());
+        Document msgDoc = docCaptor.getValue();
+        assertMessageValues(msgDoc, collection.getPid());
+    }
+
+    @Test
+    public void addCollectionThumbWrongFileType() throws Exception {
+        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
+
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+                .file(thumbnailFile))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+
+        verify(messageSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void addCollectionThumbNoAccess() throws Exception {
+        MockMultipartFile thumbnailFile = new MockMultipartFile("file", "file.txt", "plain/text", textStream());
+
+        doThrow(new AccessRestrictionException()).when(aclService)
+                .assertHasAccess(anyString(), eq(collection.getPid()), any(AccessGroupSetImpl.class), eq(editDescription));
+
+        mvc.perform(MockMvcRequestBuilders.multipart("/edit/displayThumbnail/" + collection.getPid().getUUID())
+                .file(thumbnailFile))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(messageSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void assignThumbnailSuccess() throws Exception {
+        var pid = makePid();
+        var filePidString = pid.getId();
+        var file = repositoryObjectFactory.createFileObject(pid, null);
+        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
+
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        verify(thumbnailRequestSender).sendToQueue(requestCaptor.capture());
+        ThumbnailRequest request = requestCaptor.getValue();
+        assertEquals(filePidString, request.getPidString());
+    }
+
+    @Test
+    public void assignThumbnailNoAccess() throws Exception {
+        var pid = makePid();
+        var filePidString = pid.getId();
+        doThrow(new AccessRestrictionException()).when(aclService)
+                .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
+
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+                .andExpect(status().isForbidden())
+                .andReturn();
+        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void assignThumbnailInvalidPidString() throws Exception {
+        var badPidString = "NotAPid";
+        mvc.perform(put("/edit/assignThumbnail/" + badPidString))
+                .andExpect(status().is4xxClientError())
+                .andReturn();
+        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+    }
+
+    @Test
+    public void assignThumbnailPidIsNotAFile() throws Exception {
+        var pid = makePid();
+        var filePidString = pid.getId();
+        var work = repositoryObjectFactory.createWorkObject(pid, null);
+        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
+
+        mvc.perform(put("/edit/assignThumbnail/" + filePidString))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+        verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
+    }
 
     @Test
     public void deleteThumbnailSuccess() throws Exception {
@@ -216,7 +217,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         var workPidString = pid.getId();
         var work = repositoryObjectFactory.createWorkObject(pid, null);
         when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
-        mvc.perform(put("/edit/deleteThumbnail/" + workPidString))
+        mvc.perform(delete("/edit/deleteThumbnail/" + workPidString))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
@@ -229,13 +230,12 @@ public class ThumbnailIT extends AbstractAPIIT {
     public void deleteThumbnailNoAccess() throws Exception {
         var pid = makePid();
         var workPidString = pid.getId();
-        var work = repositoryObjectFactory.createWorkObject(pid, null);
-        when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(work);
+
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(pid), any(AccessGroupSetImpl.class), eq(editDescription));
 
-        mvc.perform(put("/edit/deleteThumbnail/" + workPidString))
-                .andExpect(status().is2xxSuccessful())
+        mvc.perform(delete("/edit/deleteThumbnail/" + workPidString))
+                .andExpect(status().isForbidden())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));
     }
@@ -247,7 +247,7 @@ public class ThumbnailIT extends AbstractAPIIT {
         var file = repositoryObjectFactory.createFileObject(pid, null);
         when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(file);
 
-        mvc.perform(put("/edit/deleteThumbnail/" + filePidString))
+        mvc.perform(delete("/edit/deleteThumbnail/" + filePidString))
                 .andExpect(status().isBadRequest())
                 .andReturn();
         verify(thumbnailRequestSender, never()).sendMessage(any(Document.class));


### PR DESCRIPTION
This PR adds a controller endpoint to delete the assigned thumbnail for a work, along with some tests. I also made the Request object more flexible by letting it accept a general PID instead of a File PID.

https://unclibrary.atlassian.net/browse/BXC-4063