### PR TITLE
BXC-4497 - Use single MatomoTracker instance

### DIFF
--- a/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -21,7 +21,7 @@
         <property name="ignoreResourceNotFound" value="false" />
     </bean>
     
-    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init">
+    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init" destroy-method="close">
         <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
         <property name="matomoAuthToken" value="${matomo.authToken}" />
         <property name="matomoApiURL" value="${matomo.api.url}" />

--- a/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/web-access-app/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -21,7 +21,7 @@
         <property name="ignoreResourceNotFound" value="false" />
     </bean>
     
-    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil">
+    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init">
         <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
         <property name="matomoAuthToken" value="${matomo.authToken}" />
         <property name="matomoApiURL" value="${matomo.api.url}" />

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -222,7 +222,7 @@
       <dependency>
           <groupId>org.piwik.java.tracking</groupId>
           <artifactId>matomo-java-tracker-java11</artifactId>
-          <version>3.2.1</version>
+          <version>3.3.0</version>
       </dependency>
   </dependencies>
 </project>

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -29,8 +29,6 @@ public class AnalyticsTrackerUtil {
 
     private static final Logger log = LoggerFactory.getLogger(AnalyticsTrackerUtil.class);
 
-    // Made up CID to use if the request does not include one, such as from a API request
-    protected static final String DEFAULT_CID = "35009a79-1a05-49d7-b876-2b884d0f825b";
     public static final String MATOMO_ACTION = "Downloaded Original";
 
     private String matomoAuthToken;
@@ -46,8 +44,12 @@ public class AnalyticsTrackerUtil {
                 .build());
     }
 
-    public void close() throws Exception {
-        tracker.close();
+    public void close() {
+        try {
+            tracker.close();
+        } catch (Exception e) {
+            log.warn("Failed to close matomo tracker", e);
+        }
     }
 
     /**
@@ -133,7 +135,6 @@ public class AnalyticsTrackerUtil {
         public String userAgent;
         // matomo user id
         public String uid;
-        private Random randomService = new Random();
 
         public AnalyticsUserData(HttpServletRequest request) {
 

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -37,6 +37,14 @@ public class AnalyticsTrackerUtil {
     private String matomoApiURL;
     private int matomoSiteID;
     private SolrSearchService solrSearchService;
+    private MatomoTracker tracker;
+
+    public void init() {
+        tracker = new MatomoTracker(TrackerConfiguration
+                .builder()
+                .apiEndpoint(URI.create(matomoApiURL))
+                .build());
+    }
 
     /**
      * Track an event with the specified action for object pid for the active user on the request.
@@ -80,11 +88,6 @@ public class AnalyticsTrackerUtil {
     }
 
     private void sendMatomoRequest(MatomoRequest matomoRequest) {
-        var tracker = new MatomoTracker(TrackerConfiguration
-                .builder()
-                .apiEndpoint(URI.create(matomoApiURL))
-                .build());
-
         try {
             tracker.sendRequestAsync(matomoRequest);
         } catch (Exception e) {

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -46,6 +46,10 @@ public class AnalyticsTrackerUtil {
                 .build());
     }
 
+    public void close() throws Exception {
+        tracker.close();
+    }
+
     /**
      * Track an event with the specified action for object pid for the active user on the request.
      *

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -67,7 +67,7 @@ public class AnalyticsTrackerUtil {
     private MatomoRequest buildMatomoRequest(String url, AnalyticsUserData userData, String parentCollection, String label) throws UnsupportedEncodingException {
         return MatomoRequest.request()
                 .siteId(matomoSiteID)
-                .visitorId(VisitorId.fromHex(userData.uid))
+                .visitorId(userData.getVisitorId())
                 .actionUrl(url)
                 .actionName(parentCollection + " / " + MATOMO_ACTION)
                 .eventCategory(parentCollection)
@@ -165,26 +165,21 @@ public class AnalyticsTrackerUtil {
                 }
             }
 
-            // if it cannot be found in the cookie, generate a random 16 character hex user ID
-            if (StringUtils.isBlank(uid)) {
-                // Commented out temporarily while we debug a resource exhaustion issue
-//                uid = generateUserId();
-            }
-
             userAgent = request.getHeader("User-Agent");
             if (userAgent == null) {
                 userAgent = "";
             }
         }
 
-        private String generateUserId() {
-            StringBuilder sb = new StringBuilder();
-            while (sb.length() < 16) {
-                sb.append(Integer.toHexString(randomService.nextInt()));
+        public VisitorId getVisitorId() {
+            if (StringUtils.isBlank(uid)) {
+                // Generate a random visitor id if none is set
+                return VisitorId.random();
+            } else {
+                return VisitorId.fromHex(uid);
             }
-            sb.setLength(16);
-            return sb.toString();
         }
+
         private boolean hasUnknownUip(String uip) {
             return StringUtils.isBlank(uip) || "unknown".equalsIgnoreCase(uip);
         }

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -56,16 +57,23 @@ public class AnalyticsTrackerUtilTest {
     private StringBuffer urlBuffer = new StringBuffer("https://www.example.org");
     private String url = "http://example.com/rest/content/03/11/45/33/03114533-0017-4c83-b9d9-567b08fb2429";
     private int siteID = 3;
+    private AutoCloseable closeable;
 
     @BeforeEach
     public void setup() {
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
         analyticsTrackerUtil = new AnalyticsTrackerUtil();
         analyticsTrackerUtil.setSolrSearchService(solrSearchService);
         analyticsTrackerUtil.setMatomoApiURL(apiURL);
         analyticsTrackerUtil.setMatomoAuthToken(authToken);
         analyticsTrackerUtil.setMatomoSiteID(siteID);
+        analyticsTrackerUtil.init();
         principals = new AccessGroupSetImpl("some_group");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
     }
 
     @Test

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
@@ -147,20 +147,19 @@ public class AnalyticsTrackerUtilTest {
         assertEquals("1.1.1.1", userData.uip);
     }
 
-//    @Test
-//    public void testAnalyticsUserDataInvalidUidCookie() {
-//        when(request.getHeader("Proxy-Client-IP")).thenReturn("0.0.0.0");
-//        var uidCookie = mock(Cookie.class);
-//        when(uidCookie.getName()).thenReturn("_pk_id");
-//        when(uidCookie.getValue()).thenReturn("");
-//        when(request.getCookies()).thenReturn(new Cookie[]{ uidCookie });
-//        when(request.getHeader("User-Agent")).thenReturn("boxy-client");
-//        when(request.getRequestURL()).thenReturn(urlBuffer);
-//
-//        var userData = new AnalyticsTrackerUtil.AnalyticsUserData(request);
-//        assertNotNull(userData.uid);
-//        assertFalse(userData.uid.isEmpty());
-//    }
+    @Test
+    public void testAnalyticsUserDataInvalidUidCookie() throws Exception {
+        when(request.getHeader("Proxy-Client-IP")).thenReturn("0.0.0.0");
+        var uidCookie = mock(Cookie.class);
+        when(uidCookie.getName()).thenReturn("_pk_id");
+        when(uidCookie.getValue()).thenReturn("");
+        when(request.getCookies()).thenReturn(new Cookie[]{ uidCookie });
+        when(request.getHeader("User-Agent")).thenReturn("boxy-client");
+        when(request.getRequestURL()).thenReturn(urlBuffer);
+
+        var userData = new AnalyticsTrackerUtil.AnalyticsUserData(request);
+        assertNotNull(userData.getVisitorId());
+    }
 
     private void assertMatomoQueryIsCorrect(Map<String, StringValuePattern> params) {
         for (int i=0 ; i<100 ; i++) {

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtilTest.java
@@ -73,6 +73,7 @@ public class AnalyticsTrackerUtilTest {
 
     @AfterEach
     void closeService() throws Exception {
+        analyticsTrackerUtil.close();
         closeable.close();
     }
 

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -176,7 +176,7 @@
             destroy-method="shutdown">
     </bean>
     
-    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil">
+    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init">
         <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
         <property name="matomoAuthToken" value="${matomo.authToken}" />
         <property name="matomoApiURL" value="${matomo.api.url}" />

--- a/web-services-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/service-context.xml
@@ -176,7 +176,7 @@
             destroy-method="shutdown">
     </bean>
     
-    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init">
+    <bean id="analyticsTracker" class="edu.unc.lib.boxc.web.common.utils.AnalyticsTrackerUtil" init-method="init" destroy-method="close">
         <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
         <property name="matomoAuthToken" value="${matomo.authToken}" />
         <property name="matomoApiURL" value="${matomo.api.url}" />


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4497

* Reuse a single instance of MatomoTracker
* Add init and close methods to AnalyticsTrackerUtil to create the MatomoTracker and shut it down
* Update to Matomo-java-tracker 3.3.0