### PR TITLE
BXC-4488 fix null user id error and add test

### DIFF
--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -1,25 +1,23 @@
 package edu.unc.lib.boxc.web.common.utils;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
-import java.util.UUID;
-
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.lang.StringUtils;
-import org.matomo.java.tracking.MatomoTracker;
-import org.matomo.java.tracking.TrackerConfiguration;
-import org.matomo.java.tracking.parameters.VisitorId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.matomo.java.tracking.MatomoRequest;
-
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
+import org.apache.commons.lang.StringUtils;
+import org.matomo.java.tracking.MatomoRequest;
+import org.matomo.java.tracking.MatomoTracker;
+import org.matomo.java.tracking.TrackerConfiguration;
+import org.matomo.java.tracking.parameters.VisitorId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.util.Random;
 
 /**
  * Utility for performing asynchronous analytics tracking events when unable to use the javascript api
@@ -178,7 +176,13 @@ public class AnalyticsTrackerUtil {
         }
 
         private String generateUserId() {
-            return UUID.randomUUID().toString();
+            Random randomService = new Random();
+            StringBuilder sb = new StringBuilder();
+            while (sb.length() < 16) {
+                sb.append(Integer.toHexString(randomService.nextInt()));
+            }
+            sb.setLength(16);
+            return sb.toString();
         }
         private boolean hasUnknownUip(String uip) {
             return StringUtils.isBlank(uip) || "unknown".equalsIgnoreCase(uip);

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 
-import com.ctc.wstx.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
 import org.matomo.java.tracking.MatomoTracker;
 import org.matomo.java.tracking.TrackerConfiguration;
@@ -168,7 +167,7 @@ public class AnalyticsTrackerUtil {
             }
 
             // if it cannot be found in the cookie, generate a random UUID
-            if (uid == null) {
+            if (StringUtils.isBlank(uid)) {
                 uid = generateUserId();
             }
 

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -126,6 +126,7 @@ public class AnalyticsTrackerUtil {
         public String userAgent;
         // matomo user id
         public String uid;
+        private Random randomService = new Random();
 
         public AnalyticsUserData(HttpServletRequest request) {
 
@@ -176,7 +177,6 @@ public class AnalyticsTrackerUtil {
         }
 
         private String generateUserId() {
-            Random randomService = new Random();
             StringBuilder sb = new StringBuilder();
             while (sb.length() < 16) {
                 sb.append(Integer.toHexString(randomService.nextInt()));

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -164,7 +164,7 @@ public class AnalyticsTrackerUtil {
                 }
             }
 
-            // if it cannot be found in the cookie, generate a random UUID
+            // if it cannot be found in the cookie, generate a random 16 character hex user ID
             if (StringUtils.isBlank(uid)) {
                 uid = generateUserId();
             }

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -134,19 +134,19 @@ public class AnalyticsTrackerUtil {
 
             // Get the user's IP address, either from proxy headers or request
             uip = request.getHeader("X-Forwarded-For");
-            if (unknownUip(uip)) {
+            if (hasUnknownUip(uip)) {
                 uip = request.getHeader("Proxy-Client-IP");
             }
-            if (unknownUip(uip)) {
+            if (hasUnknownUip(uip)) {
                 uip = request.getHeader("WL-Proxy-Client-IP");
             }
-            if (unknownUip(uip)) {
+            if (hasUnknownUip(uip)) {
                 uip = request.getHeader("HTTP_CLIENT_IP");
             }
-            if (unknownUip(uip)) {
+            if (hasUnknownUip(uip)) {
                 uip = request.getHeader("HTTP_X_FORWARDED_FOR");
             }
-            if (unknownUip(uip)) {
+            if (hasUnknownUip(uip)) {
                 uip = request.getRemoteAddr();
             }
 
@@ -181,7 +181,7 @@ public class AnalyticsTrackerUtil {
         private String generateUserId() {
             return UUID.randomUUID().toString();
         }
-        private boolean unknownUip(String uip) {
+        private boolean hasUnknownUip(String uip) {
             return StringUtils.isBlank(uip) || "unknown".equalsIgnoreCase(uip);
         }
     }

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
@@ -2,25 +2,21 @@ package edu.unc.lib.boxc.web.common.utils;
 
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
-
-import org.apache.http.conn.HttpClientConnectionManager;
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.springframework.http.HttpStatus;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +29,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -162,6 +159,7 @@ public class AnalyticsTrackerUtilTest {
 
         var userData = new AnalyticsTrackerUtil.AnalyticsUserData(request);
         assertNotNull(userData.uid);
+        assertFalse(userData.uid.isEmpty());
     }
 
     private void assertMatomoQueryIsCorrect(Map<String, StringValuePattern> params) {

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
@@ -33,6 +33,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -147,6 +148,20 @@ public class AnalyticsTrackerUtilTest {
         when(request.getRemoteAddr()).thenReturn("1.1.1.1");
         var userData = new AnalyticsTrackerUtil.AnalyticsUserData(request);
         assertEquals("1.1.1.1", userData.uip);
+    }
+
+    @Test
+    public void testAnalyticsUserDataInvalidUidCookie() {
+        when(request.getHeader("Proxy-Client-IP")).thenReturn("0.0.0.0");
+        var uidCookie = mock(Cookie.class);
+        when(uidCookie.getName()).thenReturn("_pk_id");
+        when(uidCookie.getValue()).thenReturn("");
+        when(request.getCookies()).thenReturn(new Cookie[]{ uidCookie });
+        when(request.getHeader("User-Agent")).thenReturn("boxy-client");
+        when(request.getRequestURL()).thenReturn(urlBuffer);
+
+        var userData = new AnalyticsTrackerUtil.AnalyticsUserData(request);
+        assertNotNull(userData.uid);
     }
 
     private void assertMatomoQueryIsCorrect(Map<String, StringValuePattern> params) {

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DownloadImageControllerIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DownloadImageControllerIT.java
@@ -13,6 +13,7 @@ import edu.unc.lib.boxc.search.api.models.Datastream;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
 import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
 import edu.unc.lib.boxc.web.common.services.SolrQueryLayerService;
+import edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil;
 import edu.unc.lib.boxc.web.services.processing.DownloadImageService;
 import edu.unc.lib.boxc.web.services.rest.modify.AbstractAPIIT;
 import edu.unc.lib.boxc.web.services.utils.ImageServerUtil;

--- a/web-services-app/src/test/resources/download-image-it-servlet.xml
+++ b/web-services-app/src/test/resources/download-image-it-servlet.xml
@@ -33,6 +33,10 @@
         <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SearchSettings" />
     </bean>
 
+    <bean id="analyticsTrackerUtil" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" />
+    </bean>
+
     <bean id="solrSettings" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.boxc.search.solr.config.SolrSettings" />
     </bean>


### PR DESCRIPTION
This PR generates a random UUID and sets the user id to that for analytics usage, to fix these errors in the log:

`An exception occurred while recording download event on http://dcr-bes.libint.unc.edu:8181/fcrepo/rest/content/5b/b8/10/4c/5bb8104c-c218-4ee6-bd0b-6d7a705f4f83
java.lang.NullPointerException: inputHex is marked non-null but is null
	at org.matomo.java.tracking.parameters.VisitorId.fromHex(VisitorId.java:87)
	at edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil.buildMatomoRequest(AnalyticsTrackerUtil.java:70)`


https://unclibrary.atlassian.net/browse/BXC-4488