### PR TITLE
Bxc 4375 refactor image server proxy

### DIFF
--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/DownloadImageService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/DownloadImageService.java
@@ -1,6 +1,5 @@
 
 package edu.unc.lib.boxc.web.services.processing;
-import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
 
 import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
@@ -16,6 +15,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Objects;
+
+import static edu.unc.lib.boxc.web.services.utils.ImageServerUtil.FULL_SIZE;
 
 /**
  * Service to process access copy image downloads
@@ -60,7 +61,7 @@ public class DownloadImageService {
      * @return validated size string
      */
     public String getSize(ContentObjectRecord contentObjectRecord, String size) {
-        if (!Objects.equals(size, ImageServerUtil.FULL_SIZE)) {
+        if (!Objects.equals(size, FULL_SIZE)) {
             try {
                 var integerSize = Integer.parseInt(size);
 
@@ -74,7 +75,7 @@ public class DownloadImageService {
                     int longerSide = Math.max(Integer.parseInt(dimensionParts[0]), Integer.parseInt(dimensionParts[1]));
                     // request is bigger than or equal to full size, so we will switch to full size
                     if (integerSize >= longerSide) {
-                        return ImageServerUtil.FULL_SIZE;
+                        return FULL_SIZE;
                     }
                 }
             } catch (Exception e) {
@@ -92,7 +93,7 @@ public class DownloadImageService {
      * @return a filename for the download like "filename_full.jpg" or "filename_800px.jpg
      */
     public String getDownloadFilename(ContentObjectRecord contentObjectRecord, String size) {
-        var formattedSize = Objects.equals(size, ImageServerUtil.FULL_SIZE) ?  ImageServerUtil.FULL_SIZE : size + "px";
+        var formattedSize = Objects.equals(size, FULL_SIZE) ?  FULL_SIZE : size + "px";
 
         var originalFilename = getDatastream(contentObjectRecord).getFilename();
         var nameOnly = FilenameUtils.removeExtension(originalFilename);

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/ImageServerProxyService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/ImageServerProxyService.java
@@ -79,12 +79,10 @@ public class ImageServerProxyService {
     public ResponseEntity<InputStreamResource> streamJP2(String id, String region, String size, String rotation,
                                                          String quality, String format) throws IOException {
 
-        StringBuilder path = new StringBuilder(getImageServerProxyBasePath());
-        path.append(ImageServerUtil.getImageServerEncodedId(id))
-                .append("/" + region).append("/" + size)
-                .append("/" + rotation).append("/" + quality + "." + format);
+        String path = getImageServerProxyBasePath() + ImageServerUtil.getImageServerEncodedId(id) +
+                "/" + region + "/" + size + "/" + rotation + "/" + quality + "." + format;
 
-        InputStream input = new URL(path.toString()).openStream();
+        InputStream input = new URL(path).openStream();
         InputStreamResource resource = new InputStreamResource(input);
 
         return ResponseEntity.ok()

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DownloadImageController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DownloadImageController.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
 import edu.unc.lib.boxc.web.common.services.SolrQueryLayerService;
 import edu.unc.lib.boxc.web.services.processing.DownloadImageService;
+import edu.unc.lib.boxc.web.services.utils.ImageServerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,7 @@ public class DownloadImageController {
         var contentObjectRecord = solrSearchService.getObjectById(new SimpleIdRequest(pid, principals));
         String validatedSize = downloadImageService.getSize(contentObjectRecord, size);
 
-        if (Objects.equals(validatedSize, DownloadImageService.FULL_SIZE)) {
+        if (Objects.equals(validatedSize, ImageServerUtil.FULL_SIZE)) {
             aclService.assertHasAccess("Insufficient permissions to download full size copy for " + pidString,
                     pid, principals, Permission.viewOriginal);
         }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
@@ -40,9 +40,8 @@ public class ImageServerProxyController {
 
     /**
      * Determines if the user is allowed to access a JP2 datastream on the selected object.
-     *
-     * @param pid
-     * @return
+     * @param pid PID of the object
+     * @return true if user is allowed, false if not
      */
     private boolean hasAccess(PID pid) {
         var datastream = JP2_ACCESS_COPY.getId();
@@ -59,7 +58,7 @@ public class ImageServerProxyController {
      * Handles requests for individual region tiles.
      * @param id
      * @param region
-     * @param size
+     * @param size pixel size or max for full size
      * @param rotation
      * @param qualityFormat
      */
@@ -90,8 +89,7 @@ public class ImageServerProxyController {
 
     /**
      * Handles requests for jp2 metadata
-     *
-     * @param id
+     * @param id ID of the object
      */
     @CrossOrigin
     @GetMapping(value ="/iiif/v3/{id}/info.json", produces = APPLICATION_JSON_VALUE)

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
@@ -77,8 +77,7 @@ public class ImageServerProxyController {
                 String[] qualityFormatArray = qualityFormat.split("\\.");
                 String quality = qualityFormatArray[0];
                 String format = qualityFormatArray[1];
-                return imageServerProxyService.streamJP2(
-                        id, region, size, rotation, quality, format, 1);
+                return imageServerProxyService.streamJP2(id, region, size, rotation, quality, format);
             } catch (IOException e) {
                 LOG.error("Error retrieving streaming JP2 content for {}", id, e);
                 return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -100,14 +99,13 @@ public class ImageServerProxyController {
         PID pid = PIDs.get(id);
         // Check if the user is allowed to view this object
         if (this.hasAccess(pid)) {
-//        try {
-            var metadata = imageServerProxyService.getMetadata(id);
-            return new ResponseEntity<>(metadata, HttpStatus.OK);
-//        } catch (IOException e) {
-//            LOG.error("Error retrieving JP2 metadata content for {}", id, e);
-//            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-//        }
-//        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            try {
+                var metadata = imageServerProxyService.getMetadata(id);
+                return new ResponseEntity<>(metadata, HttpStatus.OK);
+            } catch (IOException e) {
+                LOG.error("Error retrieving JP2 metadata content for {}", id, e);
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         } else {
             LOG.debug("Access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
             return new ResponseEntity<>(HttpStatus.FORBIDDEN);

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
@@ -1,6 +1,7 @@
 package edu.unc.lib.boxc.web.services.rest;
 
 import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.auth.api.services.DatastreamPermissionUtil;
@@ -8,20 +9,26 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
 import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.web.common.controllers.AbstractSolrSearchController;
 import edu.unc.lib.boxc.web.services.processing.ImageServerProxyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static edu.unc.lib.boxc.model.api.DatastreamType.JP2_ACCESS_COPY;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**
  * Controller that handles IIIF V3 requests to the image server
@@ -61,13 +68,13 @@ public class ImageServerProxyController {
      * @param size
      * @param rotation
      * @param qualityFormat
-     * @param response
      */
+    @CrossOrigin
     @GetMapping("/iiif/v3/{id}/{region}/{size}/{rotation}/{qualityFormat:.+}")
-    public void getRegion(@PathVariable("id") String id,
+    public ResponseEntity<InputStreamResource> getRegion(@PathVariable("id") String id,
                           @PathVariable("region") String region,
                           @PathVariable("size") String size, @PathVariable("rotation") String rotation,
-                          @PathVariable("qualityFormat") String qualityFormat, HttpServletResponse response) {
+                          @PathVariable("qualityFormat") String qualityFormat) {
 
         PID pid = PIDs.get(id);
         // Check if the user is allowed to view this object
@@ -76,19 +83,35 @@ public class ImageServerProxyController {
                 String[] qualityFormatArray = qualityFormat.split("\\.");
                 String quality = qualityFormatArray[0];
                 String format = qualityFormatArray[1];
-                response.addHeader("Access-Control-Allow-Origin", "*");
-                imageServerProxyService.streamJP2(
-                        id, region, size, rotation, quality, format,
-                        response.getOutputStream(), response, 1);
+                return imageServerProxyService.streamJP2(
+                        id, region, size, rotation, quality, format, 1);
             } catch (IOException e) {
                 LOG.error("Error retrieving streaming JP2 content for {}", id, e);
-                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } else {
             LOG.debug("Access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
-            response.setStatus(HttpStatus.FORBIDDEN.value());
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
         }
     }
+
+//    @GetMapping("/iiif/v3/{id}/info.json")
+//    public void getMetadata(@PathVariable("id") String id, HttpServletResponse response) {
+//        PID pid = PIDs.get(id);
+//        // Check if the user is allowed to view this object
+//        if (this.hasAccess(pid)) {
+//            try {
+//                response.addHeader("Access-Control-Allow-Origin", "*");
+//                imageServerProxyService.getMetadata(id, response.getOutputStream(), response, 1);
+//            } catch (IOException e) {
+//                LOG.error("Error retrieving JP2 metadata content for {}", id, e);
+//                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+//            }
+//        } else {
+//            LOG.debug("Image access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
+//            response.setStatus(HttpStatus.FORBIDDEN.value());
+//        }
+//    }
 
     /**
      * Handles requests for jp2 metadata
@@ -96,21 +119,21 @@ public class ImageServerProxyController {
      * @param id
      * @param response
      */
-    @GetMapping("/iiif/v3/{id}/info.json")
-    public void getMetadata(@PathVariable("id") String id, HttpServletResponse response) {
-        PID pid = PIDs.get(id);
-        // Check if the user is allowed to view this object
-        if (this.hasAccess(pid)) {
-            try {
-                response.addHeader("Access-Control-Allow-Origin", "*");
-                imageServerProxyService.getMetadata(id, response.getOutputStream(), response, 1);
-            } catch (IOException e) {
-                LOG.error("Error retrieving JP2 metadata content for {}", id, e);
-                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
-            }
-        } else {
-            LOG.debug("Image access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
-            response.setStatus(HttpStatus.FORBIDDEN.value());
-        }
-    }
+//    @CrossOrigin
+//    @GetMapping("/iiif/v3/{id}/info.json", produces = APPLICATION_JSON_VALUE)
+//    public ResponseEntity<InputStreamResource> getMetadata(@PathVariable("id") String id) {
+//        PID pid = PIDs.get(id);
+//        // Check if the user is allowed to view this object
+//        AgentPrincipals agent = AgentPrincipalsImpl.createFromThread();
+//        AccessGroupSet principals = agent.getPrincipals();
+//        accessControlService.assertHasAccess("Insufficient permissions to download access copy for " + id,
+//                pid, principals, Permission.viewAccessCopies);
+//        try {
+//            return imageServerProxyService.getMetadata(id, 1);
+//        } catch (IOException e) {
+//            LOG.error("Error retrieving JP2 metadata content for {}", id, e);
+//            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+//        }
+//        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+//    }
 }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.web.services.rest;
 
 import edu.unc.lib.boxc.auth.api.Permission;
-import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.auth.api.services.DatastreamPermissionUtil;
@@ -14,17 +13,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.ResponseBody;
-
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import static edu.unc.lib.boxc.model.api.DatastreamType.JP2_ACCESS_COPY;
@@ -95,45 +89,28 @@ public class ImageServerProxyController {
         }
     }
 
-//    @GetMapping("/iiif/v3/{id}/info.json")
-//    public void getMetadata(@PathVariable("id") String id, HttpServletResponse response) {
-//        PID pid = PIDs.get(id);
-//        // Check if the user is allowed to view this object
-//        if (this.hasAccess(pid)) {
-//            try {
-//                response.addHeader("Access-Control-Allow-Origin", "*");
-//                imageServerProxyService.getMetadata(id, response.getOutputStream(), response, 1);
-//            } catch (IOException e) {
-//                LOG.error("Error retrieving JP2 metadata content for {}", id, e);
-//                response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
-//            }
-//        } else {
-//            LOG.debug("Image access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
-//            response.setStatus(HttpStatus.FORBIDDEN.value());
-//        }
-//    }
-
     /**
      * Handles requests for jp2 metadata
      *
      * @param id
-     * @param response
      */
-//    @CrossOrigin
-//    @GetMapping("/iiif/v3/{id}/info.json", produces = APPLICATION_JSON_VALUE)
-//    public ResponseEntity<InputStreamResource> getMetadata(@PathVariable("id") String id) {
-//        PID pid = PIDs.get(id);
-//        // Check if the user is allowed to view this object
-//        AgentPrincipals agent = AgentPrincipalsImpl.createFromThread();
-//        AccessGroupSet principals = agent.getPrincipals();
-//        accessControlService.assertHasAccess("Insufficient permissions to download access copy for " + id,
-//                pid, principals, Permission.viewAccessCopies);
+    @CrossOrigin
+    @GetMapping(value ="/iiif/v3/{id}/info.json", produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<Object> getMetadata(@PathVariable("id") String id) {
+        PID pid = PIDs.get(id);
+        // Check if the user is allowed to view this object
+        if (this.hasAccess(pid)) {
 //        try {
-//            return imageServerProxyService.getMetadata(id, 1);
+            var metadata = imageServerProxyService.getMetadata(id);
+            return new ResponseEntity<>(metadata, HttpStatus.OK);
 //        } catch (IOException e) {
 //            LOG.error("Error retrieving JP2 metadata content for {}", id, e);
 //            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 //        }
 //        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-//    }
+        } else {
+            LOG.debug("Access was forbidden to {} for user {}", id, GroupsThreadStore.getUsername());
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+        }
+    }
 }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyController.java
@@ -51,7 +51,7 @@ public class ImageServerProxyController {
         PID pid = PIDs.get(id);
         // Check if the user is allowed to view this object
         AccessGroupSet principals = getAgentPrincipals().getPrincipals();
-        accessControlService.assertHasAccess("Insufficient permissions to metadata for " + id,
+        accessControlService.assertHasAccess("Insufficient permissions to get a region for " + id,
                 pid, principals, Permission.viewAccessCopies);
 
         try {
@@ -75,7 +75,7 @@ public class ImageServerProxyController {
         PID pid = PIDs.get(id);
         // Check if the user is allowed to view this object
         AccessGroupSet principals = getAgentPrincipals().getPrincipals();
-        accessControlService.assertHasAccess("Insufficient permissions to metadata for " + id,
+        accessControlService.assertHasAccess("Insufficient permissions to get metadata for " + id,
                 pid, principals, Permission.viewAccessCopies);
 
         try {

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/utils/ImageServerUtil.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/utils/ImageServerUtil.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.web.services.utils;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
 
@@ -9,6 +10,7 @@ import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
  * @author snluong
  */
 public class ImageServerUtil {
+    public static final String FULL_SIZE = "max";
     /**
      * Returns the object ID in proper encoded format with .jp2 extension
      * @param id
@@ -18,5 +20,22 @@ public class ImageServerUtil {
         var idPathEncoded = URLEncoder.encode(idToPath(id, 4, 2), StandardCharsets.UTF_8);
         var idEncoded = URLEncoder.encode(id, StandardCharsets.UTF_8);
         return idPathEncoded + idEncoded + ".jp2";
+    }
+
+    /**
+     * A method that builds the IIIF URL based on an assumption of full region, 0 rotation, and default quality.
+     * @param basePath iiif V3 base path
+     * @param id the UUID of the file
+     * @param size a string which is either "max" for full size or a pixel length like "1200"
+     * @return a string which is the URL to request the IIIF server for the image
+     */
+    public static String buildURL(String basePath, String id, String size) {
+        var formattedSize = size;
+        var formattedId = getImageServerEncodedId(id);
+        if (!Objects.equals(size, FULL_SIZE)) {
+            // pixel length should be in !123,123 format
+            formattedSize = "!" + size + "," + size;
+        }
+        return basePath + formattedId + "/full/" + formattedSize + "/0/default.jpg";
     }
 }

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/ImageServerProxyControllerTest.java
@@ -2,21 +2,14 @@ package edu.unc.lib.boxc.web.services.rest;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import edu.unc.lib.boxc.auth.api.Permission;
-import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
-import edu.unc.lib.boxc.web.services.processing.ImageServerProxyService;
 import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
 import edu.unc.lib.boxc.web.services.utils.ImageServerUtil;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
@@ -24,10 +17,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MvcResult;
 
-import java.io.IOException;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.jsonResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,9 +37,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ImageServerProxyControllerTest extends AbstractAPIIT {
     @Autowired
     private AccessControlService accessControlService;
-
-    @Mock
-    private CloseableHttpClient httpClient;
     private AutoCloseable closeable;
 
     @BeforeEach


### PR DESCRIPTION
This PR adds new tests and refactors the image server proxy code to more clearly separate the controller and service. This also affected some downloadImage code to use new Util code.
https://unclibrary.atlassian.net/browse/BXC-4375