### PR TITLE
Always re)load  metadata when opening the modal as the previous metadata …

### DIFF
--- a/static/js/vue-cdr-access/src/components/modalMetadata.vue
+++ b/static/js/vue-cdr-access/src/components/modalMetadata.vue
@@ -68,9 +68,7 @@ Displays the MODS descriptive record for an object inside of a modal
         watch: {
             openModal(display) {
                 if (display) {
-                    if (this.metadata === '') {
-                        this.loadMetadata();
-                    }
+                    this.loadMetadata();
                 }
             }
         },


### PR DESCRIPTION
Always (re)load metadata when opening the modal as the previous metadata isn't cleared out when records share a component, e.g. collections and folders

https://unclibrary.atlassian.net/browse/BXC-4458