### PR TITLE
BXC-4505 - Prevent error when no facet fields are returned while populating facet list

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
@@ -73,6 +73,9 @@ public class MultiSelectFacetListService extends AbstractFacetListService {
         resultResponse.setSelectedContainer(selectedContainer);
         // Get list of facet fields without filters. Next we will add facet fields which are filtered to this list.
         FacetFieldList resultFacets = resultResponse.getFacetFields();
+        if (resultFacets == null) {
+            resultFacets = new FacetFieldList();
+        }
 
         // For each facet selected in the original search state, add facet list with results as
         // if the that facet were not selected

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 /**
@@ -637,6 +639,18 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
 
         assertNumberFacetsReturned(resp, DATE_CREATED_YEAR, 1);
         assertFacetValueCount(resp, DATE_CREATED_YEAR, UnknownRange.UNKNOWN_VALUE, 1);
+    }
+
+    @Test
+    public void noFacetsToRetrieveTest() throws Exception {
+        SearchState searchState = new SearchState();
+        searchState.setFacetsToRetrieve(Collections.emptyList());
+
+        SearchRequest request = new SearchRequest(searchState, accessGroups);
+        request.setRetrieveFacets(false);
+        SearchResultResponse resp = service.getFacetListResult(request);
+
+        assertTrue(resp.getFacetFields().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4505

* Prevent error when no facet fields are returned while populating facet list