### PR TITLE
BXC-4459 - MODS ingest in consistent format

### DIFF
--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -1,6 +1,7 @@
 package edu.unc.lib.boxc.deposit.fcrepo4;
 
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
+import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.boxc.persist.impl.storage.StorageLocationTestHelper.LOC1_ID;
@@ -39,6 +40,8 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.client.FcrepoClient;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -455,7 +458,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
         Resource historyResc = DepositModelHelpers.addDatastream(workBag, DatastreamType.MD_DESCRIPTIVE_HISTORY);
         Path modsPath = job.getModsPath(workPid, true);
-        FileUtils.writeStringToFile(modsPath.toFile(), "Mods content", UTF_8);
+        var originalModsPath = Path.of("src/test/resources/simpleMods.xml");
         Path modsHistoryPath = depositDirManager.getHistoryFile(workPid, DatastreamType.MD_DESCRIPTIVE_HISTORY);
         FileUtils.writeStringToFile(modsHistoryPath.toFile(), "History content", UTF_8);
         String modsHistorySha1 = getSha1(modsHistoryPath);
@@ -475,7 +478,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         // Make sure that the work is present and is actually a work
         WorkObject mWork = (WorkObject) findContentObjectByPid(destMembers, workPid);
         BinaryObject descBin = mWork.getDescription();
-        assertEquals("Mods content", IOUtils.toString(descBin.getBinaryStream(), UTF_8));
+        assertEquals(FileUtils.readFileToString(originalModsPath.toFile(), UTF_8), IOUtils.toString(descBin.getBinaryStream(), UTF_8));
 
         PID historyPid = DatastreamPids.getDatastreamHistoryPid(descBin.getPid());
         BinaryObject historyBin = repoObjLoader.getBinaryObject(historyPid);
@@ -810,7 +813,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         PID folderPid = pidMinter.mintContentPid();
 
         Path modsPath = job.getModsPath(folderPid, true);
-        Files.createFile(modsPath);
+        Files.copy(Path.of("src/test/resources/simpleMods.xml"), modsPath);
 
         String label = "testfolder";
 

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -459,6 +459,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         Resource historyResc = DepositModelHelpers.addDatastream(workBag, DatastreamType.MD_DESCRIPTIVE_HISTORY);
         Path modsPath = job.getModsPath(workPid, true);
         var originalModsPath = Path.of("src/test/resources/simpleMods.xml");
+        Files.copy(originalModsPath, modsPath);
         Path modsHistoryPath = depositDirManager.getHistoryFile(workPid, DatastreamType.MD_DESCRIPTIVE_HISTORY);
         FileUtils.writeStringToFile(modsHistoryPath.toFile(), "History content", UTF_8);
         String modsHistorySha1 = getSha1(modsHistoryPath);

--- a/deposit-app/src/test/resources/simpleMods.xml
+++ b/deposit-app/src/test/resources/simpleMods.xml
@@ -1,16 +1,14 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <mods xmlns="http://www.loc.gov/mods/v3">
-    <titleInfo>
-        <title>Simple MODS document</title>
-    </titleInfo>
-
-    <language>
-        <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
-    </language>
-    <name>
-        <namePart>Test</namePart>
-        <role>
-            <roleTerm>creator</roleTerm>
-        </role>
-    </name>
+  <titleInfo>
+    <title>Simple MODS document</title>
+  </titleInfo>
+  <language>
+    <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+  </language>
+  <name>
+    <namePart>Test</namePart>
+    <role>
+      <roleTerm>creator</roleTerm>
+    </role>
+  </name>
 </mods>

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ContentObjectFactory.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/factories/ContentObjectFactory.java
@@ -13,11 +13,8 @@ import edu.unc.lib.boxc.model.fcrepo.test.AclModelBuilder;
 import edu.unc.lib.boxc.model.fcrepo.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
 
 import java.io.IOException;
 import java.util.Map;
@@ -39,11 +36,9 @@ public class ContentObjectFactory {
         options = validateOptions(options);
         var modsDocument = modsFactory.createDocument(options);
         if (modsDocument != null) {
-            var modsString = new XMLOutputter(Format.getPrettyFormat()).outputString(modsDocument);
-            var inputStream = IOUtils.toInputStream(modsString, "utf-8");
-
             // put mods in fedora
-            updateDescriptionService.updateDescription(agent, object.getPid(), inputStream);
+            var request = new UpdateDescriptionService.UpdateDescriptionRequest(agent, object.getPid(), modsDocument);
+            updateDescriptionService.updateDescription(request);
         }
         // index folder in triple store
         indexTripleStore(object);

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleService.java
@@ -1,19 +1,5 @@
 package edu.unc.lib.boxc.operations.impl.edit;
 
-import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Arrays;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.output.XMLOutputter;
-
 import edu.unc.lib.boxc.auth.api.Permission;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.api.services.AccessControlService;
@@ -26,6 +12,16 @@ import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 import io.dropwizard.metrics5.Timer;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
 
 /**
  * Service that manages editing of the mods:title property on an object
@@ -81,11 +77,7 @@ public class EditTitleService {
                 newMods = addTitleToMODS(document, title);
             }
 
-            ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-            new XMLOutputter().output(newMods, outStream);
-            InputStream newModsStream = new ByteArrayInputStream(outStream.toByteArray());
-
-            updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, pid, newModsStream));
+            updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, pid, newMods));
         } catch (JDOMException e) {
             throw new ServiceException("Unable to build mods document for " + pid, e);
         } catch (IOException e) {

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/EditTitleServiceTest.java
@@ -1,38 +1,5 @@
 package edu.unc.lib.boxc.operations.impl.edit;
 
-import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.List;
-import java.util.UUID;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
-import org.jdom2.output.XMLOutputter;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-
 import edu.unc.lib.boxc.auth.api.Permission;
 import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
@@ -46,6 +13,35 @@ import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.XMLOutputter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 public class EditTitleServiceTest {
     private AutoCloseable closeable;
@@ -207,9 +203,8 @@ public class EditTitleServiceTest {
         return new ByteArrayInputStream(outStream.toByteArray());
     }
 
-    private Document getUpdatedDescriptionDocument() throws IOException, JDOMException {
-        SAXBuilder sb = createSAXBuilder();
-        return sb.build(updateCaptor.getValue().getModsStream());
+    private Document getUpdatedDescriptionDocument() {
+        return updateCaptor.getValue().getModsDocument();
     }
 
     private boolean hasTitleValue(Document document, String expectedTitle) {

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/edit/UpdateDescriptionServiceTest.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.operations.impl.edit;
 
+import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
 import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getMdDescriptivePid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,17 +8,29 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
 
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.operations.jms.indexing.IndexingPriority;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.jdom2.Document;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,8 +80,6 @@ public class UpdateDescriptionServiceTest {
     @Mock
     private MODSValidator modsValidator;
     @Mock
-    private StorageLocation destination;
-    @Mock
     private BinaryTransferSession transferSession;
     @Mock
     private VersionedDatastreamService versioningService;
@@ -91,6 +102,8 @@ public class UpdateDescriptionServiceTest {
     private PID objPid;
     private PID modsPid;
     private InputStream modsStream;
+    private String modsString;
+    private Path modsPath;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -105,7 +118,11 @@ public class UpdateDescriptionServiceTest {
 
         objPid = PIDs.get(UUID.randomUUID().toString());
         modsPid = getMdDescriptivePid(objPid);
-        modsStream = new ByteArrayInputStream(FILE_CONTENT.getBytes());
+        modsPath = Path.of("src/test/resources/samples/mods.xml");
+        modsStream = Files.newInputStream(modsPath);
+        // Reformat mods document to pretty print it to match normalization in the service
+        var modsDoc = createSAXBuilder().build(Files.newInputStream(modsPath));
+        modsString = new XMLOutputter(Format.getPrettyFormat()).outputString(modsDoc);
 
         when(versioningService.addVersion(any(DatastreamVersion.class))).thenReturn(mockDescBin);
         when(obj.getPid()).thenReturn(objPid);
@@ -128,13 +145,53 @@ public class UpdateDescriptionServiceTest {
     public void updateDescriptionTest() throws Exception {
         service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
-        verify(versioningService).addVersion(versionCaptor.capture());
-        DatastreamVersion version = versionCaptor.getValue();
-        assertEquals(modsPid, version.getDsPid());
-        assertEquals("text/xml", version.getContentType());
-        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
-
+        assertUpdateSuccessful();
         assertMessageSent();
+    }
+
+    @Test
+    public void updateDescriptionFromDocumentTest() throws Exception {
+        var modsDoc = createSAXBuilder().build(Files.newInputStream(modsPath));
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsDoc));
+
+        assertUpdateSuccessful();
+        assertMessageSent();
+    }
+
+    @Test
+    public void updateWithContentObjectTest() throws Exception {
+        var contentObj = mock(WorkObject.class);
+        when(contentObj.getPid()).thenReturn(objPid);
+        service.updateDescription(new UpdateDescriptionRequest(agent, contentObj, modsStream));
+
+        assertUpdateSuccessful();
+        assertMessageSent();
+        verify(repoObjLoader, never()).getRepositoryObject(any());
+    }
+
+    @Test
+    public void updateWithUnmodifiedSinceTest() throws Exception {
+        var unmodifedSince = Instant.now();
+        var request = new UpdateDescriptionRequest(agent, objPid, modsStream);
+        request.withUnmodifiedSince(unmodifedSince);
+        service.updateDescription(request);
+
+        assertUpdateSuccessful();
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(unmodifedSince, version.getUnmodifiedSince());
+        assertMessageSent();
+    }
+
+    @Test
+    public void updateWithIndexingPriorityTest() throws Exception {
+        var request = new UpdateDescriptionRequest(agent, objPid, modsStream);
+        request.withPriority(IndexingPriority.high);
+        service.updateDescription(request);
+
+        assertUpdateSuccessful();
+        assertMessageSent();
+        verify(messageSender).sendUpdateDescriptionOperation(
+                anyString(), any(), eq(IndexingPriority.high));
     }
 
     @Test
@@ -143,17 +200,12 @@ public class UpdateDescriptionServiceTest {
 
         service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
-        verify(versioningService).addVersion(versionCaptor.capture());
-        DatastreamVersion version = versionCaptor.getValue();
-        assertEquals(modsPid, version.getDsPid());
-        assertEquals("text/xml", version.getContentType());
-        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
-
+        assertUpdateSuccessful();
         assertMessageSent();
     }
 
     @Test
-    public void insufficientAccessTest() throws Exception {
+    public void insufficientAccessTest() {
         Assertions.assertThrows(AccessRestrictionException.class, () -> {
             doThrow(new AccessRestrictionException()).when(aclService)
                     .assertHasAccess(anyString(), eq(objPid), any(), any(Permission.class));
@@ -176,7 +228,7 @@ public class UpdateDescriptionServiceTest {
     }
 
     @Test
-    public void invalidModsTest() throws Exception {
+    public void invalidModsTest() {
         Assertions.assertThrows(MetadataValidationException.class, () -> {
             doThrow(new MetadataValidationException()).when(modsValidator).validate(any(InputStream.class));
 
@@ -194,30 +246,32 @@ public class UpdateDescriptionServiceTest {
     }
 
     @Test
+    public void invalidXMLTest() {
+        Assertions.assertThrows(MetadataValidationException.class, () -> {
+            var badXmlStream = new ByteArrayInputStream("BAD XML".getBytes());
+            service.updateDescription(new UpdateDescriptionRequest(agent, objPid, badXmlStream));
+        });
+    }
+
+    @Test
     public void updateDescriptionProvidedSession() throws Exception {
         service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream)
                 .withTransferSession(transferSession));
 
-        verify(versioningService).addVersion(versionCaptor.capture());
+        assertUpdateSuccessful();
         DatastreamVersion version = versionCaptor.getValue();
-        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
         assertEquals(transferSession, version.getTransferSession());
 
         assertMessageSent();
     }
 
     @Test
-    public void updateDescriptionDisableMassgesTest() throws Exception {
+    public void updateDescriptionDisableMessagesTest() throws Exception {
         service.setSendsMessages(false);
 
         service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
-        verify(versioningService).addVersion(versionCaptor.capture());
-        DatastreamVersion version = versionCaptor.getValue();
-        assertEquals(modsPid, version.getDsPid());
-        assertEquals("text/xml", version.getContentType());
-        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
-
+        assertUpdateSuccessful();
         verify(messageSender, never()).sendUpdateDescriptionOperation(anyString(), pidsCaptor.capture());
     }
 
@@ -227,5 +281,13 @@ public class UpdateDescriptionServiceTest {
         Collection<PID> pids = pidsCaptor.getValue();
         assertEquals(1, pids.size());
         assertTrue(pids.contains(objPid));
+    }
+
+    private void assertUpdateSuccessful() throws Exception {
+        verify(versioningService).addVersion(versionCaptor.capture());
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(modsPid, version.getDsPid());
+        assertEquals("text/xml", version.getContentType());
+        assertEquals(modsString, IOUtils.toString(version.getContentStream()));
     }
 }

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobIT.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/importxml/ImportXMLJobIT.java
@@ -1,28 +1,19 @@
 package edu.unc.lib.boxc.operations.impl.importxml;
 
-import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
-import static edu.unc.lib.boxc.operations.test.ModsTestHelper.addObjectUpdate;
-import static edu.unc.lib.boxc.operations.test.ModsTestHelper.documentToInputStream;
-import static edu.unc.lib.boxc.operations.test.ModsTestHelper.makeUpdateDocument;
-import static edu.unc.lib.boxc.operations.test.ModsTestHelper.modsWithTitleAndDate;
-import static edu.unc.lib.boxc.operations.test.ModsTestHelper.writeToFile;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.FileUtils.writeStringToFile;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.time.Instant;
-import java.util.UUID;
-
-import javax.mail.internet.MimeMessage;
-
+import com.samskivert.mustache.Template;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
+import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
+import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
+import edu.unc.lib.boxc.operations.jms.exportxml.BulkXMLConstants;
+import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -39,21 +30,26 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.samskivert.mustache.Template;
+import javax.mail.internet.MimeMessage;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.UUID;
 
-import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
-import edu.unc.lib.boxc.model.api.objects.WorkObject;
-import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
-import edu.unc.lib.boxc.model.api.services.RepositoryObjectFactory;
-import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
-import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
-import edu.unc.lib.boxc.operations.jms.exportxml.BulkXMLConstants;
-import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
-import edu.unc.lib.boxc.persist.impl.transfer.BinaryTransferServiceImpl;
+import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
+import static edu.unc.lib.boxc.operations.test.ModsTestHelper.addObjectUpdate;
+import static edu.unc.lib.boxc.operations.test.ModsTestHelper.makeUpdateDocument;
+import static edu.unc.lib.boxc.operations.test.ModsTestHelper.modsWithTitleAndDate;
+import static edu.unc.lib.boxc.operations.test.ModsTestHelper.writeToFile;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
  *
@@ -361,8 +357,7 @@ public class ImportXMLJobIT {
         workObj = factory.createWorkObject(workPid, null);
         Document doc = new Document()
                 .addContent(modsWithTitleAndDate(ORIGINAL_TITLE, ORIGINAL_DATE));
-        InputStream modsStream = documentToInputStream(doc);
-        updateService.updateDescription(new UpdateDescriptionRequest(agent, workObj, modsStream));
+        updateService.updateDescription(new UpdateDescriptionRequest(agent, workPid, doc));
         return workPid;
     }
 

--- a/operations/src/test/resources/samples/modsNormalized.xml
+++ b/operations/src/test/resources/samples/modsNormalized.xml
@@ -1,0 +1,25 @@
+<mods xmlns="http://www.loc.gov/mods/v3">
+  <titleInfo>
+    <title>SCHOLARLY COMMUNICATIONS CONVOCATION</title>
+    <subTitle>Final Report</subTitle>
+    <nonSort>The</nonSort>
+  </titleInfo>
+  <genre>presentation slides</genre>
+  <name type="personal">
+    <affiliation>Director, Wilson Institute</affiliation>
+    <namePart>Wilson, Charlie</namePart>
+    <role>
+      <roleTerm>contributor</roleTerm>
+    </role>
+  </name>
+  <originInfo>
+    <dateIssued keyDate="yes" encoding="iso8601">20070619</dateIssued>
+    <dateCreated encoding="iso8601">20070510</dateCreated>
+  </originInfo>
+  <language>
+    <languageTerm authority="iso639-2b">eng</languageTerm>
+  </language>
+  <subject>
+    <topic>scholarly communications</topic>
+  </subject>
+</mods>

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/enhancements/EnhancementRouterIT.java
@@ -272,8 +272,9 @@ public class EnhancementRouterIT {
     @Test
     public void testProcessFilterOutDescriptiveMDSolr() throws Exception {
         FileObject fileObj = repoObjectFactory.createFileObject(null);
+        var modsStream = Files.newInputStream(Path.of("src/test/resources/datastreams/simpleMods.xml"));
         BinaryObject descObj = updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
-                mock(AgentPrincipalsImpl.class), fileObj.getPid(), new ByteArrayInputStream(FILE_CONTENT.getBytes())));
+                mock(AgentPrincipalsImpl.class), fileObj.getPid(), modsStream));
 
         NotifyBuilder notify = new NotifyBuilder(cdrEnhancements)
                 .whenCompleted(1)

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/AddContainerService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/AddContainerService.java
@@ -1,32 +1,5 @@
 package edu.unc.lib.boxc.web.services.processing;
 
-import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
-import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
-import static edu.unc.lib.boxc.auth.api.UserRole.canViewOriginals;
-import static edu.unc.lib.boxc.auth.api.UserRole.none;
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_EL;
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_LABEL;
-import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_TYPE;
-import static java.util.Arrays.asList;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.jdom2.output.Format.getPrettyFormat;
-import static org.springframework.util.Assert.notNull;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.UUID;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.output.XMLOutputter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import edu.unc.lib.boxc.auth.api.Permission;
 import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
@@ -56,6 +29,28 @@ import edu.unc.lib.boxc.operations.jms.OperationsMessageSender;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocation;
 import edu.unc.lib.boxc.persist.api.storage.StorageLocationManager;
 import io.dropwizard.metrics5.Timer;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.boxc.auth.api.UserRole.canViewOriginals;
+import static edu.unc.lib.boxc.auth.api.UserRole.none;
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_EL;
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_LABEL;
+import static edu.unc.lib.boxc.model.api.xml.DescriptionConstants.COLLECTION_NUMBER_TYPE;
+import static java.util.Arrays.asList;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.springframework.util.Assert.notNull;
 
 /**
  * Service that manages the creation of containers
@@ -182,10 +177,7 @@ public class AddContainerService {
                     .setText(addRequest.getCollectionNumber().trim()));
         }
 
-        String modsString = new XMLOutputter(getPrettyFormat()).outputString(mods.getDocument());
-
-        updateDescService.updateDescription(new UpdateDescriptionRequest(addRequest.getAgent(), containerPid,
-                IOUtils.toInputStream(modsString, StandardCharsets.UTF_8)));
+        updateDescService.updateDescription(new UpdateDescriptionRequest(addRequest.getAgent(), containerPid, doc));
     }
 
     /**

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/EditTitleIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/EditTitleIT.java
@@ -1,5 +1,27 @@
 package edu.unc.lib.boxc.web.services.rest.modify;
 
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.BinaryObject;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
+import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.input.SAXBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.IOException;
+import java.util.Map;
+
 import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
 import static edu.unc.lib.boxc.model.api.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,31 +33,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.JDOMException;
-import org.jdom2.input.SAXBuilder;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.web.servlet.MvcResult;
-
-import edu.unc.lib.boxc.auth.api.Permission;
-import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
-import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
-import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
-import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.objects.BinaryObject;
-import edu.unc.lib.boxc.model.api.objects.WorkObject;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService;
-import edu.unc.lib.boxc.operations.impl.edit.UpdateDescriptionService.UpdateDescriptionRequest;
-import edu.unc.lib.boxc.operations.test.ModsTestHelper;
 
 /**
  *
@@ -100,9 +97,8 @@ public class EditTitleIT extends AbstractAPIIT {
                 .addContent(new Element("titleInfo", MODS_V3_NS)
                         .addContent(new Element("title", MODS_V3_NS).setText(oldTitle))));
 
-        InputStream modsStream = ModsTestHelper.documentToInputStream(document);
         updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
-                mock(AgentPrincipalsImpl.class), pid, modsStream));
+                mock(AgentPrincipalsImpl.class), pid, document));
 
         String newTitle = "new_work_title";
         MvcResult result = mvc.perform(put("/edit/title/" + pid.getUUID())


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4459

* Perform normalization of MODS documents when updating descriptions by pretty printing.
* Improve test coverage of UpdateDescriptionService.
* Allow MODS documents to be passed in directly without needing to be deserialized first, and update usages of the update service to do this to save unnecessary steps.