### PR TITLE
BXC-4348 - Update AMQ for CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,8 @@
         <commons-fileupload.version>1.5</commons-fileupload.version>
         <abdera.version>1.1.3</abdera.version>
         
-        <activemq.version>5.16.3</activemq.version>
+        <activemq.version>5.17.6</activemq.version>
+        <activemq-camel.version>5.16.7</activemq-camel.version>
         <activemq-protobuf.version>1.1</activemq-protobuf.version>
         
         <slf4j.version>1.7.25</slf4j.version>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-camel</artifactId>
-        <version>${activemq.version}</version>
+        <version>${activemq-camel.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4348

Update to activemq 5.17.6, and activemq-camel to 5.16.7 (the newest available version) to match version on server and resolve CVE