### PR TITLE
BXC-4497 - Update matomo tracker and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,15 +63,15 @@
         
         <cdr.version>5.0-SNAPSHOT</cdr.version>
         <fcrepo.version>3.8.0</fcrepo.version>
-        <fcrepo4.version>5.1.2-RC-1</fcrepo4.version>
+        <fcrepo4.version>5.1.2</fcrepo4.version>
         <fcrepo-indexing-triplestore.version>5.0.0</fcrepo-indexing-triplestore.version>
         <clamav-java.version>1.0.2-SNAPSHOT</clamav-java.version>
         
-        <spring.version>5.3.27</spring.version>
-        <spring.ws.version>3.1.2</spring.ws.version>
+        <spring.version>5.3.32</spring.version>
+        <spring.ws.version>3.1.8</spring.ws.version>
         
         <junit.version>4.13.1</junit.version>
-        <junit.jupiter.version>5.9.0</junit.jupiter.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <grizzly.version>2.4.4</grizzly.version>
         <jersey.version>2.34</jersey.version>
         <mockito.version>3.12.4</mockito.version>
@@ -96,7 +96,7 @@
         <sword2-server.version>1.0</sword2-server.version>
         
         <httpclient.version>4.5.13</httpclient.version>
-        <commons-compress.version>1.21</commons-compress.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-io.version>2.7</commons-io.version>
         <commons-csv.version>1.6</commons-csv.version>

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -221,8 +221,8 @@
      <!-- Matomo tracking -->
       <dependency>
           <groupId>org.piwik.java.tracking</groupId>
-          <artifactId>matomo-java-tracker</artifactId>
-          <version>3.2.0</version>
+          <artifactId>matomo-java-tracker-java11</artifactId>
+          <version>3.2.1</version>
       </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Relates to https://unclibrary.atlassian.net/browse/BXC-4497

* Switch to using matomo java11 implementation, update version
* Update other dependencies with security alerts