### PR TITLE
BXC-4503 - Handle multiple IPs and cleanup

### DIFF
--- a/auth-fcrepo/src/main/java/edu/unc/lib/boxc/auth/fcrepo/services/GroupsThreadStore.java
+++ b/auth-fcrepo/src/main/java/edu/unc/lib/boxc/auth/fcrepo/services/GroupsThreadStore.java
@@ -31,8 +31,9 @@ public abstract class GroupsThreadStore {
         GroupsThreadStore.groups.set(groups);
         if (groups != null) {
             GroupsThreadStore.groupString.set(groups.joinAccessGroups(";"));
-            GroupsThreadStore.agentPrincipals.remove();
         }
+        // Clear agent principals any time groups are set, so that agentPrincipals will reset
+        GroupsThreadStore.agentPrincipals.remove();
     }
 
     /**
@@ -51,15 +52,6 @@ public abstract class GroupsThreadStore {
      */
     public static String getGroupString() {
         return GroupsThreadStore.groupString.get();
-    }
-
-    /**
-     * Clears the CDR groups associated with the current thread.
-     */
-    public static void clearGroups() {
-        GroupsThreadStore.groups.remove();
-        GroupsThreadStore.groupString.remove();
-        GroupsThreadStore.agentPrincipals.remove();
     }
 
     /**

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProvider.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProvider.java
@@ -52,6 +52,10 @@ public class PatronPrincipalProvider {
         String remoteAddr = request.getHeader(FORWARDED_FOR_HEADER);
         if (StringUtils.isBlank(remoteAddr)) {
             return princs;
+        } else {
+            // Get the last IP in the chain, which should be the server assigned IP rather than client provided one
+            var addresses = remoteAddr.split(",");
+            remoteAddr = addresses[addresses.length - 1].trim();
         }
 
         BigInteger ipInteger = IPAddressPatronPrincipalConfig.ipToBigInteger(remoteAddr);

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProvider.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProvider.java
@@ -51,10 +51,7 @@ public class PatronPrincipalProvider {
 
         String remoteAddr = request.getHeader(FORWARDED_FOR_HEADER);
         if (StringUtils.isBlank(remoteAddr)) {
-            remoteAddr = request.getRemoteAddr();
-            if (StringUtils.isBlank(remoteAddr)) {
-                return princs;
-            }
+            return princs;
         }
 
         BigInteger ipInteger = IPAddressPatronPrincipalConfig.ipToBigInteger(remoteAddr);

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
@@ -74,7 +74,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
                         GroupsThreadStore.getGroupString());
             }
         } catch (Exception e) {
-            log.warn("Error while retrieving the users profile", e);
+            log.error("Error while retrieving the users profile", e);
         }
     }
 

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
@@ -69,9 +69,6 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
             AccessGroupSet accessGroups = getUserGroups(request);
             GroupsThreadStore.storeGroups(accessGroups);
 
-            AgentPrincipals principals = GroupsThreadStore.getAgentPrincipals();
-            request.setAttribute("accessGroupSet", principals.getPrincipals());
-
             if (log.isDebugEnabled()) {
                 log.debug("Setting cdr groups for request processing thread: {}",
                         GroupsThreadStore.getGroupString());

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilter.java
@@ -74,7 +74,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
                         GroupsThreadStore.getGroupString());
             }
         } catch (Exception e) {
-            log.debug("Error while retrieving the users profile", e);
+            log.warn("Error while retrieving the users profile", e);
         }
     }
 
@@ -123,7 +123,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
 
     protected AccessGroupSet getGrouperGroups(HttpServletRequest request) {
         String shibGroups = request.getHeader(HttpAuthHeaders.SHIBBOLETH_GROUPS_HEADER);
-        AccessGroupSet accessGroups = null;
+        AccessGroupSet accessGroups;
         String userName = GroupsThreadStore.getUsername();
         if (log.isDebugEnabled()) {
             log.debug("Normal user " + userName + " logged in with groups " + shibGroups);

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProviderTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronPrincipalProviderTest.java
@@ -354,6 +354,33 @@ public class PatronPrincipalProviderTest {
                 PUBLIC_PRINC);
     }
 
+    @Test
+    public void getPrincipalsIpChainLastMatch() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP2 + ", " + TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpChainLastNotMatch() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP + ", " + TEST_IP2));
+        assertContainsPrincipals(princs, PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsMultipleIpChainLastMatch() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP3 + ", " + TEST_IP2 + ", " + TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
     private void assertContainsPrincipals(List<String> princs, String... expected) {
         String msg = "Expected [" + String.join(",", expected) + "] received " + princs;
         assertEquals(expected.length, princs.size(), msg);

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilterTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/filters/StoreUserAccessControlFilterTest.java
@@ -94,7 +94,6 @@ public class StoreUserAccessControlFilterTest {
         assertNull(GroupsThreadStore.getEmail());
         AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
         assertTrue(accessGroups.contains(PUBLIC_PRINC), "Public must be assigned");
-        verify(request).setAttribute("accessGroupSet", accessGroups);
     }
 
     @Test
@@ -109,7 +108,6 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
         AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
-        verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue(accessGroups.contains(PUBLIC_PRINC), "Public must be assigned");
         assertTrue(accessGroups.contains(AUTHENTICATED_PRINC), "Authenticated must be assigned");
@@ -127,7 +125,6 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
         AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
-        verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue(accessGroups.contains(PUBLIC_PRINC), "Public must be assigned");
         assertTrue(accessGroups.contains(AUTHENTICATED_PRINC), "Authenticated must be assigned");
@@ -144,7 +141,6 @@ public class StoreUserAccessControlFilterTest {
         assertNull(GroupsThreadStore.getEmail());
 
         AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
-        verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertEquals(2, accessGroups.size());
         assertTrue(accessGroups.contains(PUBLIC_PRINC), "Public must be assigned");
@@ -163,7 +159,6 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
         AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
-        verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue(accessGroups.contains(PUBLIC_PRINC), "Public must be assigned");
         assertTrue(accessGroups.contains(AUTHENTICATED_PRINC), "Authenticated must be assigned");


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4503

* Use the last IP in x-forwarded-for header if multiple are present, since it is the one set by our server rather than the client. 
    * This should resolve the "No access groups" issue we have been having.
* Increase log level when an exception is thrown while setting user access info
* Remove unused code related to setting user access info, some of which was leftover from when the application used JSP for the front end.
* Always clear agentPrincipals when setting groups