### PR TITLE
BXC-4462 - Archival Collection ID inconsistently appearing in search results

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactory.java
@@ -60,10 +60,10 @@ public class ObjectPathFactory {
         titleFieldName = SearchFieldKey.TITLE.getSolrField();
         typeFieldName = SearchFieldKey.RESOURCE_TYPE.getSolrField();
         collectionId = SearchFieldKey.COLLECTION_ID.getSolrField();
-        pathFields = Arrays.asList(titleFieldName, typeFieldName);
+        pathFields = Arrays.asList(titleFieldName, typeFieldName, collectionId);
         startObjectFields = Arrays.asList(SearchFieldKey.ID.name(),
                 SearchFieldKey.TITLE.name(), SearchFieldKey.RESOURCE_TYPE.name(),
-                SearchFieldKey.ANCESTOR_PATH.name());
+                SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.COLLECTION_ID.name());
     }
 
     /**

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactoryIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/ObjectPathFactoryIT.java
@@ -69,12 +69,27 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
     }
 
     @Test
+    public void testGetCollectionPathByPid() throws Exception {
+        ObjectPath path = objPathFactory.getPath(testCorpus.coll1Pid);
+
+        assertPathPids(path, testCorpus.rootPid, testCorpus.unitPid, testCorpus.coll1Pid);
+        assertEquals("/Collections/Unit/Collection 1", path.toNamePath());
+        var pathEntries = path.getEntries();
+        var collEntry = pathEntries.get(pathEntries.size() - 1);
+        assertEquals(TestCorpus.TEST_COLL_ID, collEntry.getCollectionId());
+    }
+
+    @Test
     public void testGetWorkPathByPid() throws Exception {
         ObjectPath path = objPathFactory.getPath(testCorpus.work1Pid);
 
         assertPathPids(path, testCorpus.rootPid, testCorpus.unitPid, testCorpus.coll1Pid,
                 testCorpus.folder1Pid, testCorpus.work1Pid);
         assertEquals("/Collections/Unit/Collection 1/Folder 1/Work 1", path.toNamePath());
+        var pathEntries = path.getEntries();
+        var workEntry = pathEntries.get(pathEntries.size() - 1);
+        assertNull(workEntry.getCollectionId());
+        assertEquals(TestCorpus.TEST_COLL_ID, pathEntries.get(2).getCollectionId());
     }
 
     @Test
@@ -111,6 +126,9 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
 
         assertPathPids(path, testCorpus.rootPid, testCorpus.unitPid, testCorpus.coll1Pid);
         assertEquals("/Collections/Unit/Collection 1", path.toNamePath());
+        var pathEntries = path.getEntries();
+        var collEntry = pathEntries.get(pathEntries.size() - 1);
+        assertEquals(TestCorpus.TEST_COLL_ID, collEntry.getCollectionId());
     }
 
     private void assertPathPids(ObjectPath path, PID... pids) {


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4462

* Add tests to verify that the collection id gets set in paths when freshly retrieving them. 
* Retrieve collection id in all object path queries