### PR TITLE
BXC-4290 replace deprecated MockitoAnnotations.initMocks

### DIFF
--- a/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/ContentObjectAccessRestrictionValidatorTest.java
+++ b/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/ContentObjectAccessRestrictionValidatorTest.java
@@ -4,7 +4,7 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_P
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Calendar;
 
@@ -12,6 +12,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ public class ContentObjectAccessRestrictionValidatorTest {
             "http://example.com/rest/content/99/9a/01/a2/999a01a2-c836-499a-a72e-57f1039f4f45";
 
     private ContentObjectAccessRestrictionValidator validator;
+    private AutoCloseable closeable;
 
     @Mock
     private PID pid;
@@ -45,13 +47,18 @@ public class ContentObjectAccessRestrictionValidatorTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         validator = new ContentObjectAccessRestrictionValidator();
         when(pid.getURI()).thenReturn(PID_URI);
 
         model = ModelFactory.createDefaultModel();
         resc = model.getResource(PID_URI);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/GlobalPermissionEvaluatorTest.java
+++ b/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/GlobalPermissionEvaluatorTest.java
@@ -2,7 +2,7 @@ package edu.unc.lib.boxc.auth.fcrepo.services;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,13 +31,20 @@ public class GlobalPermissionEvaluatorTest {
 
     private GlobalPermissionEvaluator evaluator;
 
+    private AutoCloseable closeable;
+
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         configProperties = new Properties();
 
         principals = new HashSet<>(Arrays.asList(PRINC_GRP1));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/InheritedAclFactoryTest.java
+++ b/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/InheritedAclFactoryTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -49,6 +50,8 @@ public class InheritedAclFactoryTest {
     private static final String OWNER_PRINC = "owner";
     private static final String PATRON_GROUP = PATRON_NAMESPACE + "special";
 
+    private AutoCloseable closeable;
+
     @Mock
     private ContentPathFactory pathFactory;
 
@@ -63,7 +66,7 @@ public class InheritedAclFactoryTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         aclFactory = new InheritedAclFactory();
         aclFactory.setObjectAclFactory(objectAclFactory);
@@ -75,6 +78,11 @@ public class InheritedAclFactoryTest {
         when(pathFactory.getAncestorPids(any(PID.class))).thenReturn(ancestorPids);
 
         pid = PIDs.get(UUID.randomUUID().toString());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/InheritedPermissionEvaluatorTest.java
+++ b/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/InheritedPermissionEvaluatorTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,8 @@ public class InheritedPermissionEvaluatorTest {
     private static final Set<String> PATRON_GROUP_PRINCIPLES = new HashSet<>(
             asList(PUBLIC_PRINC, PATRON_GROUP));
 
+    private AutoCloseable closeable;
+
     @Mock
     private ContentPathFactory pathFactory;
 
@@ -71,7 +74,7 @@ public class InheritedPermissionEvaluatorTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         evaluator = new InheritedPermissionEvaluator();
         evaluator.setPathFactory(pathFactory);
@@ -83,6 +86,11 @@ public class InheritedPermissionEvaluatorTest {
         when(pathFactory.getAncestorPids(any(PID.class))).thenReturn(ancestorPids);
 
         pid = PIDs.get(UUID.randomUUID().toString());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/ObjectACLFactoryTest.java
+++ b/auth-fcrepo/src/test/java/edu/unc/lib/boxc/auth/fcrepo/services/ObjectACLFactoryTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
@@ -29,6 +29,7 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,6 +60,7 @@ public class ObjectACLFactoryTest {
     private static final LocalDateTime TOMORROW = LocalDateTime.now().plusDays(1);
 
     private ObjectAclFactory aclFactory;
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
@@ -71,7 +73,7 @@ public class ObjectACLFactoryTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         aclFactory = new ObjectAclFactory();
         aclFactory.setRepositoryObjectLoader(repositoryObjectLoader);
@@ -85,6 +87,11 @@ public class ObjectACLFactoryTest {
         objResc = objModel.getResource(pid.getRepositoryPath());
         when(repoObj.getModel()).thenReturn(objModel);
         when(repositoryObjectLoader.getRepositoryObject(pid)).thenReturn(repoObj);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/AbstractDepositJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/AbstractDepositJobTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -52,6 +52,8 @@ public class AbstractDepositJobTest {
     protected static final String FEDORA_BASE = "http://localhost:48085/rest/";
     protected static final String TX_URI = "http://localhost:48085/rest/tx:99b58d30-06f5-477b-a44c-d614a9049d38";
 
+    private AutoCloseable closeable;
+
     @Mock
     protected RepositoryObjectDriver driver;
     @Mock
@@ -94,7 +96,7 @@ public class AbstractDepositJobTest {
 
     @BeforeEach
     public void initBase() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -144,7 +146,8 @@ public class AbstractDepositJobTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
+        closeable.close();
         depositModelManager.close();
     }
 

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/VerifyObjectsAreInFedoraServiceTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/VerifyObjectsAreInFedoraServiceTest.java
@@ -4,7 +4,7 @@ import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -19,11 +19,11 @@ import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 import org.fcrepo.client.HeadBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.deposit.validate.VerifyObjectsAreInFedoraService;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 
@@ -38,6 +38,7 @@ public class VerifyObjectsAreInFedoraServiceTest {
     private PID workPid;
     private PID filePid;
     private Collection<String> pids;
+    private AutoCloseable closeable;
     @Mock
     private FcrepoClient client;
     @Mock
@@ -52,13 +53,18 @@ public class VerifyObjectsAreInFedoraServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         verificationService = new VerifyObjectsAreInFedoraService();
         setField(verificationService, "fcrepoClient", client);
 
         workPid = makePid();
         filePid = makePid();
         pids = new HashSet<>();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/JobStatusFactoryTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/JobStatusFactoryTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -37,7 +37,7 @@ public class JobStatusFactoryTest {
 
     @BeforeEach
     public void setup() {
-        initMocks(this);
+        openMocks(this);
 
         when(jedisPool.getResource()).thenReturn(jedis);
 

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/CDRMETSDepositHandlerTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/CDRMETSDepositHandlerTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,8 @@ public class CDRMETSDepositHandlerTest {
     private static final String DEPOSITOR = "adminuser";
     private static final String DEPOSIT_METHOD = "unitTest";
 
+    private AutoCloseable closeable;
+
     @TempDir
     public Path tmpFolder;
 
@@ -74,7 +77,7 @@ public class CDRMETSDepositHandlerTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         Files.createDirectory(tmpFolder.resolve("deposits"));
         depositsDir = tmpFolder.resolve("deposits").toFile();
@@ -91,6 +94,11 @@ public class CDRMETSDepositHandlerTest {
         depositHandler.setDepositsDirectory(depositsDir);
         depositHandler.setPidMinter(pidMinter);
         depositHandler.setDepositStatusFactory(depositStatusFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/DepositSubmissionServiceTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/DepositSubmissionServiceTest.java
@@ -1,13 +1,14 @@
 package edu.unc.lib.boxc.deposit.impl.submit;
 
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,8 @@ public class DepositSubmissionServiceTest {
     private static final String DEPOSIT_METHOD = "unitTest";
     private static final Path FILEPATH = Paths.get(FILENAME);
 
+    private AutoCloseable closeable;
+
     @Mock
     private AccessControlService aclService;
 
@@ -53,7 +56,7 @@ public class DepositSubmissionServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         packageHandlers = new HashMap<>();
         packageHandlers.put(PackagingType.SIMPLE_OBJECT, depositHandler1);
@@ -62,6 +65,11 @@ public class DepositSubmissionServiceTest {
         depositService = new DepositSubmissionService();
         depositService.setPackageHandlers(packageHandlers);
         depositService.setAclService(aclService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/FileServerDepositHandlerTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/FileServerDepositHandlerTest.java
@@ -8,13 +8,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -32,7 +33,6 @@ import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositState;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.Priority;
 import edu.unc.lib.boxc.deposit.api.submit.DepositData;
 import edu.unc.lib.boxc.deposit.impl.model.DepositStatusFactory;
-import edu.unc.lib.boxc.deposit.impl.submit.FileServerDepositHandler;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.ids.PIDMinter;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
@@ -43,6 +43,8 @@ public class FileServerDepositHandlerTest {
     private static final String DEPOSITOR = "adminuser";
     private static final String DEPOSIT_METHOD = "unitTest";
     private static final String DEPOSITOR_EMAIL = "adminuser@example.com";
+
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -65,7 +67,7 @@ public class FileServerDepositHandlerTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         sourcePath = tmpFolder.resolve("source");
         Files.createDirectory(sourcePath);
@@ -81,6 +83,11 @@ public class FileServerDepositHandlerTest {
         depositHandler = new FileServerDepositHandler();
         depositHandler.setPidMinter(pidMinter);
         depositHandler.setDepositStatusFactory(depositStatusFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/SimpleObjectDepositHandlerTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/submit/SimpleObjectDepositHandlerTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,8 @@ public class SimpleObjectDepositHandlerTest {
     private static final String FILE_CONTENT = "Simply content";
     private static final String DEPOSIT_METHOD = "unitTest";
 
+    private AutoCloseable closeable;
+
     @TempDir
     public Path tmpFolder;
 
@@ -76,7 +79,7 @@ public class SimpleObjectDepositHandlerTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         depositsDir = tmpFolder.resolve("deposits").toFile();
         Files.createDirectory(tmpFolder.resolve("deposits"));
@@ -93,6 +96,11 @@ public class SimpleObjectDepositHandlerTest {
         depositHandler.setDepositsDirectory(depositsDir);
         depositHandler.setPidMinter(pidMinter);
         depositHandler.setDepositStatusFactory(depositStatusFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/fcrepo-utils/src/test/java/edu/unc/lib/boxc/fcrepo/utils/FedoraTransactionRefresherTest.java
+++ b/fcrepo-utils/src/test/java/edu/unc/lib/boxc/fcrepo/utils/FedoraTransactionRefresherTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 
@@ -16,14 +16,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.fcrepo.utils.FedoraTransaction;
-import edu.unc.lib.boxc.fcrepo.utils.FedoraTransactionRefresher;
-import edu.unc.lib.boxc.fcrepo.utils.TransactionManager;
-
 /**
  * @author bbpennel
  */
 public class FedoraTransactionRefresherTest {
+    private AutoCloseable closeable;
 
     @Mock
     private TransactionManager txManager;
@@ -37,7 +34,7 @@ public class FedoraTransactionRefresherTest {
 
     @BeforeEach
     public void setup() {
-        initMocks(this);
+        closeable = openMocks(this);
         txUri = URI.create("http://example.com/tx");
 
         when(tx.getTransactionManager()).thenReturn(txManager);
@@ -45,7 +42,8 @@ public class FedoraTransactionRefresherTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    public void cleanup() throws Exception {
+        closeable.close();
         FedoraTransactionRefresher.setMaxTimeToLive(originalMaxTimeToLive);
         FedoraTransactionRefresher.setRefreshInterval(originalRefreshInterval);
     }

--- a/fcrepo-utils/src/test/java/edu/unc/lib/boxc/fcrepo/utils/TransactionalFcrepoClientTest.java
+++ b/fcrepo-utils/src/test/java/edu/unc/lib/boxc/fcrepo/utils/TransactionalFcrepoClientTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 
@@ -18,14 +19,11 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.fcrepo.client.FcrepoClient.FcrepoClientBuilder;
 import org.fcrepo.client.FcrepoResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
-import edu.unc.lib.boxc.fcrepo.utils.FedoraTransaction;
-import edu.unc.lib.boxc.fcrepo.utils.TransactionManager;
-import edu.unc.lib.boxc.fcrepo.utils.TransactionalFcrepoClient;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
 
 /**
@@ -44,6 +42,7 @@ public class TransactionalFcrepoClientTest {
     private TransactionalFcrepoClient txClient;
     private FedoraTransaction tx;
     private TransactionManager txManager;
+    private AutoCloseable closeable;
 
     @Mock
     private HttpRequestBase request;
@@ -60,7 +59,7 @@ public class TransactionalFcrepoClientTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         URI uri = URI.create(TX_URI);
         FcrepoClientBuilder builder = TransactionalFcrepoClient.client(BASE_URI);
         txClient = (TransactionalFcrepoClient) builder.build();
@@ -79,6 +78,11 @@ public class TransactionalFcrepoClientTest {
             .thenReturn(REQUEST_URI);
         when(httpResponse.getAllHeaders()).thenReturn(new Header[]{header});
         when(request.getMethod()).thenReturn("GET");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/DeleteSolrTreeTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/DeleteSolrTreeTest.java
@@ -1,7 +1,7 @@
 package edu.unc.lib.boxc.indexing.solr.action;
 
 import static edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType.DELETE_SOLR_TREE;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -9,6 +9,7 @@ import java.util.Properties;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -16,7 +17,6 @@ import org.mockito.Mock;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.common.test.TestHelpers;
 import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
-import edu.unc.lib.boxc.indexing.solr.action.DeleteSolrTreeAction;
 import edu.unc.lib.boxc.indexing.solr.test.TestCorpus;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.search.solr.config.SearchSettings;
@@ -33,6 +33,7 @@ import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
 public class DeleteSolrTreeTest extends BaseEmbeddedSolrTest {
 
     protected TestCorpus corpus;
+    private AutoCloseable closeable;
 
     @Mock
     private AccessRestrictionUtil restrictionUtil;
@@ -48,7 +49,7 @@ public class DeleteSolrTreeTest extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void setup() throws SolrServerException, IOException {
-        initMocks(this);
+        closeable = openMocks(this);
 
         corpus = new TestCorpus();
 
@@ -78,6 +79,11 @@ public class DeleteSolrTreeTest extends BaseEmbeddedSolrTest {
 
         server.add(corpus.populate());
         server.commit();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/IndexTreeCleanActionTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/IndexTreeCleanActionTest.java
@@ -6,12 +6,13 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.UUID;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -19,9 +20,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
-import edu.unc.lib.boxc.indexing.solr.action.DeleteSolrTreeAction;
-import edu.unc.lib.boxc.indexing.solr.action.IndexTreeCleanAction;
-import edu.unc.lib.boxc.indexing.solr.action.RecursiveTreeIndexer;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline;
 import edu.unc.lib.boxc.indexing.solr.indexing.SolrUpdateDriver;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -36,6 +34,8 @@ import edu.unc.lib.boxc.model.api.objects.ContentContainerObject;
  */
 public class IndexTreeCleanActionTest {
     private static final String USER = "user";
+
+    private AutoCloseable closeable;
 
     @Mock
     private SolrUpdateDriver driver;
@@ -64,7 +64,7 @@ public class IndexTreeCleanActionTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
         when(request.getPid()).thenReturn(pid);
@@ -83,6 +83,11 @@ public class IndexTreeCleanActionTest {
         when(containerObj.getPid()).thenReturn(pid);
         Model model = ModelFactory.createDefaultModel();
         when(containerObj.getResource()).thenReturn(model.getResource(pid.getRepositoryPath()));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/RecursiveTreeIndexerTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/RecursiveTreeIndexerTest.java
@@ -10,19 +10,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.indexing.solr.action.RecursiveTreeIndexer;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.sparql.SparqlQueryService;
@@ -42,6 +42,7 @@ public class RecursiveTreeIndexerTest {
     private static final String USER = "user";
 
     private RecursiveTreeIndexer indexer;
+    private AutoCloseable closeable;
 
     @Mock
     private ContentContainerObject containerObj;
@@ -60,7 +61,7 @@ public class RecursiveTreeIndexerTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         containerObj = makeContainer(makePid(), repositoryObjectLoader);
 
@@ -72,6 +73,11 @@ public class RecursiveTreeIndexerTest {
         indexer = new RecursiveTreeIndexer();
         indexer.setIndexingMessageSender(messageSender);
         indexer.setSparqlQueryService(sparqlQueryService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/UpdateTreeActionTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/UpdateTreeActionTest.java
@@ -11,12 +11,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -24,8 +25,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
-import edu.unc.lib.boxc.indexing.solr.action.RecursiveTreeIndexer;
-import edu.unc.lib.boxc.indexing.solr.action.UpdateTreeAction;
 import edu.unc.lib.boxc.indexing.solr.test.TestCorpus;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
@@ -46,6 +45,7 @@ public class UpdateTreeActionTest {
     protected static final String USER = "user";
 
     protected TestCorpus corpus;
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
@@ -65,7 +65,7 @@ public class UpdateTreeActionTest {
 
     @BeforeEach
     public void setupTreeAction() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         corpus = new TestCorpus();
 
@@ -93,6 +93,11 @@ public class UpdateTreeActionTest {
 
     protected UpdateTreeAction getAction() {
         return new UpdateTreeAction();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/UpdateTreeSetActionTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/UpdateTreeSetActionTest.java
@@ -8,12 +8,13 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,8 +24,6 @@ import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.ChildSetRequest;
 import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
-import edu.unc.lib.boxc.indexing.solr.action.RecursiveTreeIndexer;
-import edu.unc.lib.boxc.indexing.solr.action.UpdateTreeSetAction;
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
@@ -42,6 +41,8 @@ import edu.unc.lib.boxc.model.api.objects.ContentObject;
  */
 public class UpdateTreeSetActionTest {
     private static final String USER = "user";
+
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
@@ -61,7 +62,7 @@ public class UpdateTreeSetActionTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         sparqlModel = ModelFactory.createDefaultModel();
         sparqlQueryService = new JenaSparqlQueryServiceImpl(sparqlModel);
@@ -74,6 +75,11 @@ public class UpdateTreeSetActionTest {
         action.setRepositoryObjectLoader(repositoryObjectLoader);
         action.setTreeIndexer(treeIndexer);
         action.setActionType(IndexingActionType.ADD.name());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetAccessControlFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetAccessControlFilterTest.java
@@ -12,11 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -28,7 +29,6 @@ import edu.unc.lib.boxc.model.api.objects.ContentRootObject;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.auth.api.AccessPrincipalConstants;
 import edu.unc.lib.boxc.auth.fcrepo.services.InheritedAclFactory;
-import edu.unc.lib.boxc.indexing.solr.filter.SetAccessControlFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.auth.api.UserRole;
 import edu.unc.lib.boxc.auth.api.models.RoleAssignment;
@@ -42,6 +42,7 @@ public class SetAccessControlFilterTest {
 
     private static final String PRINC1 = "group1";
     private static final String PRINC2 = "group2";
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackage dip;
@@ -60,13 +61,18 @@ public class SetAccessControlFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(dip.getDocument()).thenReturn(idb);
         when(dip.getPid()).thenReturn(pid);
 
         filter = new SetAccessControlFilter();
         filter.setAclFactory(aclFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetAccessStatusFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetAccessStatusFilterTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.Calendar;
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -38,7 +39,6 @@ import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.auth.api.AccessPrincipalConstants;
 import edu.unc.lib.boxc.auth.fcrepo.services.InheritedAclFactory;
 import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
-import edu.unc.lib.boxc.indexing.solr.filter.SetAccessStatusFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 
 /**
@@ -46,6 +46,7 @@ import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
  */
 public class SetAccessStatusFilterTest {
     private static final String CUSTOM_GROUP = AccessPrincipalConstants.IP_PRINC_NAMESPACE + "special";
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackage dip;
@@ -77,7 +78,7 @@ public class SetAccessStatusFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
         parentPid = PIDs.get(UUID.randomUUID().toString());
@@ -117,6 +118,11 @@ public class SetAccessStatusFilterTest {
         filter = new SetAccessStatusFilter();
         filter.setObjectAclFactory(objAclFactory);
         filter.setInheritedAclFactory(inheritedAclFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
@@ -5,19 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.indexing.solr.filter.SetContentStatusFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.rdf.Cdr;
@@ -31,6 +31,7 @@ import edu.unc.lib.boxc.model.api.objects.WorkObject;
  * @author harring
  */
 public class SetContentStatusFilterTest {
+    private AutoCloseable closeable;
     @Mock
     private DocumentIndexingPackage dip;
     @Mock
@@ -52,7 +53,7 @@ public class SetContentStatusFilterTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(dip.getDocument()).thenReturn(idb);
         when(dip.getPid()).thenReturn(pid);
@@ -60,8 +61,12 @@ public class SetContentStatusFilterTest {
         when(resc.hasProperty(any(Property.class))).thenReturn(false);
 
         when(fileObj.getParent()).thenReturn(workObj);
-
         filter = new SetContentStatusFilter();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -23,6 +23,7 @@ import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import org.apache.commons.collections.CollectionUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -46,7 +47,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  *
@@ -57,6 +58,7 @@ public class SetContentTypeFilterTest {
 
     private DocumentIndexingPackage dip;
     private PID pid;
+    private AutoCloseable closeable;
     @Mock
     private FileObject fileObj;
     @Mock
@@ -87,7 +89,7 @@ public class SetContentTypeFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
         dip = new DocumentIndexingPackage(pid, null, documentIndexingPackageDataLoader);
@@ -109,6 +111,11 @@ public class SetContentTypeFilterTest {
         filter.setSolrSearchService(solrSearchService);
         filter.setTechnicalMetadataService(technicalMetadataService);
         filter.setContentPathFactory(contentPathFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
@@ -10,7 +10,6 @@ import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.FolderObject;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.api.rdf.Ebucore;
 import edu.unc.lib.boxc.model.api.rdf.Premis;
@@ -23,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  *
@@ -89,6 +89,8 @@ public class SetDatastreamFilterTest {
     private static final String PREMIS_DIGEST = "urn:sha1:da39a3ee5e6b4b0d3255bfef95601890afd80709";
     private static final long PREMIS_SIZE = 893l;
 
+    private AutoCloseable closeable;
+
     @TempDir
     public Path derivDir;
 
@@ -113,7 +115,7 @@ public class SetDatastreamFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(PID_STRING);
 
@@ -133,6 +135,11 @@ public class SetDatastreamFilterTest {
 
         when(binObj.getResource()).thenReturn(
                 fileResource(ORIGINAL_FILE.getId(), FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDescriptiveMetadataFilterTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,6 +22,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -44,6 +45,8 @@ import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
  */
 public class SetDescriptiveMetadataFilterTest {
     private static final String PID_STRING = "uuid:07d9594f-310d-4095-ab67-79a1056e7430";
+
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackageDataLoader loader;
@@ -74,7 +77,7 @@ public class SetDescriptiveMetadataFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(pid.getId()).thenReturn(PID_STRING);
 
@@ -89,6 +92,11 @@ public class SetDescriptiveMetadataFilterTest {
 
         filter = new SetDescriptiveMetadataFilter();
         filter.setTitleRetrievalService(titleRetrievalService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetFullTextFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetFullTextFilterTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -13,12 +13,12 @@ import java.nio.file.Path;
 import java.util.UUID;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.indexing.solr.filter.SetFullTextFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageFactory;
@@ -34,6 +34,7 @@ import edu.unc.lib.boxc.model.fcrepo.services.DerivativeService;
  * @author harring
  */
 public class SetFullTextFilterTest {
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tempDir;
@@ -60,7 +61,7 @@ public class SetFullTextFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         derivativeDir = tempDir.resolve("testFolder").toFile();
         Files.createDirectory(tempDir.resolve("testFolder"));
@@ -79,6 +80,11 @@ public class SetFullTextFilterTest {
 
         filter = new SetFullTextFilter();
         filter.setDerivativeService(derivativeService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetMemberOrderFilterTest.java
@@ -7,6 +7,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -15,13 +16,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
  */
 public class SetMemberOrderFilterTest {
     private static final String SUBJECT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+
+    private AutoCloseable closeable;
 
     @Mock
     private MemberOrderService memberOrderService;
@@ -35,13 +38,18 @@ public class SetMemberOrderFilterTest {
 
     @BeforeEach
     public void setup() {
-        initMocks(this);
+        closeable = openMocks(this);
         subjectPid = PIDs.get(SUBJECT_UUID);
         dip = new DocumentIndexingPackage(subjectPid, null, documentIndexingPackageDataLoader);
         dip.setPid(subjectPid);
         idb = dip.getDocument();
         filter = new SetMemberOrderFilter();
         filter.setMemberOrderService(memberOrderService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetObjectTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetObjectTypeFilterTest.java
@@ -3,18 +3,18 @@ package edu.unc.lib.boxc.indexing.solr.filter;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.filter.SetObjectTypeFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -31,6 +31,7 @@ import edu.unc.lib.boxc.model.api.objects.ContentObject;
 public class SetObjectTypeFilterTest {
 
     private SetObjectTypeFilter filter;
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackage dip;
@@ -44,7 +45,7 @@ public class SetObjectTypeFilterTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(dip.getDocument()).thenReturn(idb);
         when(dip.getPid()).thenReturn(pid);
@@ -52,6 +53,11 @@ public class SetObjectTypeFilterTest {
         when(dip.getContentObject()).thenReturn(contentObj);
 
         filter = new SetObjectTypeFilter();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetPathFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetPathFilterTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +18,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.boxc.search.solr.services.TitleRetrievalService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.filter.SetPathFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.boxc.model.api.ResourceType;
@@ -47,6 +47,8 @@ import edu.unc.lib.boxc.model.api.objects.FileObject;
 public class SetPathFilterTest {
     private final static String UNIT_TITLE = "Administration of Boxy";
     private final static String COLLECTION_TITLE = "Collection of Boxes";
+
+    private AutoCloseable closeable;
 
     @Mock
     private ContentPathFactory pathFactory;
@@ -74,7 +76,7 @@ public class SetPathFilterTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
 
@@ -86,6 +88,11 @@ public class SetPathFilterTest {
         filter = new SetPathFilter();
         filter.setPathFactory(pathFactory);
         filter.setTitleRetrievalService(titleRetrievalService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetRecordDatesFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetRecordDatesFilterTest.java
@@ -3,20 +3,20 @@ package edu.unc.lib.boxc.indexing.solr.filter;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.text.SimpleDateFormat;
 
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.filter.SetRecordDatesFilter;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -32,6 +32,8 @@ public class SetRecordDatesFilterTest {
     private static final String DATE_ADDED = "2017-01-01";
     private static final String DATE_MODIFIED = "2017-05-31";
     private static final String BAD_DATE = "abcd";
+
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackageDataLoader loader;
@@ -62,7 +64,7 @@ public class SetRecordDatesFilterTest {
     @BeforeEach
     public void setup() throws Exception {
         idb = new IndexDocumentBean();
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(dip.getDocument()).thenReturn(idb);
         when(dip.getPid()).thenReturn(pid);
@@ -82,6 +84,11 @@ public class SetRecordDatesFilterTest {
         when(object2.toString()).thenReturn(DATE_MODIFIED);
 
         filter = new SetRecordDatesFilter();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPackageDataLoaderTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPackageDataLoaderTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -15,13 +15,11 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
-import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
@@ -35,6 +33,7 @@ import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectLoaderImpl;
 public class DocumentIndexingPackageDataLoaderTest {
 
     private DocumentIndexingPackageDataLoader dataLoader;
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectLoaderImpl repoObjLoader;
@@ -50,12 +49,17 @@ public class DocumentIndexingPackageDataLoaderTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         dataLoader = new DocumentIndexingPackageDataLoader();
         dataLoader.setRepositoryObjectLoader(repoObjLoader);
 
         when(dip.getPid()).thenReturn(pid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPipelineTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/DocumentIndexingPipelineTest.java
@@ -2,11 +2,12 @@ package edu.unc.lib.boxc.indexing.solr.indexing;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,8 +15,6 @@ import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
 import edu.unc.lib.boxc.indexing.solr.filter.IndexDocumentFilter;
-import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
-import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline;
 
 /**
  *
@@ -25,6 +24,7 @@ import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPipeline;
 public class DocumentIndexingPipelineTest extends Assertions {
 
     private DocumentIndexingPipeline pipeline;
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackage dip;
@@ -37,12 +37,17 @@ public class DocumentIndexingPipelineTest extends Assertions {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         filters = Arrays.asList(mockFilter1, mockFilter2);
 
         pipeline = new DocumentIndexingPipeline();
         pipeline.setFilters(filters);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/SolrUpdateDriverTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/indexing/SolrUpdateDriverTest.java
@@ -3,20 +3,20 @@ package edu.unc.lib.boxc.indexing.solr.indexing;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
-import edu.unc.lib.boxc.indexing.solr.indexing.SolrUpdateDriver;
 import edu.unc.lib.boxc.search.solr.config.SolrSettings;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 
@@ -26,6 +26,8 @@ import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
  *
  */
 public class SolrUpdateDriverTest {
+    private AutoCloseable closeable;
+
     @Mock
     private SolrClient solrClient;
     @Mock
@@ -54,7 +56,7 @@ public class SolrUpdateDriverTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         driver = new SolrUpdateDriver();
         driver.setUpdateSolrClient(updateSolrClient);
@@ -62,6 +64,11 @@ public class SolrUpdateDriverTest {
         driver.setSolrSettings(solrSettings);
 
         when(solrSettings.getRequiredFields()).thenReturn(REQUIRED_INDEXING_FIELDS);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/utils/MemberOrderServiceTest.java
@@ -7,15 +7,12 @@ import edu.unc.lib.boxc.model.api.objects.ContentRootObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.FolderObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -25,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -36,11 +34,18 @@ public class MemberOrderServiceTest {
 
     private MemberOrderService memberOrderService;
 
+    private AutoCloseable closeable;
+
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         memberOrderService = new MemberOrderService();
         memberOrderService.init();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/fcrepo/FedoraTransactionIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/fcrepo/FedoraTransactionIT.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.IOException;
 
@@ -16,6 +16,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,18 +38,23 @@ import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
  *
  */
 public class FedoraTransactionIT extends AbstractFedoraIT {
-
+    private AutoCloseable closeable;
     private Model model;
     @Mock
     private BinaryTransferService binaryTransferService;
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
         txManager.setBinaryTransferService(binaryTransferService);
         model = ModelFactory.createDefaultModel();
         Resource resc = model.createResource("");
         resc.addProperty(DcElements.title, "Folder Title");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/model/fcrepo/event/RepositoryPremisLoggerIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/model/fcrepo/event/RepositoryPremisLoggerIT.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -32,6 +32,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -72,6 +73,8 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
 
     private Map<PID, String> previousDigestMap;
 
+    private AutoCloseable closeable;
+
     @Mock
     private BinaryTransferService transferService;
     @Mock
@@ -81,7 +84,7 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         lockManager = PidLockManager.getDefaultPidLockManager();
 
@@ -108,6 +111,11 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
                 });
 
         previousDigestMap = new HashMap<>();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private void initPremisLogger(RepositoryObject repoObj) {

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/AbstractFedoraObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/AbstractFedoraObjectTest.java
@@ -1,7 +1,8 @@
 package edu.unc.lib.boxc.model.fcrepo.objects;
 
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mock;
 
@@ -20,6 +21,8 @@ public class AbstractFedoraObjectTest {
 
     protected static final String FEDORA_BASE = "http://example.com/";
 
+    private AutoCloseable closeable;
+
     @Mock
     protected RepositoryObjectDriver driver;
     @Mock
@@ -31,9 +34,13 @@ public class AbstractFedoraObjectTest {
 
     @BeforeEach
     public void initBase() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pidMinter = new RepositoryPIDMinter();
     }
 
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
 }

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/AdminUnitTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/AdminUnitTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,8 @@ public class AdminUnitTest extends AbstractFedoraObjectTest {
 
     private PID collectionChildPid;
 
+    private AutoCloseable closeable;
+
     @Mock
     private CollectionObject collectionChildObj;
     @Mock
@@ -47,7 +50,7 @@ public class AdminUnitTest extends AbstractFedoraObjectTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
 
@@ -55,7 +58,11 @@ public class AdminUnitTest extends AbstractFedoraObjectTest {
 
         collectionChildPid = PIDs.get(UUID.randomUUID().toString());
         when(collectionChildObj.getPid()).thenReturn(collectionChildPid);
+    }
 
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/BinaryObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/BinaryObjectTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -15,11 +16,11 @@ import java.util.List;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -38,6 +39,8 @@ import edu.unc.lib.boxc.model.fcrepo.services.RepositoryObjectDriver;
  *
  */
 public class BinaryObjectTest extends AbstractFedoraObjectTest {
+    private AutoCloseable closeable;
+
     @Mock
     private PID mockPid;
 
@@ -51,7 +54,7 @@ public class BinaryObjectTest extends AbstractFedoraObjectTest {
 
     @BeforeEach
     public void init() throws URISyntaxException {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
 
         byte[] buf = new byte[10];
         stream = new ByteArrayInputStream(buf);
@@ -66,6 +69,11 @@ public class BinaryObjectTest extends AbstractFedoraObjectTest {
         when(driver.loadModel(eq(binObj), anyBoolean())).thenReturn(driver);
 
         setupModel();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private void setupModel() {

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
@@ -12,20 +12,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +65,8 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
 
     private WorkObjectImpl work;
 
+    private AutoCloseable closeable;
+
     @Mock
     private FileObject fileObj;
     private URI contentUri;
@@ -75,7 +77,7 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = makePid();
 
@@ -106,6 +108,11 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
             }
         });
         when(driver.getRepositoryObject(any(PID.class))).thenReturn(fileObj);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectCacheLoaderTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectCacheLoaderTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.IOException;
 import java.util.UUID;
@@ -19,6 +19,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoResponse;
 import org.fcrepo.client.RequestBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,7 @@ public class RepositoryObjectCacheLoaderTest {
     private static final String ETAG_HEADER =  "\"etag\"";
 
     private RepositoryObjectCacheLoader objectCacheLoader;
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectDriver driver;
@@ -69,7 +71,7 @@ public class RepositoryObjectCacheLoaderTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         client = mock(FcrepoClient.class, new BuilderReturningAnswer());
 
@@ -80,6 +82,11 @@ public class RepositoryObjectCacheLoaderTest {
         objectCacheLoader.setRepositoryObjectDriver(driver);
 
         pid = PIDs.get(UUID.randomUUID().toString());
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectFactoryTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectFactoryTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -25,6 +25,7 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 import org.fcrepo.client.PostBuilder;
 import org.fcrepo.client.PutBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -50,6 +51,7 @@ import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPIDMinter;
  *
  */
 public class RepositoryObjectFactoryTest {
+    private AutoCloseable closeable;
 
     @Mock
     private LdpContainerFactory ldpFactory;
@@ -74,7 +76,7 @@ public class RepositoryObjectFactoryTest {
 
     @BeforeEach
     public void init() throws FcrepoOperationFailedException, URISyntaxException {
-        initMocks(this);
+        closeable = openMocks(this);
         repoObjFactory = new RepositoryObjectFactoryImpl();
         repoObjFactory.setClient(fcrepoClient);
         repoObjFactory.setLdpFactory(ldpFactory);
@@ -95,6 +97,11 @@ public class RepositoryObjectFactoryTest {
         when(mockPostBuilder.perform()).thenReturn(mockResponse);
         when(mockResponse.getLinkHeaders(any(String.class))).thenReturn(linkHeaders);
 
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectLoaderTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/services/RepositoryObjectLoaderTest.java
@@ -7,10 +7,11 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,7 @@ import edu.unc.lib.boxc.model.fcrepo.objects.RepositoryObjectCacheLoader;
  *
  */
 public class RepositoryObjectLoaderTest {
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectCacheLoader objectCacheLoader;
@@ -54,7 +56,7 @@ public class RepositoryObjectLoaderTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         contentPid = PIDs.get("content/uuid:0311cf7e-9ac0-4ab0-8c24-ff367e8e77f5");
         depositRecordPid = PIDs.get("deposit/uuid:0411cf7e-9ac0-4ab0-8c24-ff367e8e77f6");
@@ -69,6 +71,11 @@ public class RepositoryObjectLoaderTest {
         when(pidMinter.mintContentPid()).thenReturn(contentPid);
         when(pidMinter.mintDepositRecordPid()).thenReturn(depositRecordPid);
         when(pidMinter.mintPremisEventPid(any(PID.class))).thenReturn(premisPid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingServiceTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/indexing/IndexingServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.UUID;
 
@@ -23,12 +23,10 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
 
 /**
  *
@@ -37,6 +35,8 @@ import edu.unc.lib.boxc.operations.jms.indexing.IndexingService;
  */
 public class IndexingServiceTest {
     private static final String USERNAME = "username";
+
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -60,8 +60,8 @@ public class IndexingServiceTest {
     private PID objPid;
 
     @BeforeEach
-    public void init() throws Exception{
-        initMocks(this);
+    public void init() throws Exception {
+        closeable = openMocks(this);
 
         when(agent.getPrincipals()).thenReturn(groups);
         when(agent.getUsername()).thenReturn(USERNAME);
@@ -74,7 +74,8 @@ public class IndexingServiceTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
+        closeable.close();
         GroupsThreadStore.clearStore();
     }
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/ExpireEmbargoServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/ExpireEmbargoServiceIT.java
@@ -10,7 +10,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,7 +52,6 @@ import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.acl.ExpireEmbargoService;
 import edu.unc.lib.boxc.operations.jms.JMSMessageUtil;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -62,6 +62,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
         @ContextConfiguration("/spring-test/cdr-client-container.xml")
 })
 public class ExpireEmbargoServiceIT {
+    private AutoCloseable closeable;
 
     @Autowired
     private String baseAddress;
@@ -90,7 +91,7 @@ public class ExpireEmbargoServiceIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(baseAddress);
 
         service = new ExpireEmbargoService();
@@ -104,6 +105,11 @@ public class ExpireEmbargoServiceIT {
         PID contentRootPid = RepositoryPaths.getContentRootPid();
         repoInitializer.initializeRepository();
         contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/PatronAccessAssignmentServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/PatronAccessAssignmentServiceIT.java
@@ -20,7 +20,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Files;
@@ -35,6 +35,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,8 +80,6 @@ import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.acl.PatronAccessAssignmentService;
-import edu.unc.lib.boxc.operations.impl.acl.PatronAccessDetails;
 import edu.unc.lib.boxc.operations.impl.acl.PatronAccessAssignmentService.PatronAccessAssignmentRequest;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 import edu.unc.lib.boxc.operations.jms.JMSMessageUtil.CDRActions;
@@ -97,6 +96,8 @@ public class PatronAccessAssignmentServiceIT {
 
     private static final String origFilename = "original.txt";
     private static final String origMimetype = "text/plain";
+
+    private AutoCloseable closeable;
 
     @Autowired
     private String baseAddress;
@@ -129,7 +130,7 @@ public class PatronAccessAssignmentServiceIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(baseAddress);
 
         groups = new AccessGroupSetImpl(GRP_PRINC);
@@ -146,6 +147,11 @@ public class PatronAccessAssignmentServiceIT {
         PID contentRootPid = RepositoryPaths.getContentRootPid();
         repoInitializer.initializeRepository();
         contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/StaffRoleAssignmentServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/acl/StaffRoleAssignmentServiceIT.java
@@ -18,7 +18,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.time.ZonedDateTime;
 import java.util.Calendar;
@@ -32,6 +32,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,7 +78,6 @@ import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.acl.StaffRoleAssignmentService;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 import edu.unc.lib.boxc.operations.jms.JMSMessageUtil.CDRActions;
 
@@ -97,6 +97,8 @@ public class StaffRoleAssignmentServiceIT {
     private static final String USER_PRINC = "user";
     private static final String GRP_PRINC = "group";
     private static final Calendar TOMORROW = GregorianCalendar.from(ZonedDateTime.now().plusDays(1));
+
+    private AutoCloseable closeable;
 
     @Autowired
     private String baseAddress;
@@ -132,7 +134,7 @@ public class StaffRoleAssignmentServiceIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(baseAddress);
 
         groups = new AccessGroupSetImpl(GRP_PRINC);
@@ -150,6 +152,11 @@ public class StaffRoleAssignmentServiceIT {
         PID contentRootPid = RepositoryPaths.getContentRootPid();
         repoInitializer.initializeRepository();
         contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/delete/MarkForDeletionJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/delete/MarkForDeletionJobTest.java
@@ -11,12 +11,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,6 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.common.test.SelfReturningAnswer;
 import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -42,7 +42,6 @@ import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.api.events.PremisEventBuilder;
 import edu.unc.lib.boxc.operations.api.events.PremisLogger;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.delete.MarkForDeletionJob;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 
 /**
@@ -53,6 +52,7 @@ import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 public class MarkForDeletionJobTest {
 
     private static final String MESSAGE = "Reason for the deletion";
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -86,7 +86,7 @@ public class MarkForDeletionJobTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(repositoryObjectLoader.getRepositoryObject(any(PID.class))).thenReturn(contentObj);
 
@@ -103,6 +103,11 @@ public class MarkForDeletionJobTest {
 
         job = new MarkForDeletionJob(pid, MESSAGE, agent, repositoryObjectLoader, sparqlUpdateService, aclService,
                 premisLoggerFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/delete/RestoreDeletedJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/delete/RestoreDeletedJobTest.java
@@ -9,11 +9,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,6 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.common.test.SelfReturningAnswer;
 import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -37,7 +37,6 @@ import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.api.events.PremisEventBuilder;
 import edu.unc.lib.boxc.operations.api.events.PremisLogger;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.delete.RestoreDeletedJob;
 
 /**
  *
@@ -45,6 +44,7 @@ import edu.unc.lib.boxc.operations.impl.delete.RestoreDeletedJob;
  *
  */
 public class RestoreDeletedJobTest {
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -73,7 +73,7 @@ public class RestoreDeletedJobTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(repositoryObjectLoader.getRepositoryObject(any(PID.class))).thenReturn(contentObj);
 
@@ -90,6 +90,11 @@ public class RestoreDeletedJobTest {
 
         job = new RestoreDeletedJob(pid, agent, repositoryObjectLoader, sparqlUpdateService,
                 aclService, premisLoggerFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsCompletelyJobIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsCompletelyJobIT.java
@@ -14,7 +14,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -32,6 +32,7 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +71,6 @@ import edu.unc.lib.boxc.model.fcrepo.services.RepositoryInitializer;
 import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.operations.impl.destroy.DestroyObjectsCompletelyJob;
 import edu.unc.lib.boxc.operations.impl.edit.EditTitleService;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
 import edu.unc.lib.boxc.operations.jms.destroy.DestroyObjectsRequest;
@@ -93,6 +93,8 @@ public class DestroyObjectsCompletelyJobIT {
     private final static String LOC1_ID = "loc1";
     private static final String USER_NAME = "user";
     private static final String USER_GROUPS = "edu:lib:staff_grp";
+
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -141,7 +143,7 @@ public class DestroyObjectsCompletelyJobIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(baseAddress);
 
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(USER_GROUPS);
@@ -150,6 +152,11 @@ public class DestroyObjectsCompletelyJobIT {
         createContentTree();
 
         treeIndexer = new RepositoryObjectTreeIndexer(queryModel, fcrepoClient);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private void createContentTree() throws Exception {

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsJobIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/destroy/DestroyObjectsJobIT.java
@@ -49,6 +49,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.client.FcrepoClient;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,7 +91,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  *
@@ -107,6 +108,8 @@ public class DestroyObjectsJobIT {
     private final static String LOC1_ID = "loc1";
     private static final String USER_NAME = "user";
     private static final String USER_GROUPS = "edu:lib:staff_grp";
+
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -166,7 +169,7 @@ public class DestroyObjectsJobIT {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(baseAddress);
 
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(USER_GROUPS);
@@ -179,6 +182,11 @@ public class DestroyObjectsJobIT {
         when(pathFactory.getPath(any(PID.class))).thenReturn(path);
         when(path.toNamePath()).thenReturn("path/to/object");
         when(path.toIdPath()).thenReturn("pid0/pid1/pid2/pid3");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditFilenameServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditFilenameServiceTest.java
@@ -9,13 +9,14 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,6 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.common.test.SelfReturningAnswer;
 import edu.unc.lib.boxc.fcrepo.exceptions.TransactionCancelledException;
 import edu.unc.lib.boxc.fcrepo.utils.FedoraTransaction;
@@ -56,6 +56,7 @@ import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
  *
  */
 public class EditFilenameServiceTest {
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -101,7 +102,7 @@ public class EditFilenameServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
 
@@ -135,6 +136,11 @@ public class EditFilenameServiceTest {
             }
 
         }).when(tx).cancel(any(Throwable.class));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleServiceTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,6 +25,7 @@ import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.XMLOutputter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,12 +44,11 @@ import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.operations.impl.edit.EditTitleService;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 
 public class EditTitleServiceTest {
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -78,7 +78,7 @@ public class EditTitleServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         pid = PIDs.get(UUID.randomUUID().toString());
         service = new EditTitleService();
@@ -97,6 +97,11 @@ public class EditTitleServiceTest {
         when(agent.getUsername()).thenReturn("agentname");
 
         document = new Document();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceIT.java
@@ -7,7 +7,7 @@ import static edu.unc.lib.boxc.operations.test.ModsTestHelper.documentToInputStr
 import static edu.unc.lib.boxc.operations.test.ModsTestHelper.modsWithTitleAndDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -17,6 +17,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +36,6 @@ import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 
 /**
@@ -48,6 +48,8 @@ import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDesc
     @ContextConfiguration("/spring-test/import-job-it.xml")
 })
 public class UpdateDescriptionServiceIT {
+    private AutoCloseable closeable;
+
     @Autowired
     private String baseAddress;
     @Autowired
@@ -61,9 +63,14 @@ public class UpdateDescriptionServiceIT {
 
     @BeforeEach
     public void init_() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(baseAddress);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,6 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.ContentObject;
@@ -43,7 +43,6 @@ import edu.unc.lib.boxc.operations.impl.validation.MODSValidator;
 import edu.unc.lib.boxc.operations.impl.versioning.VersionedDatastreamService;
 import edu.unc.lib.boxc.operations.impl.versioning.VersionedDatastreamService.DatastreamVersion;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingPriority;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocation;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferSession;
 
@@ -55,6 +54,7 @@ import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferSession;
 public class UpdateDescriptionServiceTest {
 
     private static final String FILE_CONTENT = "Some content";
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -95,7 +95,7 @@ public class UpdateDescriptionServiceTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void init() throws Exception{
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(agent.getPrincipals()).thenReturn(groups);
         when(agent.getUsername()).thenReturn("username");
@@ -117,6 +117,11 @@ public class UpdateDescriptionServiceTest {
         service.setOperationsMessageSender(messageSender);
         service.setModsValidator(modsValidator);
         service.setVersionedDatastreamService(versioningService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobIT.java
@@ -12,12 +12,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.UUID;
@@ -28,6 +27,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,6 +69,7 @@ import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
 public class ImportXMLJobIT {
 
     private ImportXMLJob job;
+    private AutoCloseable closeable;
 
     private final static String USER_EMAIL = "user@example.com";
 
@@ -117,7 +118,7 @@ public class ImportXMLJobIT {
 
     @BeforeEach
     public void init_() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         tempDir = tmpFolder.resolve("tempDir").toFile();
 
@@ -125,6 +126,11 @@ public class ImportXMLJobIT {
         when(completeTemplate.execute(any(Object.class))).thenReturn("update was successful");
 
         TestHelper.setContentBase(baseAddress);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -36,6 +36,7 @@ import javax.xml.stream.events.XMLEvent;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -80,6 +81,7 @@ public class ImportXMLJobTest {
     private static final String ADMIN_EMAIL = "admin@example.com";
 
     private ImportXMLJob job;
+    private AutoCloseable closeable;
 
     @Mock
     private AgentPrincipals agent;
@@ -129,13 +131,18 @@ public class ImportXMLJobTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(mailSender.createMimeMessage()).thenReturn(msg);
 
         when(transferService.getSession()).thenReturn(multiDestSession);
         when(multiDestSession.forDestination(storageLocation)).thenReturn(singleDestSession);
         when(locationManager.getStorageLocation(any(PID.class))).thenReturn(storageLocation);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @SuppressWarnings("unchecked")

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/move/MoveObjectsServiceTest.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.operations.impl.move;
 
 import static java.util.Arrays.asList;
-import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,7 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -48,7 +47,6 @@ import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.fcrepo.exceptions.TransactionCancelledException;
 import edu.unc.lib.boxc.fcrepo.utils.FedoraTransaction;
 import edu.unc.lib.boxc.fcrepo.utils.TransactionManager;
@@ -74,6 +72,7 @@ import edu.unc.lib.boxc.search.solr.services.ObjectPathFactory;
 public class MoveObjectsServiceTest {
     private final static String DEST_OBJ_PATH = "/path/to/destination";
     private final static String SOURCE_OBJ_PATH = "/path/to/source";
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -119,7 +118,7 @@ public class MoveObjectsServiceTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         service = new MoveObjectsService();
         service.setAclService(aclService);
@@ -165,7 +164,8 @@ public class MoveObjectsServiceTest {
     }
 
     @AfterEach
-    public void after() {
+    public void after() throws Exception {
+        closeable.close();
         actionAppender.stop();
     }
 

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/ClearOrderJobTest.java
@@ -7,19 +7,21 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
  */
 public class ClearOrderJobTest {
     private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private AutoCloseable closeable;
     @Mock
     private RepositoryObjectFactory repositoryObjectFactory;
     @Mock
@@ -31,12 +33,17 @@ public class ClearOrderJobTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         parentPid = PIDs.get(PARENT_UUID);
         orderJobFactory = new OrderJobFactory();
         orderJobFactory.setRepositoryObjectFactory(repositoryObjectFactory);
         orderJobFactory.setRepositoryObjectLoader(repositoryObjectLoader);
         when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentWork);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderJobFactoryTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderJobFactoryTest.java
@@ -3,15 +3,16 @@ package edu.unc.lib.boxc.operations.impl.order;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -20,6 +21,7 @@ public class OrderJobFactoryTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
     private static final String PARENT_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    private AutoCloseable closeable;
     @Mock
     private RepositoryObjectFactory repositoryObjectFactory;
     @Mock
@@ -28,10 +30,15 @@ public class OrderJobFactoryTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         factory = new OrderJobFactory();
         factory.setRepositoryObjectFactory(repositoryObjectFactory);
         factory.setRepositoryObjectLoader(repositoryObjectLoader);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/OrderValidatorFactoryTest.java
@@ -3,14 +3,15 @@ package edu.unc.lib.boxc.operations.impl.order;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class OrderValidatorFactoryTest {
     private static final String PARENT_UUID = "f277bb38-272c-471c-a28a-9887a1328a1f";
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
+    private AutoCloseable closeable;
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
     @Mock
@@ -26,10 +28,15 @@ public class OrderValidatorFactoryTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         factory = new OrderValidatorFactory();
         factory.setMembershipService(membershipService);
         factory.setRepositoryObjectLoader(repositoryObjectLoader);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromJobTest.java
@@ -7,13 +7,12 @@ import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
-import edu.unc.lib.boxc.operations.test.OrderTestHelper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -24,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.createRequest;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author snluong
@@ -33,6 +33,8 @@ public class RemoveFromJobTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
     private static final String CHILD3_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectFactory repositoryObjectFactory;
@@ -47,7 +49,7 @@ public class RemoveFromJobTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         parentPid = PIDs.get(PARENT_UUID);
         orderJobFactory = new OrderJobFactory();
         orderJobFactory.setRepositoryObjectFactory(repositoryObjectFactory);
@@ -57,6 +59,11 @@ public class RemoveFromJobTest {
         // need to make list modifiable
         var childrenOrder = new LinkedList<>(listOfPids);
         when(parentWork.getMemberOrder()).thenReturn(childrenOrder);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/RemoveFromOrderValidatorTest.java
@@ -8,10 +8,10 @@ import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.test.OrderTestHelper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.mockParentType;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.assertHasErrors;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author snluong
@@ -30,6 +31,7 @@ public class RemoveFromOrderValidatorTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
     private static final String CHILD3_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    private AutoCloseable closeable;
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
     @Mock
@@ -44,7 +46,7 @@ public class RemoveFromOrderValidatorTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         validator = new RemoveFromOrderValidator();
         validator.setRepositoryObjectLoader(repositoryObjectLoader);
 
@@ -54,6 +56,11 @@ public class RemoveFromOrderValidatorTest {
         child3Pid = PIDs.get(CHILD3_UUID);
         when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentObj);
         mockParentType(parentObj, ResourceType.Work);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJobTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderJobTest.java
@@ -8,17 +8,18 @@ import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.test.OrderTestHelper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -28,6 +29,7 @@ public class SetOrderJobTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
     private static final String CHILD3_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectFactory repositoryObjectFactory;
@@ -42,12 +44,17 @@ public class SetOrderJobTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         parentPid = PIDs.get(PARENT_UUID);
         orderJobFactory = new OrderJobFactory();
         orderJobFactory.setRepositoryObjectFactory(repositoryObjectFactory);
         orderJobFactory.setRepositoryObjectLoader(repositoryObjectLoader);
         when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentWork);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/order/SetOrderValidatorTest.java
@@ -7,10 +7,10 @@ import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.MembershipService;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.assertHasErrors;
 import static edu.unc.lib.boxc.operations.test.OrderTestHelper.mockParentType;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -29,6 +30,7 @@ public class SetOrderValidatorTest {
     private static final String CHILD1_UUID = "83c2d7f8-2e6b-4f0b-ab7e-7397969c0682";
     private static final String CHILD2_UUID = "0e33ad0b-7a16-4bfa-b833-6126c262d889";
     private static final String CHILD3_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
+    private AutoCloseable closeable;
     @Mock
     private RepositoryObjectLoader repositoryObjectLoader;
     @Mock
@@ -44,7 +46,7 @@ public class SetOrderValidatorTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         validator = new SetOrderValidator();
         validator.setRepositoryObjectLoader(repositoryObjectLoader);
         validator.setMembershipService(membershipService);
@@ -55,6 +57,11 @@ public class SetOrderValidatorTest {
         child3Pid = PIDs.get(CHILD3_UUID);
         when(repositoryObjectLoader.getRepositoryObject(parentPid)).thenReturn(parentObj);
         mockParentType(parentObj, ResourceType.Work);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/DatastreamHistoryLogTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/DatastreamHistoryLogTest.java
@@ -4,7 +4,7 @@ import static edu.unc.lib.boxc.common.util.DateTimeUtil.parseUTCToDate;
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.DCR_PACKAGING_NS;
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -17,6 +17,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,6 @@ import edu.unc.lib.boxc.common.xml.SecureXMLFactory;
 import edu.unc.lib.boxc.fcrepo.exceptions.ServiceException;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.operations.impl.versioning.DatastreamHistoryLog;
 
 /**
  * @author bbpennel
@@ -40,11 +40,17 @@ public class DatastreamHistoryLogTest {
     private static final Date VERSION2_DATE = parseUTCToDate(VERSION2_TIME);
 
     private PID dsPid;
+    private AutoCloseable closeable;
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         dsPid = PIDs.get(TEST_ID);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/sources/IngestSourceManagerImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/sources/IngestSourceManagerImplTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Files;
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,8 @@ import edu.unc.lib.boxc.persist.impl.sources.IngestSourceManagerImpl.IngestSourc
  * @author bbpennel
  */
 public class IngestSourceManagerImplTest {
+    private AutoCloseable closeable;
+
     @TempDir
     public Path tmpFolder;
     private Path sourceFolderPath;
@@ -62,7 +65,7 @@ public class IngestSourceManagerImplTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         sourceFolderPath = tmpFolder.resolve("sourceFolder");
         Files.createDirectory(sourceFolderPath);
 
@@ -73,6 +76,11 @@ public class IngestSourceManagerImplTest {
         destPid = makePid();
 
         mockAncestors(destPid, rootPid, adminUnitPid);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private void initializeManager() throws Exception {

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/storage/StorageLocationManagerImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/storage/StorageLocationManagerImplTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,6 @@ import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocation;
 import edu.unc.lib.boxc.persist.api.storage.StorageType;
 import edu.unc.lib.boxc.persist.api.storage.UnknownStorageLocationException;
-import edu.unc.lib.boxc.persist.impl.storage.StorageLocationManagerImpl;
 
 /**
  * @author bbpennel
@@ -47,6 +47,8 @@ public class StorageLocationManagerImplTest {
     private static final String LOC2_ID = "loc2";
     private static final String LOC2_NAME = "Stor2";
     private static final String LOC2_BASE = "file://some/other";
+
+    private AutoCloseable closeable;
 
     @Mock
     private ContentPathFactory pathFactory;
@@ -62,13 +64,18 @@ public class StorageLocationManagerImplTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         locManager = new StorageLocationManagerImpl();
         locManager.setPathFactory(pathFactory);
         locManager.setRepositoryObjectLoader(repositoryObjectLoader);
 
         helper = new StorageLocationTestHelper();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private void initializeManager() throws Exception {

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/BinaryTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/BinaryTransferSessionImplTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Files;
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,8 +27,6 @@ import edu.unc.lib.boxc.persist.api.sources.IngestSourceManager;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocation;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
-import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
-import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferSessionImpl;
 
 /**
  * @author bbpennel
@@ -36,6 +35,7 @@ import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferSessionImpl;
 public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
     private BinaryTransferSessionImpl session;
+    private AutoCloseable closeable;
 
     private BinaryTransferService bts;
     @Mock
@@ -50,7 +50,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         createPaths();
 
         binPid = makeBinPid();
@@ -63,6 +63,11 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         when(storageLoc.getId()).thenReturn("loc1");
 
         bts = new BinaryTransferServiceImpl();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.RandomAccessFile;
@@ -22,6 +22,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,6 @@ import edu.unc.lib.boxc.persist.api.transfer.BinaryAlreadyExistsException;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferException;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.impl.storage.HashedFilesystemStorageLocation;
-import edu.unc.lib.boxc.persist.impl.transfer.FSToFSTransferClient;
 
 /**
  * @author bbpennel
@@ -50,6 +50,7 @@ public class FSToFSTransferClientTest {
     protected static final String FILE_CONTENT_SHA1 = "6c4244329888770c6fa7f3fbf1d3b8baf9ccb7d0";
 
     protected FSToFSTransferClient client;
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -63,7 +64,7 @@ public class FSToFSTransferClientTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         sourcePath = tmpFolder.resolve("source");
         Files.createDirectory(sourcePath);
         storagePath = tmpFolder.resolve("storage");
@@ -77,6 +78,11 @@ public class FSToFSTransferClientTest {
         client = new FSToFSTransferClient(ingestSource, storageLoc);
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToPosixTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToPosixTransferClientTest.java
@@ -3,7 +3,7 @@ package edu.unc.lib.boxc.persist.impl.transfer;
 import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getOriginalFilePid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Files;
@@ -12,13 +12,13 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.impl.storage.HashedPosixStorageLocation;
-import edu.unc.lib.boxc.persist.impl.transfer.FSToPosixTransferClient;
 
 /**
  * @author bbpennel
@@ -26,11 +26,12 @@ import edu.unc.lib.boxc.persist.impl.transfer.FSToPosixTransferClient;
 public class FSToPosixTransferClientTest extends FSToFSTransferClientTest {
 
     private FSToPosixTransferClient posixClient;
+    private AutoCloseable closeable;
 
     @Override
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         sourcePath = tmpFolder.resolve("source");
         Files.createDirectory(sourcePath);
         storagePath = tmpFolder.resolve("storage");
@@ -45,6 +46,11 @@ public class FSToPosixTransferClientTest extends FSToFSTransferClientTest {
         this.client = posixClient;
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/MultiDestinationTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/MultiDestinationTransferSessionImplTest.java
@@ -4,13 +4,14 @@ import static edu.unc.lib.boxc.persist.api.storage.StorageType.FILESYSTEM;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,6 @@ import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferSession;
-import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
-import edu.unc.lib.boxc.persist.impl.transfer.MultiDestinationTransferSessionImpl;
 
 /**
  * @author bbpennel
@@ -36,6 +35,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
     private static final String FILE_CONTENT = "File content";
 
     private Path storagePath2;
+    private AutoCloseable closeable;
     @Mock
     private IngestSourceManager sourceManager;
     @Mock
@@ -53,7 +53,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         createPaths();
 
         binPid = makeBinPid();
@@ -68,6 +68,11 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         when(storageLoc.getId()).thenReturn("loc1");
 
         bts = new BinaryTransferServiceImpl();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/StreamToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/StreamToFSTransferClientTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,7 @@ public class StreamToFSTransferClientTest {
     protected static final String STREAM_CONTENT_SHA1 = "bf29c7fd7f87fe7395b89012e73d91c85a0cb19b";
 
     protected StreamToFSTransferClient client;
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -58,7 +60,7 @@ public class StreamToFSTransferClientTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         sourcePath = tmpFolder.resolve("source");
         Files.createDirectory(sourcePath);
         storagePath = tmpFolder.resolve("storage");
@@ -72,6 +74,11 @@ public class StreamToFSTransferClientTest {
         client = new StreamToFSTransferClient(storageLoc);
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/StreamToPosixTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/StreamToPosixTransferClientTest.java
@@ -3,7 +3,7 @@ package edu.unc.lib.boxc.persist.impl.transfer;
 import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getOriginalFilePid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -12,13 +12,13 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.impl.storage.HashedPosixStorageLocation;
-import edu.unc.lib.boxc.persist.impl.transfer.StreamToPosixTransferClient;
 
 /**
  * @author bbpennel
@@ -26,11 +26,12 @@ import edu.unc.lib.boxc.persist.impl.transfer.StreamToPosixTransferClient;
 public class StreamToPosixTransferClientTest extends StreamToFSTransferClientTest {
 
     private StreamToPosixTransferClient posixClient;
+    private AutoCloseable closeable;
 
     @Override
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         storagePath = tmpFolder.resolve("storage");
         Files.createDirectory(storagePath);
 
@@ -43,6 +44,11 @@ public class StreamToPosixTransferClientTest extends StreamToFSTransferClientTes
         this.client = posixClient;
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ChildrenCountServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ChildrenCountServiceIT.java
@@ -9,7 +9,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,8 +31,6 @@ import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
 import edu.unc.lib.boxc.search.solr.config.SearchSettings;
-import edu.unc.lib.boxc.search.solr.services.ChildrenCountService;
-import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -42,6 +41,7 @@ import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
  *
  */
 public class ChildrenCountServiceIT extends BaseEmbeddedSolrTest {
+    private AutoCloseable closeable;
 
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
@@ -62,7 +62,7 @@ public class ChildrenCountServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         index(testCorpus.populate());
 
@@ -85,6 +85,11 @@ public class ChildrenCountServiceIT extends BaseEmbeddedSolrTest {
         setField(countService, "solrClient", server);
 
         principals = new AccessGroupSetImpl(PUBLIC_PRINC);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/FacetValuesServiceIT.java
@@ -20,6 +20,7 @@ import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
 import edu.unc.lib.boxc.search.solr.utils.FacetFieldUtil;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -33,7 +34,7 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -47,6 +48,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
     private final static String SUBJECT_6 = "University of North Carolina";
     private final static String SUBJECT_7 = "Chapel Hill";
     private final static String SUBJECT_8 = "Boxy";
+    private AutoCloseable closeable;
 
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
@@ -67,7 +69,7 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void setupFacets() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         accessRestrictionUtil = new AccessRestrictionUtil();
         accessRestrictionUtil.setSearchSettings(searchSettings);
@@ -99,6 +101,11 @@ public class FacetValuesServiceIT extends BaseEmbeddedSolrTest {
             corpusLoaded = true;
             index(testCorpus.populate());
         }
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/GetCollectionIdServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/GetCollectionIdServiceIT.java
@@ -3,8 +3,9 @@ package edu.unc.lib.boxc.search.solr.services;
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -12,8 +13,6 @@ import org.mockito.Mock;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
-import edu.unc.lib.boxc.search.solr.services.GetCollectionIdService;
-import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -25,6 +24,7 @@ public class GetCollectionIdServiceIT extends BaseEmbeddedSolrTest {
     private TestCorpus testCorpus;
     private GetCollectionIdService collIdService;
     private SolrSearchService solrSearchService;
+    private AutoCloseable closeable;
     @Mock
     private AccessRestrictionUtil restrictionUtil;
 
@@ -34,7 +34,7 @@ public class GetCollectionIdServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         index(testCorpus.populate());
 
@@ -46,6 +46,11 @@ public class GetCollectionIdServiceIT extends BaseEmbeddedSolrTest {
         collIdService = new GetCollectionIdService();
         collIdService.setSolrSettings(solrSettings);
         setField(collIdService, "solrClient", server);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
@@ -22,6 +22,7 @@ import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
 import edu.unc.lib.boxc.search.solr.utils.FacetFieldUtil;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -57,6 +58,7 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
     private TestCorpus testCorpus;
     private boolean corpusLoaded;
     private AccessGroupSet accessGroups;
+    private AutoCloseable closeable;
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
 
@@ -72,7 +74,7 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         if (!corpusLoaded) {
             corpusLoaded = true;
             index(testCorpus.populate());
@@ -104,6 +106,11 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         service.setSearchService(searchService);
 
         accessGroups = new AccessGroupSetImpl("unitOwner", PUBLIC_PRINC);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/NeighborQueryServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/NeighborQueryServiceIT.java
@@ -4,7 +4,7 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.common.SolrInputDocument;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -26,8 +27,6 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
-import edu.unc.lib.boxc.search.solr.services.NeighborQueryService;
-import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -53,6 +52,8 @@ public class NeighborQueryServiceIT extends BaseEmbeddedSolrTest {
 
     private TestCorpus testCorpus;
 
+    private AutoCloseable closeable;
+
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
 
@@ -71,7 +72,7 @@ public class NeighborQueryServiceIT extends BaseEmbeddedSolrTest {
     @Override
     @BeforeEach
     public void setUp() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         super.setUp();
 
@@ -101,6 +102,11 @@ public class NeighborQueryServiceIT extends BaseEmbeddedSolrTest {
         queryService.setAccessRestrictionUtil(restrictionUtil);
         queryService.setFacetFieldUtil(facetFieldUtil);
         setField(queryService, "solrClient", server);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactoryIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactoryIT.java
@@ -3,12 +3,13 @@ package edu.unc.lib.boxc.search.solr.services;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -19,8 +20,6 @@ import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.models.ObjectPath;
 import edu.unc.lib.boxc.search.api.models.ObjectPathEntry;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
-import edu.unc.lib.boxc.search.solr.services.ObjectPathFactory;
-import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -36,6 +35,8 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
 
     private ObjectPathFactory objPathFactory;
 
+    private AutoCloseable closeable;
+
     @Mock
     private AccessRestrictionUtil restrictionUtil;
 
@@ -45,7 +46,7 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         index(testCorpus.populate());
 
@@ -60,6 +61,11 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
         objPathFactory.setTimeToLiveMilli(500L);
         objPathFactory.setCacheSize(10);
         objPathFactory.init();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/SetFacetTitleByIdServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/SetFacetTitleByIdServiceIT.java
@@ -1,20 +1,17 @@
 package edu.unc.lib.boxc.search.solr.services;
 
 import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
-import static edu.unc.lib.boxc.search.api.SearchFieldKey.FILE_FORMAT_CATEGORY;
 import static edu.unc.lib.boxc.search.api.SearchFieldKey.PARENT_COLLECTION;
 import static edu.unc.lib.boxc.search.api.SearchFieldKey.PARENT_UNIT;
 import static edu.unc.lib.boxc.search.api.SearchFieldKey.SUBJECT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
-import java.util.Arrays;
 import java.util.Map;
 
-import edu.unc.lib.boxc.search.solr.facets.GenericFacet;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -24,12 +21,9 @@ import edu.unc.lib.boxc.auth.api.services.GlobalPermissionEvaluator;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
-import edu.unc.lib.boxc.search.api.facets.FacetFieldList;
 import edu.unc.lib.boxc.search.api.facets.FacetFieldObject;
 import edu.unc.lib.boxc.search.api.facets.SearchFacet;
-import edu.unc.lib.boxc.search.api.requests.SearchRequest;
 import edu.unc.lib.boxc.search.api.requests.SearchState;
-import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -49,6 +43,8 @@ public class SetFacetTitleByIdServiceIT extends BaseEmbeddedSolrTest {
 
     private MultiSelectFacetListService facetListService;
 
+    private AutoCloseable closeable;
+
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
     private FacetFieldFactory facetFieldFactory;
@@ -63,7 +59,7 @@ public class SetFacetTitleByIdServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         if (!corpusLoaded) {
             corpusLoaded = true;
             index(testCorpus.populate());
@@ -107,6 +103,11 @@ public class SetFacetTitleByIdServiceIT extends BaseEmbeddedSolrTest {
         searchStateFactory = new SearchStateFactory();
         searchStateFactory.setFacetFieldFactory(facetFieldFactory);
         searchStateFactory.setSearchSettings(searchSettings);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/StructureQueryServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/StructureQueryServiceIT.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.NoSuchElementException;
 import java.util.UUID;
@@ -35,11 +35,6 @@ import edu.unc.lib.boxc.search.api.requests.SearchState;
 import edu.unc.lib.boxc.search.solr.facets.GenericFacet;
 import edu.unc.lib.boxc.search.solr.responses.HierarchicalBrowseResultResponse;
 import edu.unc.lib.boxc.search.solr.responses.HierarchicalBrowseResultResponse.ResultNode;
-import edu.unc.lib.boxc.search.solr.services.ChildrenCountService;
-import edu.unc.lib.boxc.search.solr.services.FacetFieldFactory;
-import edu.unc.lib.boxc.search.solr.services.SearchStateFactory;
-import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
-import edu.unc.lib.boxc.search.solr.services.StructureQueryService;
 import edu.unc.lib.boxc.search.solr.test.BaseEmbeddedSolrTest;
 import edu.unc.lib.boxc.search.solr.test.TestCorpus;
 import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
@@ -51,6 +46,7 @@ import edu.unc.lib.boxc.search.solr.utils.FacetFieldUtil;
  *
  */
 public class StructureQueryServiceIT extends BaseEmbeddedSolrTest {
+    private AutoCloseable closeable;
 
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
@@ -77,7 +73,7 @@ public class StructureQueryServiceIT extends BaseEmbeddedSolrTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         index(testCorpus.populate());
 

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/utils/AccessRestrictionUtilTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/utils/AccessRestrictionUtilTest.java
@@ -3,9 +3,10 @@ package edu.unc.lib.boxc.search.solr.utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.anySetOf;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.apache.solr.client.solrj.SolrQuery;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,6 @@ import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.services.GlobalPermissionEvaluator;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.search.solr.config.SearchSettings;
-import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
 
 /**
  *
@@ -27,6 +27,8 @@ public class AccessRestrictionUtilTest {
 
     private final static String BASE_QUERY = "*:*";
     private final static String ACCESS_GROUP = "group";
+
+    private AutoCloseable closeable;
 
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
@@ -39,13 +41,18 @@ public class AccessRestrictionUtilTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         restrictionUtil = new AccessRestrictionUtil();
         restrictionUtil.setGlobalPermissionEvaluator(globalPermissionEvaluator);
         restrictionUtil.setSearchSettings(searchSettings);
 
         accessGroups = new AccessGroupSetImpl(ACCESS_GROUP);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryEnhancementProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryEnhancementProcessorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Collections;
 
@@ -22,6 +22,7 @@ import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
@@ -30,7 +31,6 @@ import edu.unc.lib.boxc.model.api.objects.CollectionObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.BinaryEnhancementProcessor;
 
 /**
  *
@@ -39,6 +39,7 @@ import edu.unc.lib.boxc.services.camel.BinaryEnhancementProcessor;
  */
 public class BinaryEnhancementProcessorTest {
     private BinaryEnhancementProcessor processor;
+    private AutoCloseable closeable;
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -61,7 +62,7 @@ public class BinaryEnhancementProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -72,6 +73,11 @@ public class BinaryEnhancementProcessorTest {
         when(exchange.getIn().getHeader(FCREPO_URI)).thenReturn(null);
         when(repoObjLoader.getRepositoryObject(any(PID.class))).thenReturn(repoObj);
         when(repoObj.getTypes()).thenReturn(Collections.singletonList(Binary.getURI()));
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessorTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -27,6 +27,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
@@ -49,6 +50,7 @@ import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 public class BinaryMetadataProcessorTest {
 
     private BinaryMetadataProcessor processor;
+    private AutoCloseable closeable;
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -79,7 +81,7 @@ public class BinaryMetadataProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -96,6 +98,11 @@ public class BinaryMetadataProcessorTest {
         when(exchange.getIn().getHeader(FCREPO_URI)).thenReturn(RESC_ID);
 
         binaryPid = PIDs.get(RESC_ID);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/NonBinaryEnhancementProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/NonBinaryEnhancementProcessorTest.java
@@ -6,7 +6,7 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -20,17 +20,18 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.NonBinaryEnhancementProcessor;
 
 /**
  * @author lfarrell
  */
 public class NonBinaryEnhancementProcessorTest {
     private NonBinaryEnhancementProcessor processor;
+    private AutoCloseable closeable;
 
     @Rule
     public final TemporaryFolder tmpDir = new TemporaryFolder();
@@ -49,7 +50,7 @@ public class NonBinaryEnhancementProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         dataDir = tmpDir.newFolder().getAbsolutePath();
 
         TestHelper.setContentBase(FEDORA_BASE);
@@ -58,6 +59,11 @@ public class NonBinaryEnhancementProcessorTest {
 
         when(exchange.getIn()).thenReturn(message);
         when(message.getHeader(FCREPO_URI)).thenReturn(RESC_URI);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/binaryCleanup/BinaryCleanupRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/binaryCleanup/BinaryCleanupRouterIT.java
@@ -4,7 +4,7 @@ import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.getContentRootPi
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.net.URI;
@@ -17,6 +17,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.NotifyBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -85,9 +86,11 @@ public class BinaryCleanupRouterIT {
 
     private CollectionObject collection;
 
+    private AutoCloseable closeable;
+
     @Before
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(baseAddress);
 
@@ -99,6 +102,11 @@ public class BinaryCleanupRouterIT {
         collection = repoObjectFactory.createCollectionObject(null);
         contentRoot.addMember(adminUnit);
         adminUnit.addMember(collection);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/cdrEvents/CdrEventProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/cdrEvents/CdrEventProcessorTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 
@@ -20,11 +20,10 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-
-import edu.unc.lib.boxc.services.camel.cdrEvents.CdrEventProcessor;
 
 /**
  *
@@ -34,6 +33,7 @@ import edu.unc.lib.boxc.services.camel.cdrEvents.CdrEventProcessor;
 public class CdrEventProcessorTest {
     private CdrEventProcessor processor;
     private String actionType = "action_placeholder";
+    private AutoCloseable closeable;
 
     @Mock
     private Exchange exchange;
@@ -46,12 +46,17 @@ public class CdrEventProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         processor = new CdrEventProcessor();
 
         when(exchange.getIn())
             .thenReturn(message);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/cdrEvents/CdrEventRoutingTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/cdrEvents/CdrEventRoutingTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +22,7 @@ import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -60,6 +61,7 @@ public class CdrEventRoutingTest {
     private static final String USER_ID = "user";
     private static final String DEPOSIT_ID = "deposit";
     private static final String BASE_URI = "http://example.com/rest/";
+    private AutoCloseable closeable;
 
     @Autowired
     private OperationsMessageSender opsMsgSender;
@@ -82,7 +84,7 @@ public class CdrEventRoutingTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(BASE_URI);
 
@@ -91,6 +93,11 @@ public class CdrEventRoutingTest {
 
         when(mockActionMap.get(any(IndexingActionType.class)))
                 .thenReturn(mockIndexingAction);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroy/DestroyObjectsRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroy/DestroyObjectsRouterTest.java
@@ -7,17 +7,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Collections;
 import java.util.UUID;
 
-import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
 import edu.unc.lib.boxc.model.api.rdf.Premis;
 import edu.unc.lib.boxc.operations.api.events.PremisEventBuilder;
 import edu.unc.lib.boxc.operations.api.events.PremisLogger;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
-import edu.unc.lib.boxc.operations.impl.events.PremisEventBuilderImpl;
 import org.apache.camel.BeanInject;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
@@ -28,6 +26,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -61,6 +60,8 @@ public class DestroyObjectsRouterTest extends CamelSpringTestSupport {
     private static final String USER_NAME = "user";
     private static final String USER_GROUPS = "edu:lib:staff_grp";
 
+    private AutoCloseable closeable;
+
     @Produce(uri = "direct:start")
     protected ProducerTemplate template;
 
@@ -93,11 +94,16 @@ public class DestroyObjectsRouterTest extends CamelSpringTestSupport {
 
     @Before
     public void setup() {
-        initMocks(this);
+        closeable = openMocks(this);
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(USER_GROUPS);
         agent = new AgentPrincipalsImpl(USER_NAME, testPrincipals);
 
         when(txManager.startTransaction()).thenReturn(tx);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Override

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesProcessorTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -20,12 +20,12 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.destroyDerivatives.DestroyDerivativesProcessor;
 
 public class DestroyDerivativesProcessorTest {
     private DestroyDerivativesProcessor processor;
@@ -40,6 +40,7 @@ public class DestroyDerivativesProcessorTest {
     private static final String PID_ID = "content/" + PID_UUID;
     private static final String PID_PATH = "content/de/75/d8/11/" + PID_UUID;
     private static final String RESC_ID = FEDORA_BASE + PID_PATH;
+    private AutoCloseable closeable;
 
     @Rule
     public TemporaryFolder derivativeDir = new TemporaryFolder();
@@ -52,7 +53,7 @@ public class DestroyDerivativesProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -64,6 +65,11 @@ public class DestroyDerivativesProcessorTest {
                 .thenReturn(PID_ID);
 
         derivativeDirBase = derivativeDir.getRoot().getAbsolutePath();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -27,6 +27,7 @@ import org.apache.jena.rdf.model.Model;
 import org.fcrepo.client.FcrepoClient;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,8 +65,6 @@ import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.boxc.persist.impl.storage.StorageLocationManagerImpl;
 import edu.unc.lib.boxc.search.api.models.ObjectPath;
 import edu.unc.lib.boxc.search.solr.services.ObjectPathFactory;
-import edu.unc.lib.boxc.services.camel.destroyDerivatives.DestroyDerivativesProcessor;
-import edu.unc.lib.boxc.services.camel.destroyDerivatives.DestroyedMsgProcessor;
 
 /**
  *
@@ -151,9 +150,11 @@ public class DestroyDerivativesRouterIT {
 
     private final static String LOC1_ID = "loc1";
 
+    private AutoCloseable closeable;
+
     @Before
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(baseAddress);
 
@@ -185,6 +186,11 @@ public class DestroyDerivativesRouterIT {
         when(pathFactory.getPath(any(PID.class))).thenReturn(path);
         when(path.toNamePath()).thenReturn("path/to/object");
         when(path.toIdPath()).thenReturn("pid0/pid1/pid2/pid3");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/enhancements/EnhancementRouterIT.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -39,6 +39,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,6 +82,8 @@ public class EnhancementRouterIT {
     private final static String FILE_CONTENT = "content";
 
     private final static long ALLOW_WAIT = 5000;
+
+    private AutoCloseable closeable;
 
     @Autowired
     private String baseAddress;
@@ -125,7 +128,7 @@ public class EnhancementRouterIT {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         reset(solrIngestProcessor);
         reset(addSmallThumbnailProcessor);
@@ -147,6 +150,11 @@ public class EnhancementRouterIT {
         File jp2ScriptFile = new File("target/convertJp2.sh");
         FileUtils.writeStringToFile(jp2ScriptFile, "exit 0", "utf-8");
         jp2ScriptFile.deleteOnExit();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/exportxml/ExportXMLRouteIT.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,6 +43,7 @@ import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -99,6 +100,8 @@ import edu.unc.lib.boxc.operations.jms.exportxml.ExportXMLRequestService;
 public class ExportXMLRouteIT {
     private static final String EMAIL = "test@example.com";
 
+    private AutoCloseable closeable;
+
     @Autowired
     private CamelContext cdrExportXML;
     @Autowired
@@ -149,12 +152,17 @@ public class ExportXMLRouteIT {
 
     @Before
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         reset(emailHandler);
         TestHelper.setContentBase("http://localhost:48085/rest");
         agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("adminGroup"));
         generateBaseStructure();
         exportXmlProcessor.setObjectsPerExport(500);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/fulltext/FulltextProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/fulltext/FulltextProcessorTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 
@@ -18,13 +18,13 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
 import com.google.common.io.Files;
 
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.services.camel.fulltext.FulltextProcessor;
 
 public class FulltextProcessorTest {
     private FulltextProcessor processor;
@@ -40,6 +40,8 @@ public class FulltextProcessorTest {
 
     private static final String RESC_ID = FEDORA_BASE + "content/de/75/d8/11/de75d811-9e0f-4b1f-8631-2060ab3580cc";
 
+    private AutoCloseable closeable;
+
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 
@@ -51,7 +53,7 @@ public class FulltextProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -65,6 +67,11 @@ public class FulltextProcessorTest {
         finalDerivativeFile = new File(derivPath + "/" + derivativeFinalPath + ".txt");
         // Ensure that final path does not carry over between tests.
         finalDerivativeFile.delete();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/AddDerivativeProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/AddDerivativeProcessorTest.java
@@ -7,6 +7,7 @@ import edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.component.exec.ExecResult;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -24,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class AddDerivativeProcessorTest {
 
@@ -39,6 +40,8 @@ public class AddDerivativeProcessorTest {
     private static final String FEDORA_BASE = "http://example.com/rest/";
 
     private static final String RESC_ID = FEDORA_BASE + "content/de/75/d8/11/de75d811-9e0f-4b1f-8631-2060ab3580cc";
+
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -57,7 +60,7 @@ public class AddDerivativeProcessorTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(FEDORA_BASE);
 
@@ -86,6 +89,11 @@ public class AddDerivativeProcessorTest {
         when(message.getBody()).thenReturn(result);
 
         destinationPath = moveFolder.resolve(fileName + ".PNG");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/importxml/ImportXMLIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/importxml/ImportXMLIT.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.InputStream;
 import java.util.concurrent.TimeUnit;
@@ -21,6 +21,7 @@ import org.jdom2.input.SAXBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -43,7 +44,6 @@ import edu.unc.lib.boxc.operations.impl.importxml.ImportXMLService;
 import edu.unc.lib.boxc.operations.test.ModsTestHelper;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
-import edu.unc.lib.boxc.services.camel.importxml.ImportXMLProcessor;
 
 /**
  * @author bbpennel
@@ -62,6 +62,8 @@ public class ImportXMLIT {
 
     private final static String UPDATED_TITLE = "Updated Work Title";
     private final static String UPDATED_DATE = "2018-04-06";
+
+    private AutoCloseable closeable;
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -99,7 +101,7 @@ public class ImportXMLIT {
 
     @Before
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         TestHelper.setContentBase(baseAddress);
 
@@ -116,6 +118,11 @@ public class ImportXMLIT {
         importXMLProcessor.setLocationManager(locationManager);
         when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
         when(updateCompleteTemplate.execute(any())).thenReturn("");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderNotificationServiceTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderNotificationServiceTest.java
@@ -10,8 +10,8 @@ import edu.unc.lib.boxc.operations.jms.order.MultiParentOrderRequest;
 import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isNull;
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.times;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.util.Arrays;
@@ -38,6 +39,7 @@ public class OrderNotificationServiceTest {
     private AgentPrincipals agent = new AgentPrincipalsImpl(USERNAME, new AccessGroupSetImpl("agroup"));
     private MultiParentOrderRequest request = new MultiParentOrderRequest();
     private OrderNotificationService orderNotificationService;
+    private AutoCloseable closeable;
 
     @Mock
     private EmailHandler emailHandler;
@@ -46,7 +48,7 @@ public class OrderNotificationServiceTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         request.setAgent(agent);
         request.setOperation(OrderOperationType.SET);
         parentPid1 = PIDs.get(PARENT1_UUID);
@@ -55,6 +57,12 @@ public class OrderNotificationServiceTest {
         orderNotificationService.setOrderNotificationBuilder(orderNotificationBuilder);
         orderNotificationService.setEmailHandler(emailHandler);
     }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
     @Test
     public void sendResultsSendsEmail() {
         when(orderNotificationBuilder.construct(any(), any(), any())).thenReturn("Hi there");

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/order/OrderRequestProcessorTest.java
@@ -17,14 +17,13 @@ import edu.unc.lib.boxc.operations.jms.order.OrderOperationType;
 import edu.unc.lib.boxc.operations.jms.order.OrderRequestSerializationHelper;
 import edu.unc.lib.boxc.services.camel.ProcessorTestHelper;
 import org.apache.camel.Exchange;
-import org.apache.camel.Message;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -58,6 +58,7 @@ public class OrderRequestProcessorTest {
     private static final String EMAIL = "user1@example.com";
     private PID parentPid1;
     private PID parentPid2;
+    private AutoCloseable closeable;
     @Mock
     private AccessControlService accessControlService;
     @Mock
@@ -82,7 +83,7 @@ public class OrderRequestProcessorTest {
 
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         processor = new OrderRequestProcessor();
         processor.setAccessControlService(accessControlService);
         processor.setOrderJobFactory(orderJobFactory);
@@ -94,6 +95,11 @@ public class OrderRequestProcessorTest {
         when(accessControlService.hasAccess(any(), any(), eq(Permission.orderMembers))).thenReturn(true);
         when(orderJobFactory.createJob(any())).thenReturn(orderJob);
         when(orderValidatorFactory.createValidator(any())).thenReturn(orderValidator);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/patronAccess/PatronAccessAssignmentRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/patronAccess/PatronAccessAssignmentRouterTest.java
@@ -7,13 +7,14 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.apache.camel.BeanInject;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.jgroups.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.context.support.AbstractApplicationContext;
@@ -37,6 +38,7 @@ import edu.unc.lib.boxc.operations.impl.acl.PatronAccessOperationSender;
 public class PatronAccessAssignmentRouterTest extends CamelSpringTestSupport {
     private static final String USER = "someone";
     private static final String PRINCIPALS = "my:special:group;everyone;authenticated";
+    private AutoCloseable closeable;
 
     @BeanInject(value = "patronAccessAssignmentService")
     private PatronAccessAssignmentService patronAccessAssignmentService;
@@ -49,7 +51,12 @@ public class PatronAccessAssignmentRouterTest extends CamelSpringTestSupport {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Override

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/CdrEventToSolrUpdateProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/CdrEventToSolrUpdateProcessorTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +26,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -47,6 +48,7 @@ public class CdrEventToSolrUpdateProcessorTest {
     private static final String USER_ID = "user_id";
 
     private CdrEventToSolrUpdateProcessor processor;
+    private AutoCloseable closeable;
 
     @Mock
     private IndexingMessageSender messageSender;
@@ -68,7 +70,7 @@ public class CdrEventToSolrUpdateProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         processor = new CdrEventToSolrUpdateProcessor();
         processor.setIndexingMessageSender(messageSender);
@@ -77,6 +79,11 @@ public class CdrEventToSolrUpdateProcessorTest {
 
         when(exchange.getIn()).thenReturn(msg);
         when(msg.getHeader(eq("name"))).thenReturn(USER_ID);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorIT.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -25,17 +25,14 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
 import edu.unc.lib.boxc.auth.fcrepo.services.InheritedAclFactory;
 import edu.unc.lib.boxc.fcrepo.utils.TransactionManager;
-import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.api.sparql.SparqlUpdateService;
 import edu.unc.lib.boxc.operations.api.events.PremisLoggerFactory;
 import edu.unc.lib.boxc.operations.impl.delete.MarkForDeletionJob;
-import edu.unc.lib.boxc.operations.impl.delete.MarkForDeletionService;
 import edu.unc.lib.boxc.operations.impl.destroy.DestroyObjectsJob;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
 import edu.unc.lib.boxc.operations.jms.destroy.DestroyObjectsRequest;
 import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
 import edu.unc.lib.boxc.operations.jms.order.MemberOrderRequestSender;
-import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.boxc.search.solr.services.ObjectPathFactory;
 import org.apache.commons.collections.CollectionUtils;
@@ -46,6 +43,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.fcrepo.client.FcrepoClient;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -68,7 +66,6 @@ import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDesc
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
-import edu.unc.lib.boxc.services.camel.solr.SolrIngestProcessor;
 
 /**
  *
@@ -78,6 +75,7 @@ import edu.unc.lib.boxc.services.camel.solr.SolrIngestProcessor;
 public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
     private SolrIngestProcessor processor;
+    private AutoCloseable closeable;
 
     private static final String CONTENT_TEXT = "Content";
     private static final String TEXT_EXTRACT = "Cone Tent";
@@ -118,7 +116,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("group"));
         TestHelper.setContentBase(baseAddress);
@@ -129,6 +127,11 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
         when(exchange.getIn()).thenReturn(message);
 
         generateBaseStructure();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessorTest.java
@@ -8,20 +8,19 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
-import edu.unc.lib.boxc.indexing.solr.SolrUpdateRequest;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
 import edu.unc.lib.boxc.model.api.rdf.Fcrepo4Repository;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.MessageSender;
-import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
 
 import edu.unc.lib.boxc.indexing.solr.exception.IndexingException;
@@ -33,7 +32,6 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
-import edu.unc.lib.boxc.services.camel.solr.SolrIngestProcessor;
 
 import java.util.UUID;
 
@@ -50,6 +48,7 @@ public class SolrIngestProcessorTest {
             "http://localhost:48085/rest/content/7c/73/29/6f/7c73296f-54ae-438e-b8d5-1890eba41676";
 
     private SolrIngestProcessor processor;
+    private AutoCloseable closeable;
 
     @Mock
     private DocumentIndexingPackageFactory dipFactory;
@@ -74,7 +73,7 @@ public class SolrIngestProcessorTest {
     @Before
     public void init() throws Exception {
         TestHelper.setContentBase(CONTENT_BASE_URI);
-        initMocks(this);
+        closeable = openMocks(this);
         processor = new SolrIngestProcessor(dipFactory, pipeline, solrUpdateDriver, repoObjLoader);
         processor.setUpdateWorkSender(messageSender);
 
@@ -84,6 +83,11 @@ public class SolrIngestProcessorTest {
 
         when(dip.getDocument()).thenReturn(docBean);
         when(dipFactory.createDip(any(PID.class))).thenReturn(dip);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateProcessorTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,6 +30,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -47,6 +48,7 @@ import edu.unc.lib.boxc.operations.jms.indexing.IndexingActionType;
  *
  */
 public class SolrUpdateProcessorTest {
+    private AutoCloseable closeable;
 
     private SolrUpdateProcessor processor;
 
@@ -74,7 +76,7 @@ public class SolrUpdateProcessorTest {
 
     @Before
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         indexingActionMap = new HashMap<>();
         indexingActionMap.put(ADD, mockAddAction);
@@ -90,6 +92,11 @@ public class SolrUpdateProcessorTest {
         when(msg.getBody()).thenReturn(bodyDoc);
 
         targetPid = ProcessorTestHelper.makePid();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -7,7 +7,7 @@ import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +72,7 @@ import edu.unc.lib.boxc.operations.jms.indexing.IndexingMessageSender;
 })
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class TriplesReindexingRouterIT {
+    private AutoCloseable closeable;
 
     @Autowired
     private CamelContext fcrepoTriplestoreIndexer;
@@ -115,7 +116,7 @@ public class TriplesReindexingRouterIT {
 
     @Before
     public void setUp() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         fusekiModel = createDefaultModel();
 
@@ -139,6 +140,7 @@ public class TriplesReindexingRouterIT {
 
     @After
     public void tearDown() throws Exception {
+        closeable.close();
         fusekiServer.stop();
     }
 

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessorTest.java
@@ -14,6 +14,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.mockito.Mock;
 
 import static org.mockito.Matchers.any;
@@ -22,7 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -31,6 +32,8 @@ public class CacheInvalidatingProcessorTest {
     private static final String FEDORA_BASE = "http://example.com/rest/";
     private static final String PID_UUID = "de75d811-9e0f-4b1f-8631-2060ab3580cc";
     private static final String PID_PATH = "/de/75/d8/11/" + PID_UUID;
+
+    private AutoCloseable closeable;
 
     @Mock
     private RepositoryObjectLoaderImpl repoObjLoader;
@@ -47,7 +50,7 @@ public class CacheInvalidatingProcessorTest {
 
     @Before
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         TestHelper.setContentBase(FEDORA_BASE);
         processor = new CacheInvalidatingProcessor();
         processor.setRepositoryObjectLoader(repoObjLoader);
@@ -55,6 +58,11 @@ public class CacheInvalidatingProcessorTest {
         processor.setContentPathFactory(contentPathFactory);
         processor.setTitleRetrievalService(titleRetrievalService);
         processor.setMemberOrderService(memberOrderService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProviderTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProviderTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author bbpennel
  */
 public class PatronPrincipalProviderTest {
+    private AutoCloseable closeable;
 
     @TempDir
     public Path tmpFolder;
@@ -53,7 +55,7 @@ public class PatronPrincipalProviderTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         provider = new PatronPrincipalProvider();
 
         configFile = tmpFolder.resolve("patronConfig.json").toFile();
@@ -79,6 +81,11 @@ public class PatronPrincipalProviderTest {
     private void serializeConfigAndInit() throws Exception {
         objectMapper.writeValue(configFile, patronConfig);
         provider.init();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilterTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilterTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +43,7 @@ import edu.unc.lib.boxc.web.common.auth.RemoteUserUtil;
 public class StoreUserAccessControlFilterTest {
 
     private StoreUserAccessControlFilter filter;
+    private AutoCloseable closeable;
 
     @Mock
     private HttpServletRequest request;
@@ -64,7 +65,7 @@ public class StoreUserAccessControlFilterTest {
 
     @BeforeEach
     public void init() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         configFile = tmpFolder.resolve("patronConfig.json").toFile();
         FileUtils.writeStringToFile(configFile, CONFIG, StandardCharsets.US_ASCII);
 
@@ -80,7 +81,8 @@ public class StoreUserAccessControlFilterTest {
     }
 
     @AfterEach
-    public void cleanup() {
+    public void cleanup() throws Exception {
+        closeable.close();
         GroupsThreadStore.clearStore();
     }
 

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/AccessCopiesServiceTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/AccessCopiesServiceTest.java
@@ -9,20 +9,12 @@ import edu.unc.lib.boxc.model.api.ResourceType;
 import edu.unc.lib.boxc.search.api.ContentCategory;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SearchRequest;
-import edu.unc.lib.boxc.search.api.requests.SearchState;
-import edu.unc.lib.boxc.search.solr.config.SearchSettings;
-import edu.unc.lib.boxc.search.solr.config.SolrSettings;
 import edu.unc.lib.boxc.search.solr.filters.NamedDatastreamFilter;
 import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
 import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
-import edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil;
-import edu.unc.lib.boxc.search.solr.utils.FacetFieldUtil;
-import org.apache.solr.client.solrj.SolrClient;
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.SolrDocumentList;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,7 +25,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.UUID;
 
 import static edu.unc.lib.boxc.auth.api.Permission.viewOriginal;
@@ -46,9 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author lfarrell
@@ -70,6 +60,8 @@ public class AccessCopiesServiceTest  {
 
     private AccessCopiesService accessCopiesService;
 
+    private AutoCloseable closeable;
+
     @Mock
     private AccessControlService accessControlService;
     @Mock
@@ -83,7 +75,7 @@ public class AccessCopiesServiceTest  {
 
     @BeforeEach
     public void init() throws IOException, SolrServerException {
-        initMocks(this);
+        closeable = openMocks(this);
 
         mdObject = createPdfObject(ResourceType.Work);
         mdObjectImg = createImgObject(ResourceType.Work);
@@ -107,6 +99,11 @@ public class AccessCopiesServiceTest  {
 
         when(solrSearchService.getSearchResults(searchRequestCaptor.capture())).thenReturn(searchResultResponse);
         when(searchResultResponse.getResultCount()).thenReturn(1l);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private ContentObjectSolrRecord createAudioObject(ResourceType resourceType) {

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/FindingAidUrlServiceTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/FindingAidUrlServiceTest.java
@@ -4,19 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-
-import edu.unc.lib.boxc.web.common.services.FindingAidUrlService;
 
 /**
  * @author bbpennel
@@ -24,6 +23,7 @@ import edu.unc.lib.boxc.web.common.services.FindingAidUrlService;
 public class FindingAidUrlServiceTest {
 
     private FindingAidUrlService service;
+    private AutoCloseable closeable;
 
     private static final String BASE_URL = "http://example.com/";
 
@@ -36,7 +36,7 @@ public class FindingAidUrlServiceTest {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         service = new FindingAidUrlService();
         service.setHttpClient(httpClient);
         service.setFindingAidBaseUrl(BASE_URL);
@@ -46,6 +46,11 @@ public class FindingAidUrlServiceTest {
 
         when(httpClient.execute(any(HttpHead.class))).thenReturn(httpResp);
         when(httpResp.getStatusLine()).thenReturn(statusLine);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/PermissionsHelperTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/PermissionsHelperTest.java
@@ -11,12 +11,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,12 +45,14 @@ public class PermissionsHelperTest {
 
     private AccessGroupSet principals;
 
+    private AutoCloseable closeable;
+
     @Mock
     private AccessControlService accessControlService;
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         roleGroups = new ArrayList<>();
 
@@ -65,6 +68,11 @@ public class PermissionsHelperTest {
 
         helper = new PermissionsHelper();
         helper.setAccessControlService(accessControlService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/StoreAccessLevelFilterTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/services/StoreAccessLevelFilterTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -22,12 +22,10 @@ import javax.servlet.http.HttpSession;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import edu.unc.lib.boxc.auth.api.AccessPrincipalConstants;
 import edu.unc.lib.boxc.auth.api.UserRole;
@@ -41,8 +39,8 @@ import edu.unc.lib.boxc.web.common.auth.filters.StoreAccessLevelFilter;
 /**
  * @author bbpennel
  */
-@ExtendWith(MockitoExtension.class)
 public class StoreAccessLevelFilterTest {
+    private AutoCloseable closeable;
     @Mock
     private HttpServletRequest request;
     @Mock
@@ -64,7 +62,7 @@ public class StoreAccessLevelFilterTest {
 
     @BeforeEach
     public void setup() {
-        initMocks(StoreAccessLevelFilterTest.class);
+        closeable = openMocks(StoreAccessLevelFilterTest.class);
         principals = new AccessGroupSetImpl();
         GroupsThreadStore.storeGroups(principals);
 
@@ -72,7 +70,8 @@ public class StoreAccessLevelFilterTest {
     }
 
     @AfterEach
-    public void tearDown() {
+    public void tearDown() throws Exception {
+        closeable.close();
         GroupsThreadStore.clearStore();
     }
 

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/SerializationUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/SerializationUtilTest.java
@@ -41,7 +41,6 @@ import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
  * @author bbpennel
  *
  */
-@ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class SerializationUtilTest extends Assertions {
     private static final List<String> DATASTREAMS =

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/AddContainerServiceTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/AddContainerServiceTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.impl.ModelCom;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -65,6 +66,7 @@ import edu.unc.lib.boxc.web.services.processing.AddContainerService.AddContainer
 public class AddContainerServiceTest {
 
     private static final String STORAGE_LOC_ID = "loc1";
+    private AutoCloseable closeable;
 
     @Mock
     private AccessControlService aclService;
@@ -107,7 +109,7 @@ public class AddContainerServiceTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        closeable = openMocks(this);
 
         when(agent.getPrincipals()).thenReturn(groups);
         when(agent.getUsername()).thenReturn("user");
@@ -141,6 +143,11 @@ public class AddContainerServiceTest {
         service.setStorageLocationManager(storageLocationManager);
         service.setUpdateDescriptionService(updateDescService);
         service.setPremisLoggerFactory(premisLoggerFactory);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     private AddContainerRequest createRequest(String label, boolean staffOnly, ResourceType containerType) {

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/MemberOrderCsvExporterTest.java
@@ -19,11 +19,11 @@ import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -41,6 +41,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  * @author bbpennel
@@ -54,6 +55,8 @@ public class MemberOrderCsvExporterTest {
     private static final String COLLECTION_UUID = "9cb6cc61-d88e-403e-b959-2396cd331a12";
     private static final String ADMIN_UNIT_UUID = "5158b962-9e59-4ed8-b920-fc948213efd3";
 
+    private AutoCloseable closeable;
+
     @Mock
     private SolrSearchService solrSearchService;
     @Mock
@@ -63,10 +66,15 @@ public class MemberOrderCsvExporterTest {
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.initMocks(this);
+        closeable = openMocks(this);
         csvService = new MemberOrderCsvExporter();
         csvService.setSolrSearchService(solrSearchService);
         csvService.setAclService(aclService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/SetAsPrimaryObjectServiceTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/processing/SetAsPrimaryObjectServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.Collection;
 import java.util.UUID;
@@ -74,7 +74,7 @@ public class SetAsPrimaryObjectServiceTest {
 
     @BeforeEach
     public void init() {
-        initMocks(this);
+        openMocks(this);
 
         fileObjPid = makePid();
         folderObjPid = makePid();

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/ItemInfoRestControllerIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/ItemInfoRestControllerIT.java
@@ -5,7 +5,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,14 +31,20 @@ import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
 
 @ContextConfiguration("/item-info-it-servlet.xml")
 public class ItemInfoRestControllerIT extends AbstractAPIIT {
+    private AutoCloseable closeable;
 
     @Autowired
     private SolrQueryLayerService solrSearchService;
 
     @BeforeEach
     public void setup() {
-        initMocks(this);
+        closeable = openMocks(this);
         reset(solrSearchService);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/RunEnhancementsIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/RunEnhancementsIT.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,6 +75,8 @@ public class RunEnhancementsIT extends AbstractAPIIT {
     private static final String USER_NAME = "user";
     private static final String ADMIN_GROUP = "adminGroup";
 
+    private AutoCloseable closeable;
+
     @Autowired
     private AccessControlServiceImpl aclServices;
     @Autowired
@@ -93,7 +96,7 @@ public class RunEnhancementsIT extends AbstractAPIIT {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         reset(messageSender);
 
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(ADMIN_GROUP);
@@ -106,6 +109,11 @@ public class RunEnhancementsIT extends AbstractAPIIT {
         when(queryLayer.performSearch(any(SearchRequest.class))).thenReturn(results);
 
         setupContentRoot();
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportXMLIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportXMLIT.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -58,6 +58,7 @@ public class ExportXMLIT extends AbstractAPIIT {
     private Connection conn;
     private Session session;
     private MessageConsumer consumer;
+    private AutoCloseable closeable;
     @Autowired
     private ExportXMLRequestService exportXmlRequestService;
     private PIDMinter pidMinter;
@@ -68,7 +69,7 @@ public class ExportXMLIT extends AbstractAPIIT {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         pidMinter = new RepositoryPIDMinter();
         ConnectionFactory connectionFactory = new ActiveMQConnectionFactory(
                 "vm://embedded-broker?create=false&waitForStart=5000");
@@ -98,6 +99,7 @@ public class ExportXMLIT extends AbstractAPIIT {
 
     @AfterEach
     public void shutdown() throws Exception {
+        closeable.close();
         consumer.close();
         session.close();
         conn.stop();

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/UpdateDescriptionIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/UpdateDescriptionIT.java
@@ -8,7 +8,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.util.Map;
 
 import org.apache.tika.io.IOUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -44,6 +45,7 @@ import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
     @ContextConfiguration("/update-description-it-servlet.xml")
 })
 public class UpdateDescriptionIT extends AbstractAPIIT {
+    private AutoCloseable closeable;
     @Mock
     private ContentPathFactory pathFactory;
     @Autowired
@@ -51,9 +53,14 @@ public class UpdateDescriptionIT extends AbstractAPIIT {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
 
         updateDescriptionService.setValidate(true);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/UpdatePatronAccessIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/UpdatePatronAccessIT.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -75,6 +75,7 @@ public class UpdatePatronAccessIT extends AbstractAPIIT {
 
     private AdminUnit adminUnit;
     private CollectionObject collObj;
+    private AutoCloseable closeable;
     @Autowired
     private JmsTemplate patronAccessOperationTemplate;
     @Autowired
@@ -85,7 +86,7 @@ public class UpdatePatronAccessIT extends AbstractAPIIT {
 
     @BeforeEach
     public void setup() throws Exception {
-        initMocks(this);
+        closeable = openMocks(this);
         reset(patronAccessOperationTemplate);
         reset(patronAccessOperationSender);
         AccessGroupSet testPrincipals = new AccessGroupSetImpl(USER_GROUPS);
@@ -98,6 +99,7 @@ public class UpdatePatronAccessIT extends AbstractAPIIT {
 
     @AfterEach
     public void teardown() throws Exception {
+        closeable.close();
         GroupsThreadStore.clearStore();
     }
 


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4290](https://unclibrary.atlassian.net/browse/BXC-4290)

- replace initMocks() with openMocks()
- add AutoCloseable instance variable and close the mocks
- removed unused imports
