### PR TITLE
Update Matomo Java Tracker Dependency to Version 3.0.3

### DIFF
--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -222,7 +222,7 @@
       <dependency>
           <groupId>org.piwik.java.tracking</groupId>
           <artifactId>matomo-java-tracker</artifactId>
-          <version>2.0</version>
+          <version>3.0.2</version>
       </dependency>
   </dependencies>
 </project>

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -222,7 +222,7 @@
       <dependency>
           <groupId>org.piwik.java.tracking</groupId>
           <artifactId>matomo-java-tracker</artifactId>
-          <version>3.0.2</version>
+          <version>3.0.3</version>
       </dependency>
   </dependencies>
 </project>

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.web.common.utils;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +20,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.matomo.java.tracking.MatomoTracker;
+import org.matomo.java.tracking.TrackerConfiguration;
+import org.matomo.java.tracking.parameters.VisitorId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.matomo.java.tracking.MatomoRequest;
@@ -115,9 +118,9 @@ public class AnalyticsTrackerUtil {
     }
 
     private MatomoRequest buildMatomoRequest(String url, AnalyticsUserData userData, String parentCollection, String label) throws UnsupportedEncodingException {
-        return MatomoRequest.builder()
+        return MatomoRequest.request()
                 .siteId(matomoSiteID)
-                .visitorId(userData.uid)
+                .visitorId(VisitorId.fromHex(userData.uid))
                 .actionUrl(url)
                 .actionName(parentCollection + " / " + MATOMO_ACTION)
                 .eventCategory(parentCollection)
@@ -130,7 +133,10 @@ public class AnalyticsTrackerUtil {
     }
 
     private void sendMatomoRequest(MatomoRequest matomoRequest) {
-        var tracker = new MatomoTracker(matomoApiURL);
+        var tracker = new MatomoTracker(TrackerConfiguration
+                .builder()
+                .apiEndpoint(URI.create(matomoApiURL))
+                .build());
 
         try {
             tracker.sendRequestAsync(matomoRequest);


### PR DESCRIPTION
### Hey @bbpennel and team,

Just wanted to give our project a little boost with the latest and greatest from Matomo Java Tracker! 🚀

### Changes in a Nutshell:

- **Bug Fixes & Performance Boosts:** Say goodbye to some pesky bugs and enjoy a faster, smoother tracking experience.

- **Security Makeover:** We're getting the latest security swag to keep our project locked down.

- **Stay Cool with Compatibility:** Now we're best buddies with Matomo versions up to 5, so no more awkward compatibility issues.

- **Less Baggage:** Matomo Java Tracker 3.0.3 is lean and mean with fewer dependencies. Less stuff, more speed!

- **New Toys:** Check out the cool new dimension parameter for super-customizable tracking.

- **Java 11 Party:** We're upgrading to the latest Java 11 implementation. It's like giving our project a cool new set of wheels.

- **Smooth Moves:** If you're coming from version 2, no worries! There's a handy migration guide [here](https://github.com/matomo-org/matomo-java-tracker#migration-from-version-2-to-302) to make the switch painless.

### How to Test:

1. Update to Matomo Java Tracker version 3.0.3.
2. Make sure our project still builds like a champ.
3. Double-check that our Matomo tracking mojo is still on point.
4. Test out any new features and give that dimension parameter a spin.

### Where to Get Help:

- Dive into the [Javadoc](https://javadoc.io/doc/org.piwik.java.tracking/matomo-java-tracker-core/3.0.3/index.html) for the nitty-gritty details.
- Got issues or bright ideas? Hit up the [Matomo Java Tracker GitHub](https://github.com/matomo-org/matomo-java-tracker).

### Your Feedback Matters:

Give it a whirl and let us know how it goes! Your feedback is like gold to us. 🌟

Cheers,
Daniel
