### PR TITLE
BXC-4327 only allow export member order for work objects

### DIFF
--- a/static/js/admin/src/ResultObjectActionMenu.js
+++ b/static/js/admin/src/ResultObjectActionMenu.js
@@ -203,7 +203,9 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 				items['export']['items']["exportCSV"] = {name: "Export CSV"};
 			}
 
-			items['export']['items']["exportMemberOrder"] = {name: "Export Member Order"};
+			if (metadata.type === 'Work') {
+				items['export']['items']["exportMemberOrder"] = {name: "Export Member Order"};
+			}
 		}
 
 		items["copyid"] = {name : 'Copy PID to Clipboard'};


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4327](https://unclibrary.atlassian.net/browse/BXC-4327)

update to only allow export member order option for work objects