### PR TITLE
Match form field to onlyIncludeValidDatastreams setter

### DIFF
--- a/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
+++ b/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
@@ -86,7 +86,7 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 					email : email,
 					pids : pids,
 					exportChildren: includeChildren || false,
-					excludeNoDatastreams: excludeNoDs || false,
+					onlyIncludeValidDatastreams: excludeNoDs || false,
 					datastreams: datastreamTypes || []
 				})
 			}).done(function(response) {


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4461

Match form field to `onlyIncludeValidDatastreams` setter otherwise the value is always false