### PR TITLE
Bxc 4082 thumbnail solr index

### DIFF
--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilter.java
@@ -53,6 +53,9 @@ public class SetContentStatusFilter implements IndexDocumentFilter{
             if (parentResc.hasProperty(Cdr.primaryObject, resc)) {
                 status.add(FacetConstants.IS_PRIMARY_OBJECT);
             }
+            if (parentResc.hasProperty(Cdr.useAsThumbnail, resc)) {
+                status.add(FacetConstants.IS_ASSIGNED_THUMBNAIL);
+            }
         }
 
         return status;
@@ -69,6 +72,12 @@ public class SetContentStatusFilter implements IndexDocumentFilter{
             status.add(FacetConstants.MEMBERS_ARE_ORDERED);
         } else {
             status.add(FacetConstants.MEMBERS_ARE_UNORDERED);
+        }
+
+        if (resource.hasProperty(Cdr.useAsThumbnail)) {
+            status.add(FacetConstants.THUMBNAIL_ASSIGNED);
+        } else {
+            status.add(FacetConstants.NO_THUMBNAIL_ASSIGNED);
         }
     }
 }

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilter.java
@@ -234,14 +234,7 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
             }
 
             String owner = (ownedByOtherObject ? pid.getId() : null);
-            String name = type.getId();
-            String mimetype = type.getMimetype();
-            String extension = type.getExtension();
-            File file = deriv.getFile();
-            Long filesize = file.length();
-            String filename = file.getName();
-            var derivative = new DatastreamImpl(owner, name, filesize, mimetype, filename, extension, null, null);
-            addDerivativeToList(dsList, derivative);
+            dsList.add(createDatastream(deriv, owner));
         });
     }
 
@@ -268,17 +261,19 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
      * @return modified list of datastreams without thumbnail datastreams
      */
     private List<Datastream> clearPreviousThumbnailDatastreams(List<Datastream> datastreams) {
-        for (Datastream datastream : datastreams) {
-            var type = DatastreamType.getByIdentifier(datastream.getName());
-            if (THUMBNAIL_DS_TYPES.contains(type)) {
-                datastreams.remove(datastream);
-            }
-        }
+        datastreams.removeIf(ds -> THUMBNAIL_DS_TYPES.contains(DatastreamType.getByIdentifier(ds.getName())));
         return datastreams;
     }
 
-    private void addDerivativeToList(List<Datastream> dsList, DatastreamImpl derivative) {
-        dsList.add(derivative);
+    private DatastreamImpl createDatastream(DerivativeService.Derivative derivative, String owner) {
+        DatastreamType type = derivative.getType();
+        String name = type.getId();
+        String mimetype = type.getMimetype();
+        String extension = type.getExtension();
+        File file = derivative.getFile();
+        Long filesize = file.length();
+        String filename = file.getName();
+        return new DatastreamImpl(owner, name, filesize, mimetype, filename, extension, null, null);
     }
 
     /**

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentStatusFilterTest.java
@@ -180,4 +180,42 @@ public class SetContentStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_UNORDERED));
         assertFalse(listCaptor.getValue().contains(FacetConstants.MEMBERS_ARE_ORDERED));
     }
+
+    @Test
+    public void testWorkWithAssignedThumbnail() throws Exception {
+        when(dip.getContentObject()).thenReturn(workObj);
+        when(workObj.getResource()).thenReturn(resc);
+        when(resc.hasProperty(Cdr.useAsThumbnail)).thenReturn(true);
+
+        filter.filter(dip);
+
+        verify(idb).setContentStatus(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(FacetConstants.THUMBNAIL_ASSIGNED));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.NO_THUMBNAIL_ASSIGNED));
+    }
+
+    @Test
+    public void testWorkNoAssignedThumbnail() throws Exception {
+        when(dip.getContentObject()).thenReturn(workObj);
+        when(workObj.getResource()).thenReturn(resc);
+
+        filter.filter(dip);
+
+        verify(idb).setContentStatus(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(FacetConstants.NO_THUMBNAIL_ASSIGNED));
+    }
+
+    @Test
+    public void testIsAssignedThumbnail() throws Exception {
+        when(workObj.getResource()).thenReturn(resc);
+        when(resc.hasProperty(Cdr.useAsThumbnail, fileResc)).thenReturn(true);
+
+        when(dip.getContentObject()).thenReturn(fileObj);
+        when(fileObj.getResource()).thenReturn(fileResc);
+
+        filter.filter(dip);
+
+        verify(idb).setContentStatus(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(FacetConstants.IS_ASSIGNED_THUMBNAIL));
+    }
 }

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
@@ -326,6 +326,18 @@ public class SetDatastreamFilterTest {
         when(fileObj.getPid()).thenReturn(filePid);
         when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
 
+        File smallFile = derivDir.resolve("small.png").toFile();
+        FileUtils.write(smallFile, "content", "UTF-8");
+        long smallSize = 7l;
+
+        File largeFile = derivDir.resolve("large.png").toFile();
+        FileUtils.write(smallFile, "content", "UTF-8");
+        long largeSize = 20l;
+
+        List<Derivative> derivs = Arrays.asList(new Derivative(THUMBNAIL_SMALL, smallFile),
+                new Derivative(THUMBNAIL_LARGE, largeFile));
+        when(derivativeService.getDerivatives(filePid)).thenReturn(derivs);
+
         dip.setContentObject(workObj);
         filter.filter(dip);
 
@@ -334,36 +346,45 @@ public class SetDatastreamFilterTest {
         assertNotNull(idb.getFilesizeTotal());
 
         assertContainsDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
-                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
+                smallSize, THUMBNAIL_SMALL.getMimetype(), smallFile.getName(), null, fileId, null);
+        assertContainsDatastream(idb.getDatastream(), THUMBNAIL_LARGE.getId(),
+                largeSize, THUMBNAIL_LARGE.getMimetype(), largeFile.getName(), null, fileId, null);
     }
 
-    @Test
-    public void workObjectTestWithPrimaryAndThumbnailObjects() throws Exception {
-        WorkObject workObj = mock(WorkObject.class);
-        when(workObj.getPrimaryObject()).thenReturn(fileObj);
-        when(workObj.getPid()).thenReturn(pid);
-        addMetadataDatastreams(workObj);
-
-        dip.setContentObject(workObj);
-
-        String fileId = "055ed112-f548-479e-ab4b-bf1aad40d470";
-        PID filePid = PIDs.get(fileId);
-        when(fileObj.getPid()).thenReturn(filePid);
-        when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
-
-        filter.filter(dip);
-
-        assertContainsDatastream(idb.getDatastream(), ORIGINAL_FILE.getId(),
-                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
-        assertContainsDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
-                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
-        assertContainsMetadataDatastreams(idb.getDatastream());
-
-        // Sort size is based off primary object's size
-        assertEquals(FILE_SIZE, (long) idb.getFilesizeSort());
-        // Work has no datastreams of its own
-        assertEquals(FILE2_SIZE + MODS_SIZE + PREMIS_SIZE, (long) idb.getFilesizeTotal());
-    }
+//    @Test
+//    public void workObjectTestWithPrimaryAndThumbnailObjects() throws Exception {
+//        WorkObject workObj = mock(WorkObject.class);
+//        FileObject thumbnailObj = mock(FileObject.class);
+//        when(workObj.getPrimaryObject()).thenReturn(fileObj);
+//        when(workObj.getThumbnailObject()).thenReturn(thumbnailObj);
+//        when(workObj.getPid()).thenReturn(pid);
+//        addMetadataDatastreams(workObj);
+//
+//        dip.setContentObject(workObj);
+//
+//        String fileId = "055ed112-f548-479e-ab4b-bf1aad40d470";
+//        PID filePid = PIDs.get(fileId);
+//        when(fileObj.getPid()).thenReturn(filePid);
+//
+//        String thumbnailId = "066ed112-f548-479e-ab4b-bf1aad40d678";
+//        PID thumbnailPid = PIDs.get(thumbnailId);
+//        when(thumbnailObj.getPid()).thenReturn(thumbnailPid);
+//
+//        when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
+//
+//        filter.filter(dip);
+//
+//        assertContainsDatastream(idb.getDatastream(), ORIGINAL_FILE.getId(),
+//                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
+//        assertContainsDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
+//                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, thumbnailId, null);
+//        assertContainsMetadataDatastreams(idb.getDatastream());
+//
+//        // Sort size is based off primary object's size
+//        assertEquals(FILE_SIZE, (long) idb.getFilesizeSort());
+//        // Work has no datastreams of its own
+//        assertEquals(FILE2_SIZE + MODS_SIZE + PREMIS_SIZE, (long) idb.getFilesizeTotal());
+//    }
 
     @Test
     public void folderObjectWithMetadataTest() throws Exception {

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
@@ -316,6 +316,56 @@ public class SetDatastreamFilterTest {
     }
 
     @Test
+    public void workObjectWithThumbnailNoPrimaryObjectTest() throws Exception {
+        WorkObject workObj = mock(WorkObject.class);
+        when(workObj.getThumbnailObject()).thenReturn(fileObj);
+        when(workObj.getPid()).thenReturn(pid);
+
+        String fileId = "055ed112-f548-479e-ab4b-bf1aad40d470";
+        PID filePid = PIDs.get(fileId);
+        when(fileObj.getPid()).thenReturn(filePid);
+        when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
+
+        dip.setContentObject(workObj);
+        filter.filter(dip);
+
+        assertNotNull(idb.getDatastream());
+        assertNull(idb.getFilesizeSort());
+        assertNotNull(idb.getFilesizeTotal());
+
+        assertContainsDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
+                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
+    }
+
+    @Test
+    public void workObjectTestWithPrimaryAndThumbnailObjects() throws Exception {
+        WorkObject workObj = mock(WorkObject.class);
+        when(workObj.getPrimaryObject()).thenReturn(fileObj);
+        when(workObj.getPid()).thenReturn(pid);
+        addMetadataDatastreams(workObj);
+
+        dip.setContentObject(workObj);
+
+        String fileId = "055ed112-f548-479e-ab4b-bf1aad40d470";
+        PID filePid = PIDs.get(fileId);
+        when(fileObj.getPid()).thenReturn(filePid);
+        when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
+
+        filter.filter(dip);
+
+        assertContainsDatastream(idb.getDatastream(), ORIGINAL_FILE.getId(),
+                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
+        assertContainsDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
+                FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId, null);
+        assertContainsMetadataDatastreams(idb.getDatastream());
+
+        // Sort size is based off primary object's size
+        assertEquals(FILE_SIZE, (long) idb.getFilesizeSort());
+        // Work has no datastreams of its own
+        assertEquals(FILE2_SIZE + MODS_SIZE + PREMIS_SIZE, (long) idb.getFilesizeTotal());
+    }
+
+    @Test
     public void folderObjectWithMetadataTest() throws Exception {
         FolderObject folderObj = mock(FolderObject.class);
         addMetadataDatastreams(folderObj);

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetDatastreamFilterTest.java
@@ -46,6 +46,7 @@ import static edu.unc.lib.boxc.model.api.DatastreamType.THUMBNAIL_SMALL;
 import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getOriginalFilePid;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -350,6 +351,7 @@ public class SetDatastreamFilterTest {
         PID filePid = PIDs.get(fileId);
         when(fileObj.getPid()).thenReturn(filePid);
         when(binObj.getPid()).thenReturn(getOriginalFilePid(filePid));
+        setUpDerivatives(filePid);
 
         // set up thumbnail file object
         FileObject thumbnailObj = mock(FileObject.class);
@@ -370,6 +372,11 @@ public class SetDatastreamFilterTest {
         assertEquals(FILE_SIZE, (long) idb.getFilesizeSort());
         // Work has no datastreams of its own
         assertEquals(FILE2_SIZE + MODS_SIZE + PREMIS_SIZE, (long) idb.getFilesizeTotal());
+
+        assertDoesNotContainDatastream(idb.getDatastream(), THUMBNAIL_SMALL.getId(),
+                7l, THUMBNAIL_SMALL.getMimetype(), "small.png", null, fileId, null);
+        assertDoesNotContainDatastream(idb.getDatastream(), THUMBNAIL_LARGE.getId(),
+                13l, THUMBNAIL_LARGE.getMimetype(), "large.png", null, fileId, null);
     }
 
     @Test
@@ -444,6 +451,17 @@ public class SetDatastreamFilterTest {
                 .map(c -> c == null ? "" : c.toString())
                 .collect(Collectors.joining("|"));
         assertTrue(values.contains(joined), "Did not contain datastream " + name);
+    }
+
+    private void assertDoesNotContainDatastream(List<String> values, String name, long filesize, String mimetype,
+                                          String filename, String digest, String owner, String extent) {
+        String extension = filename.substring(filename.lastIndexOf('.') + 1);
+        List<Object> components = Arrays.asList(
+                name, mimetype, filename, extension, filesize, digest, owner, extent);
+        String joined = components.stream()
+                .map(c -> c == null ? "" : c.toString())
+                .collect(Collectors.joining("|"));
+        assertFalse(values.contains(joined), "Contains datastream " + name);
     }
 
     private void addMetadataDatastreams(ContentObject obj) throws Exception {

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/objects/WorkObject.java
@@ -75,4 +75,11 @@ public interface WorkObject extends ContentContainerObject {
      * @return Ordered list of member ids, or an empty list if members aren't ordered.
      */
     List<PID> getMemberOrder();
+
+    /**
+     * Get the thumbnail object for this work if one is assigned, otherwise return null.
+     *
+     * @return
+     */
+    FileObject getThumbnailObject();
 }

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectImpl.java
@@ -103,7 +103,7 @@ public class WorkObjectImpl extends AbstractContentContainerObject implements Wo
      */
     @Override
     public FileObject getPrimaryObject() {
-        return getObject(Cdr.primaryObject);
+        return getFileObjectByProperty(Cdr.primaryObject);
     }
 
     @Override
@@ -205,10 +205,10 @@ public class WorkObjectImpl extends AbstractContentContainerObject implements Wo
 
     @Override
     public FileObject getThumbnailObject() {
-        return getObject(Cdr.useAsThumbnail);
+        return getFileObjectByProperty(Cdr.useAsThumbnail);
     }
 
-    private FileObject getObject(Property property) {
+    private FileObject getFileObjectByProperty(Property property) {
         Resource resource = getResource();
         // Find the object relation if it is present
         Statement stmt = resource.getProperty(property);

--- a/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
+++ b/model-fcrepo/src/test/java/edu/unc/lib/boxc/model/fcrepo/objects/WorkObjectTest.java
@@ -191,7 +191,7 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
     @Test
     public void getPrimaryObjectTest() {
         PID primaryPid = makePid();
-        Resource primaryResc = createResource(primaryPid.getURI());
+        Resource primaryResc = createResource(primaryPid.getRepositoryPath());
 
         when(driver.getRepositoryObject(eq(primaryPid), eq(FileObject.class))).thenReturn(fileObj);
 
@@ -294,6 +294,28 @@ public class WorkObjectTest extends AbstractFedoraObjectTest {
         var memberValue = member1.getId() + "|" + member2.getId() + "|" + member3.getId();
         resc.addProperty(Cdr.memberOrder, memberValue);
         assertEquals(members, work.getMemberOrder());
+    }
+
+    @Test
+    public void getThumbnailObjectTest() {
+        PID pid = makePid();
+        Resource resource = createResource(pid.getRepositoryPath());
+
+        when(driver.getRepositoryObject(eq(pid), eq(FileObject.class))).thenReturn(fileObj);
+
+        resc.addProperty(Cdr.useAsThumbnail, resource);
+
+        FileObject resultObj = work.getThumbnailObject();
+
+        assertEquals(resultObj, fileObj);
+    }
+
+    @Test
+    public void getNoThumbnailObjectTest() {
+        FileObject resultObj = work.getThumbnailObject();
+
+        assertNull(resultObj);
+        verify(driver, never()).getRepositoryObject(any(PID.class), eq(FileObject.class));
     }
 
     private PID makePid() {

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/FacetConstants.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/FacetConstants.java
@@ -23,4 +23,8 @@ public abstract class FacetConstants {
     public static final String STAFF_ONLY_ACCESS = "Staff-Only Access";
     public static final String MEMBERS_ARE_ORDERED = "Members Are Ordered";
     public static final String MEMBERS_ARE_UNORDERED = "Members Are Unordered";
+    public static final String THUMBNAIL_ASSIGNED = "Has Assigned Thumbnail";
+    public static final String NO_THUMBNAIL_ASSIGNED = "No Assigned Thumbnail";
+    public static final String IS_ASSIGNED_THUMBNAIL = "Is Assigned Thumbnail";
+
 }

--- a/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -80,6 +80,7 @@
             <list>
                 <ref bean="setRecordDatesFilter" />
                 <ref bean="setDatastreamFilter" />
+                <ref bean="setContentStatusFilter" />
             </list>
         </property>
     </bean>

--- a/services-camel-app/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel-app/src/test/resources/solr-indexing-it-context.xml
@@ -64,6 +64,7 @@
             <list>
                 <ref bean="setRecordDatesFilter" />
                 <ref bean="setDatastreamFilter" />
+                <ref bean="setContentStatusFilter" />
             </list>
         </property>
     </bean>


### PR DESCRIPTION
This PR allows the assigned thumbnail to be indexed in solr for a work. If the content object is a work object, it looks to see if there is a thumbnail object relation. if there is, then it selectively adds the thumbnail streams of the assigned file object to the work object's datastreams.

https://unclibrary.atlassian.net/browse/BXC-4082