### PR TITLE
BXC-3390 - Skip MODS updates when content is unmodified

### DIFF
--- a/operations/src/main/java/edu/unc/lib/boxc/operations/api/exceptions/StateUnmodifiedException.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/api/exceptions/StateUnmodifiedException.java
@@ -1,0 +1,14 @@
+package edu.unc.lib.boxc.operations.api.exceptions;
+
+/**
+ * Exception thrown when an operation is skipped due to the incoming state being the same as the existing state.
+ *
+ * @author bbpennel
+ */
+public class StateUnmodifiedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public StateUnmodifiedException(String message) {
+        super(message);
+    }
+}

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionService.java
@@ -116,6 +116,7 @@ public class UpdateDescriptionService {
             newVersion.setFilename(MD_DESCRIPTIVE.getDefaultFilename());
             newVersion.setTransferSession(request.getTransferSession());
             newVersion.setUnmodifiedSince(request.getUnmodifiedSince());
+            newVersion.setSkipUnmodified(true);
 
             BinaryObject descBinary;
             if (repoObjFactory.objectExists(modsDsPid.getRepositoryUri())) {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJob.java
@@ -31,6 +31,7 @@ import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
 import edu.unc.lib.boxc.fcrepo.exceptions.OptimisticLockException;
+import edu.unc.lib.boxc.operations.api.exceptions.StateUnmodifiedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -357,7 +358,7 @@ public class ImportXMLJob implements Runnable {
                                             "Error reading or converting MODS stream: " + ex.getMessage());
                                 } catch (NotFoundException ex) {
                                     failed.put(currentPid.getQualifiedId(), "Object not found");
-                                } catch (OptimisticLockException ex) {
+                                } catch (StateUnmodifiedException | OptimisticLockException ex) {
                                     failed.put(currentPid.getQualifiedId(), ex.getMessage());
                                 } catch (FedoraException ex) {
                                     failed.put(currentPid.getQualifiedId(),

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -74,9 +74,8 @@ public class VersionedDatastreamService {
                 log.debug("Adding head version for datastream {}", dsPid);
                 return updateHeadVersion(newVersion, session);
             } else {
-                if (skipUpdateDueToUnmodifiedContent(dsObj, newVersion)) {
-                    return dsObj;
-                }
+                checkForUnmodifiedContent(dsObj, newVersion);
+
                 log.debug("Adding history and head version for datastream {}", dsPid);
                 // Datastream already exists
                 // Add the current head version to the history log
@@ -115,10 +114,10 @@ public class VersionedDatastreamService {
         }
     }
 
-    // Returns true if the new content is the same as the old and isSkipUnmodified is true.
-    private boolean skipUpdateDueToUnmodifiedContent(BinaryObject dsObj, DatastreamVersion newVersion) {
+    // Throws a StateUnmodifiedException if the new content is the same as the old and isSkipUnmodified is true.
+    private void checkForUnmodifiedContent(BinaryObject dsObj, DatastreamVersion newVersion) {
         if (!newVersion.isSkipUnmodified()) {
-            return false;
+            return;
         }
         var oldSha1 = StringUtils.substringAfterLast(dsObj.getSha1Checksum(), ":");
         var newSha1 = InputStreamDigestUtil.computeDigest(newVersion.getContentStream());
@@ -134,7 +133,6 @@ public class VersionedDatastreamService {
                 throw new ServiceException("Invalid content stream, must support reset when skipping unmodified", e);
             }
         }
-        return false;
     }
 
     /**

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -260,10 +260,6 @@ public class VersionedDatastreamService {
         this.transactionManager = transactionManager;
     }
 
-    public static enum DatastreamVersioningOption {
-        SKIP_UNMODIFIED
-    }
-
     /**
      * Details of a datastream version
      *

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -124,7 +124,7 @@ public class VersionedDatastreamService {
         var newSha1 = InputStreamDigestUtil.computeDigest(newVersion.getContentStream());
         if (newSha1.equals(oldSha1)) {
             throw new StateUnmodifiedException(
-                    "Old version and new version of " + dsObj.getPid() + " are the same.");
+                    "Old version and new version of " + dsObj.getPid().getQualifiedId() + " are the same.");
         } else {
             log.debug("Continuing with update of {}, content has changed", dsObj.getPid());
             try {

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamService.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.concurrent.locks.Lock;
 
 import edu.unc.lib.boxc.fcrepo.exceptions.OptimisticLockException;
+import edu.unc.lib.boxc.operations.api.exceptions.StateUnmodifiedException;
 import edu.unc.lib.boxc.persist.impl.InputStreamDigestUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
@@ -122,8 +123,8 @@ public class VersionedDatastreamService {
         var oldSha1 = StringUtils.substringAfterLast(dsObj.getSha1Checksum(), ":");
         var newSha1 = InputStreamDigestUtil.computeDigest(newVersion.getContentStream());
         if (newSha1.equals(oldSha1)) {
-            log.debug("Skipping update of {}, old version and new version have the same digest", dsObj.getPid());
-            return true;
+            throw new StateUnmodifiedException(
+                    "Old version and new version of " + dsObj.getPid() + " are the same.");
         } else {
             log.debug("Continuing with update of {}, content has changed", dsObj.getPid());
             try {

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceIT.java
@@ -9,12 +9,14 @@ import static edu.unc.lib.boxc.operations.test.ModsTestHelper.modsWithTitleAndDa
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import edu.unc.lib.boxc.operations.api.exceptions.StateUnmodifiedException;
 import edu.unc.lib.boxc.operations.impl.versioning.DatastreamHistoryLog;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -117,7 +119,9 @@ public class UpdateDescriptionServiceIT {
 
         addDescription(folderObj, "new title", "2018-04-06");
         // Perform a second update with the exact same content
-        addDescription(folderObj, "new title", "2018-04-06");
+        assertThrows(StateUnmodifiedException.class, () -> {
+            addDescription(folderObj, "new title", "2018-04-06");
+        });
 
         // Update should have been skipped, so no history datastream
         List<BinaryObject> mdBins = folderObj.listMetadata();
@@ -134,7 +138,9 @@ public class UpdateDescriptionServiceIT {
         addDescription(folderObj, "new title", "2018-04-06");
         addDescription(folderObj, "updated title", "2018-04-08");
         // Perform a third update with the exact same content
-        addDescription(folderObj, "updated title", "2018-04-08");
+        assertThrows(StateUnmodifiedException.class, () -> {
+            addDescription(folderObj, "updated title", "2018-04-08");
+        });
 
         // History should be present, but only have one entry in it
         List<BinaryObject> mdBins = folderObj.listMetadata();

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceIT.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.List;
 
 import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.operations.api.exceptions.StateUnmodifiedException;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -313,8 +314,9 @@ public class VersionedDatastreamServiceIT {
         newV2.setContentType("text/xml");
         newV2.setSkipUnmodified(true);
 
-        BinaryObject dsObj2 = service.addVersion(newV2);
-        assertEquals(dsObj.getLastModified(), dsObj2.getLastModified());
+        assertThrows(StateUnmodifiedException.class, () -> {
+            service.addVersion(newV2);
+        });
 
         // No history should have been created since no update occurred
         PID historyPid = DatastreamPids.getDatastreamHistoryPid(dsPid);

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceIT.java
@@ -6,6 +6,7 @@ import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -17,6 +18,7 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -291,6 +293,44 @@ public class VersionedDatastreamServiceIT {
 
             service.addVersion(newV);
         });
+    }
+
+    @Test
+    public void addVersion_DatastreamWithSameContentSkipUnmodified() throws Exception {
+        repoObjFactory.createFolderObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        DatastreamVersion newV1 = new DatastreamVersion(dsPid);
+        newV1.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV1.setContentType("text/xml");
+        newV1.setSkipUnmodified(false);
+
+        BinaryObject dsObj = service.addVersion(newV1);
+
+        // Perform update with same content and skipUnmodified
+        DatastreamVersion newV2 = new DatastreamVersion(dsPid);
+        newV2.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV2.setContentType("text/xml");
+        newV2.setSkipUnmodified(true);
+
+        BinaryObject dsObj2 = service.addVersion(newV2);
+        assertEquals(dsObj.getLastModified(), dsObj2.getLastModified());
+
+        // No history should have been created since no update occurred
+        PID historyPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
+        assertThrows(NotFoundException.class, () -> {
+            repoObjLoader.getBinaryObject(historyPid);
+        });
+
+        // Perform third request to update with same content, but without skipping unmodified
+        DatastreamVersion newV3 = new DatastreamVersion(dsPid);
+        newV3.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV3.setContentType("text/xml");
+        newV3.setSkipUnmodified(false);
+
+        service.addVersion(newV3);
+
+        assertNotNull(repoObjLoader.getBinaryObject(historyPid), "History object should have been created");
     }
 
     private InputStream getModsDocumentStream(String title) throws Exception {

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceTest.java
@@ -1,0 +1,152 @@
+package edu.unc.lib.boxc.operations.impl.versioning;
+
+import edu.unc.lib.boxc.fcrepo.utils.FedoraTransaction;
+import edu.unc.lib.boxc.fcrepo.utils.TransactionManager;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.BinaryObject;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.boxc.persist.api.transfer.MultiDestinationTransferSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * @author bbpennel
+ */
+public class VersionedDatastreamServiceTest {
+    private final static String TEST_SHA1 = "60cff04894583ce46f68d80a376eea30f5473f11";
+    private VersionedDatastreamService service;
+
+    @Mock
+    private RepositoryObjectLoader repoObjLoader;
+    @Mock
+    private RepositoryObjectFactory repoObjFactory;
+    @Mock
+    private BinaryTransferService transferService;
+    @Mock
+    private TransactionManager transactionManager;
+    @Mock
+    private FedoraTransaction mockTx;
+    @Mock
+    private BinaryObject dsObj;
+    @Mock
+    private BinaryObject dsHistoryObj;
+    @Mock
+    private FileObject fileObj;
+    @Mock
+    private BinaryTransferSession session;
+    @Mock
+    private BinaryTransferOutcome dsOutcome;
+    private URI destinationUri;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() {
+        closeable = openMocks(this);
+        service = new VersionedDatastreamService();
+        service.setBinaryTransferService(transferService);
+        service.setRepositoryObjectFactory(repoObjFactory);
+        service.setRepositoryObjectLoader(repoObjLoader);
+        service.setTransactionManager(transactionManager);
+        when(transactionManager.startTransaction()).thenReturn(mockTx);
+        when(transferService.getSession(any(RepositoryObject.class))).thenReturn(session);
+        destinationUri = URI.create("file://path/to/my/file.xml");
+        when(session.transferReplaceExisting(any(), any(InputStream.class))).thenReturn(dsOutcome);
+        when(dsOutcome.getDestinationUri()).thenReturn(destinationUri);
+        when(dsOutcome.getSha1()).thenReturn(TEST_SHA1);
+        when(session.transferReplaceExisting(any(), any(InputStream.class))).thenReturn(dsOutcome);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void addVersion_DatastreamWithSameContent() throws Exception {
+        PID pid = TestHelper.makePid();
+        PID dsPid = DatastreamPids.getDatastreamPid(pid, DatastreamType.MD_DESCRIPTIVE);
+        PID dsHistoryPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
+
+        when(repoObjLoader.getRepositoryObject(pid)).thenReturn(fileObj);
+        when(repoObjLoader.getBinaryObject(dsPid)).thenReturn(dsObj);
+        setupDatastreamObject(dsPid);
+
+        VersionedDatastreamService.DatastreamVersion newV2 = new VersionedDatastreamService.DatastreamVersion(dsPid);
+        newV2.setContentStream(getModsDocumentStream());
+        newV2.setContentType("text/xml");
+
+        service.addVersion(newV2);
+
+        verify(session).transferReplaceExisting(eq(dsPid), any(InputStream.class));
+        verify(repoObjFactory).createOrUpdateBinary(eq(dsHistoryPid), any(), isNull(), eq("text/xml"),
+                any(), isNull(), isNull());
+        verify(session).transferReplaceExisting(eq(dsHistoryPid), any(InputStream.class));
+    }
+
+    @Test
+    public void addVersion_DatastreamWithSameContentSkipUnchanged() throws Exception {
+        PID pid = TestHelper.makePid();
+        PID dsPid = DatastreamPids.getDatastreamPid(pid, DatastreamType.MD_DESCRIPTIVE);
+        PID dsHistoryPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
+
+        when(repoObjLoader.getRepositoryObject(pid)).thenReturn(fileObj);
+        when(repoObjLoader.getBinaryObject(dsPid)).thenReturn(dsObj);
+        setupDatastreamObject(dsPid);
+
+        VersionedDatastreamService.DatastreamVersion newV2 = new VersionedDatastreamService.DatastreamVersion(dsPid);
+        newV2.setContentStream(getModsDocumentStream());
+        newV2.setContentType("text/xml");
+        newV2.setSkipUnmodified(true);
+
+        service.addVersion(newV2);
+
+        verify(session, never()).transferReplaceExisting(eq(dsPid), any(InputStream.class));
+        verify(repoObjFactory, never()).createOrUpdateBinary(eq(dsHistoryPid), any(), isNull(), eq("text/xml"),
+                any(), isNull(), isNull());
+        verify(session, never()).transferReplaceExisting(eq(dsHistoryPid), any(InputStream.class));
+    }
+
+    private void setupDatastreamObject(PID dsPid) throws IOException {
+        when(dsObj.getPid()).thenReturn(dsPid);
+        when(dsObj.getMimetype()).thenReturn("text/xml");
+        when(dsObj.getLastModified()).thenReturn(new Date());
+        when(dsObj.getCreatedDate()).thenReturn(new Date());
+        when(dsObj.getSha1Checksum()).thenReturn("urn:sha1:" + TEST_SHA1);
+        when(dsObj.getBinaryStream()).thenReturn(getModsDocumentStream());
+    }
+
+    private InputStream getModsDocumentStream() throws IOException {
+        return Files.newInputStream(Paths.get("src/test/resources/samples/mods.xml"));
+    }
+}

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/versioning/VersionedDatastreamServiceTest.java
@@ -11,6 +11,7 @@ import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.operations.api.exceptions.StateUnmodifiedException;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.boxc.persist.api.transfer.BinaryTransferSession;
@@ -30,6 +31,7 @@ import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -129,7 +131,9 @@ public class VersionedDatastreamServiceTest {
         newV2.setContentType("text/xml");
         newV2.setSkipUnmodified(true);
 
-        service.addVersion(newV2);
+        assertThrows(StateUnmodifiedException.class, () -> {
+            service.addVersion(newV2);
+        });
 
         verify(session, never()).transferReplaceExisting(eq(dsPid), any(InputStream.class));
         verify(repoObjFactory, never()).createOrUpdateBinary(eq(dsHistoryPid), any(), isNull(), eq("text/xml"),

--- a/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtil.java
+++ b/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtil.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 
 /**
+ * Utilities for using digests with InputStreams
  * @author bbpennel
  */
 public class InputStreamDigestUtil {

--- a/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtil.java
+++ b/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtil.java
@@ -1,0 +1,49 @@
+package edu.unc.lib.boxc.persist.impl;
+
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.persist.api.DigestAlgorithm;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+
+/**
+ * @author bbpennel
+ */
+public class InputStreamDigestUtil {
+    private InputStreamDigestUtil(){
+    }
+
+    /**
+     * Calculates the digest of provided inputStream using the default digest algorithm
+     * @param inputStream Contents to compute digest of. InputStream will be consumed.
+     * @return String representation of the digest
+     */
+    public static String computeDigest(InputStream inputStream) {
+        return computeDigest(inputStream, DigestAlgorithm.DEFAULT_ALGORITHM);
+    }
+
+    /**
+     * Calculates the digest of provided inputStream.
+     * @param inputStream Contents to compute digest of. InputStream will be consumed.
+     * @param algorithm
+     * @return String representation of the digest
+     */
+    public static String computeDigest(InputStream inputStream, DigestAlgorithm algorithm) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance(algorithm.getName());
+            // Consume the inputStream
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                digest.update(buffer, 0, bytesRead);
+            }
+            return encodeHexString(digest.digest());
+        } catch (final IOException | NoSuchAlgorithmException e) {
+            throw new RepositoryException("Failed to read content stream while calculating digests", e);
+        }
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtilTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/InputStreamDigestUtilTest.java
@@ -1,0 +1,37 @@
+package edu.unc.lib.boxc.persist.impl;
+
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.persist.api.DigestAlgorithm;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author bbpennel
+ */
+public class InputStreamDigestUtilTest {
+    @Test
+    public void computeDigestTest() throws Exception {
+        String input = "Hello Boxc";
+        String expectedSha1 = "890a5e69ae90a0766f98a9f4d82e25fa7dbb8049";
+        String output = InputStreamDigestUtil.computeDigest(new ByteArrayInputStream(input.getBytes()));
+        assertEquals(expectedSha1, output);
+    }
+
+    @Test
+    public void computeDigestInvalidAlgorithmTest() throws Exception {
+        var inputStream = mock(InputStream.class);
+        when(inputStream.read(any())).thenThrow(new IOException());
+        assertThrows(RepositoryException.class, () -> {
+            InputStreamDigestUtil.computeDigest(inputStream, DigestAlgorithm.MD5);
+        });
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/MultiDigestInputStreamWrapperTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/MultiDigestInputStreamWrapperTest.java
@@ -1,0 +1,79 @@
+package edu.unc.lib.boxc.persist.impl;
+
+import edu.unc.lib.boxc.persist.api.DigestAlgorithm;
+import edu.unc.lib.boxc.persist.api.exceptions.InvalidChecksumException;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * @author bbpennel
+ */
+public class MultiDigestInputStreamWrapperTest {
+
+    private static String CONTENT = "Something to digest";
+
+    private static String MD5 = "7afbf05666feeebe7fbbf1c9071584e6";
+    private static URI MD5_URI = URI.create("urn:md5:" + MD5);
+
+    private static String SHA1 = "23d51c61a578a8cb00c5eec6b29c12b7da15c8de";
+    private static URI SHA1_URI = URI.create("urn:sha1:" + SHA1);
+
+    private static String SHA512 =
+            "051c93c9cfd1b0a238c858267789fddb4fd1500c957d0ae609ec2fc2c96b3db9edddde5374be7" +
+                    "3b664056ed6281a842041aa43a87fd4e0fbc1b6890676cead6d";
+    private static URI SHA512_URI = URI.create("urn:sha-512:" + SHA512);
+
+    private static String SHA512256 = "dea93ec79abc429b0065e73995a4fe0ddb7a3ec65f2b14139e75360a8ab66efc";
+    private static URI SHA512256_URI = URI.create("urn:sha-512/256:" + SHA512256);
+
+    private InputStream contentStream = new ByteArrayInputStream(CONTENT.getBytes());
+
+    @Test
+    public void checkFixity_SingleDigests_Success() throws Exception {
+        var digests = Map.of(DigestAlgorithm.SHA1, SHA1);
+        var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+    }
+
+    @Test
+    public void checkFixity_SingleDigests_Mismatch() throws Exception {
+        var digests = Map.of(DigestAlgorithm.SHA1, "ohnothisisrealbad");
+        var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
+
+        assertThrows(InvalidChecksumException.class, () -> wrapper.checkFixity());
+    }
+
+    @Test
+    public void checkFixity_WantAdditionalDigests_Success() throws Exception {
+        var digests = new HashMap<DigestAlgorithm, String>();
+        digests.put(DigestAlgorithm.SHA1, SHA1);
+        var wantDigests = List.of(DigestAlgorithm.MD5);
+        var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, wantDigests);
+
+        // Read the stream to allow digest calculation
+        IOUtils.toString(wrapper.getInputStream(), UTF_8);
+
+        // Expect no failures
+        wrapper.checkFixity();
+
+        var results = wrapper.getDigests();
+        assertEquals(MD5, results.get(DigestAlgorithm.MD5));
+        assertEquals(SHA1, results.get(DigestAlgorithm.SHA1));
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/MultiDigestInputStreamWrapperTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/MultiDigestInputStreamWrapperTest.java
@@ -7,37 +7,22 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author bbpennel
  */
 public class MultiDigestInputStreamWrapperTest {
-
-    private static String CONTENT = "Something to digest";
-
-    private static String MD5 = "7afbf05666feeebe7fbbf1c9071584e6";
-    private static URI MD5_URI = URI.create("urn:md5:" + MD5);
-
-    private static String SHA1 = "23d51c61a578a8cb00c5eec6b29c12b7da15c8de";
-    private static URI SHA1_URI = URI.create("urn:sha1:" + SHA1);
-
-    private static String SHA512 =
-            "051c93c9cfd1b0a238c858267789fddb4fd1500c957d0ae609ec2fc2c96b3db9edddde5374be7" +
-                    "3b664056ed6281a842041aa43a87fd4e0fbc1b6890676cead6d";
-    private static URI SHA512_URI = URI.create("urn:sha-512:" + SHA512);
-
-    private static String SHA512256 = "dea93ec79abc429b0065e73995a4fe0ddb7a3ec65f2b14139e75360a8ab66efc";
-    private static URI SHA512256_URI = URI.create("urn:sha-512/256:" + SHA512256);
-
-    private InputStream contentStream = new ByteArrayInputStream(CONTENT.getBytes());
+    private static final String CONTENT = "Something to digest";
+    private static final String MD5 = "7afbf05666feeebe7fbbf1c9071584e6";
+    private static final String SHA1 = "23d51c61a578a8cb00c5eec6b29c12b7da15c8de";
+    private final InputStream contentStream = new ByteArrayInputStream(CONTENT.getBytes());
 
     @Test
     public void checkFixity_SingleDigests_Success() throws Exception {
@@ -52,11 +37,11 @@ public class MultiDigestInputStreamWrapperTest {
     }
 
     @Test
-    public void checkFixity_SingleDigests_Mismatch() throws Exception {
+    public void checkFixity_SingleDigests_Mismatch() {
         var digests = Map.of(DigestAlgorithm.SHA1, "ohnothisisrealbad");
         var wrapper = new MultiDigestInputStreamWrapper(contentStream, digests, null);
 
-        assertThrows(InvalidChecksumException.class, () -> wrapper.checkFixity());
+        assertThrows(InvalidChecksumException.class, wrapper::checkFixity);
     }
 
     @Test

--- a/services-camel-app/src/main/resources/update-complete-html.txt
+++ b/services-camel-app/src/main/resources/update-complete-html.txt
@@ -29,9 +29,6 @@
       {{#updated}}
       <li>{{this}}</li>
       {{/updated}}
-      {{#skipped}}
-      <li>{{this}}</li>
-      {{/skipped}}
     </ul>
   {{/updatedCount}}
 

--- a/services-camel-app/src/main/resources/update-complete-html.txt
+++ b/services-camel-app/src/main/resources/update-complete-html.txt
@@ -13,16 +13,6 @@
     <h3>DCR metadata update completed with issues: {{fileName}}</h3>
   {{/issues}}
 
-  {{#outdatedCount}}
-    <h4>Outdated ({{outdatedCount}})</h4>
-    <p>Metadata for these objects was not updated because the repository has a more recent version.</p>
-    <ul>
-      {{#outdated}}
-      <li>{{this}}</li>
-      {{/outdated}}
-    </ul>
-  {{/outdatedCount}}
-
   {{#failedCount}}
     <h4>Failed ({{failedCount}})</h4>
     <dl>
@@ -44,5 +34,15 @@
       {{/skipped}}
     </ul>
   {{/updatedCount}}
+
+  {{#skippedCount}}
+    <h4>Skipped ({{skippedCount}})</h4>
+    <dl>
+      {{#skipped}}
+        <dt>{{key}}</dt>
+        <dd>{{value}}</dd>
+      {{/skipped}}
+    </dl>
+  {{/skippedCount}}
 </body>
 </html>


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-3390

* VersionedDatastreamService now supports flag to tell it to skip updates if the SHA1 of the new version and existing version are the same
* UpdateDescriptionService uses this flag to prevent unnecessary updates when the incoming data is unchanged
* Adds utility for digest calculation on a stream
* Adds test coverage for MultiDigestInputStreamWrapper