### PR TITLE
Bxc 4448 api endpoint

### DIFF
--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequest.java
@@ -22,7 +22,7 @@ public class StreamingPropertiesRequest {
     public static Set<String> VALID_FOLDERS = new HashSet<>(asList(OPEN, CLOSED, CAMPUS));
     @JsonDeserialize(as = AgentPrincipalsImpl.class)
     private AgentPrincipals agent;
-    private String filePidString;
+    private String id;
     private String filename;
     private String folder;
     private String action;
@@ -38,12 +38,12 @@ public class StreamingPropertiesRequest {
         this.agent = agent;
     }
 
-    public String getFilePidString() {
-        return filePidString;
+    public String getId() {
+        return id;
     }
 
-    public void setFilePidString(String filePidString) {
-        this.filePidString = filePidString;
+    public void setId(String id) {
+        this.id = id;
     }
 
     public String getFilename() {

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSender.java
@@ -19,6 +19,6 @@ public class StreamingPropertiesRequestSender extends MessageSender {
         String messageBody = MAPPER.writeValueAsString(request);
         sendMessage(messageBody);
         log.info("Job to update streaming properties has been queued for file {} by {}",
-                request.getFilePidString(), request.getAgent().getUsername());
+                request.getId(), request.getAgent().getUsername());
     }
 }

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSender.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSender.java
@@ -1,0 +1,24 @@
+package edu.unc.lib.boxc.operations.jms.streaming;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import edu.unc.lib.boxc.operations.jms.MessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Service for sending requests to update streaming properties of a file object
+ */
+public class StreamingPropertiesRequestSender extends MessageSender {
+    private static final Logger log = LoggerFactory.getLogger(StreamingPropertiesRequestSender.class);
+    private static final ObjectWriter MAPPER = new ObjectMapper().writerFor(StreamingPropertiesRequest.class);
+
+    public void sendToQueue(StreamingPropertiesRequest request) throws IOException {
+        String messageBody = MAPPER.writeValueAsString(request);
+        sendMessage(messageBody);
+        log.info("Job to update streaming properties has been queued for file {} by {}",
+                request.getFilePidString(), request.getAgent().getUsername());
+    }
+}

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
@@ -41,7 +41,7 @@ public class StreamingPropertiesRequestSenderTest {
         var filePidString = makePid().toString();
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
-        request.setFilePidString(filePidString);
+        request.setId(filePidString);
         request.setFilename("banjo.mp3");
         request.setFolder(StreamingPropertiesRequest.CLOSED);
         request.setAction("add");

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
@@ -1,0 +1,56 @@
+package edu.unc.lib.boxc.operations.jms.streaming;
+
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.jms.core.JmsTemplate;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class StreamingPropertiesRequestSenderTest {
+    @Mock
+    private JmsTemplate jmsTemplate;
+    private StreamingPropertiesRequestSender streamingPropertiesRequestSender = new StreamingPropertiesRequestSender();
+    private AutoCloseable closeable;
+    private final AgentPrincipals agent = new AgentPrincipalsImpl("user", new AccessGroupSetImpl("agroup"));
+
+    @BeforeEach
+    public void setup() {
+        closeable = openMocks(this);
+        streamingPropertiesRequestSender.setJmsTemplate(jmsTemplate);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void sendToQueueTest() throws IOException {
+        var filePidString = makePid().toString();
+        var request = new StreamingPropertiesRequest();
+        request.setAgent(agent);
+        request.setFilePidString(filePidString);
+        request.setFilename("banjo.mp3");
+        request.setFolder(StreamingPropertiesRequest.CLOSED);
+        request.setAction("add");
+
+        streamingPropertiesRequestSender.sendToQueue(request);
+        verify(jmsTemplate).send(any());
+    }
+
+    public static PID makePid() {
+        return PIDs.get(UUID.randomUUID().toString());
+    }
+}

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSerializationHelperTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSerializationHelperTest.java
@@ -22,7 +22,7 @@ public class StreamingPropertiesRequestSerializationHelperTest {
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
         request.setFilename("banjo_recording.mp3");
-        request.setFilePidString(pid.getId());
+        request.setId(pid.getId());
         request.setFolder(StreamingPropertiesRequest.OPEN);
         request.setAction(ADD);
 
@@ -32,7 +32,7 @@ public class StreamingPropertiesRequestSerializationHelperTest {
         assertEquals(request.getAction(), helperRequest.getAction());
         assertEquals(request.getAgent().getPrincipals(), helperRequest.getAgent().getPrincipals());
         assertEquals(request.getFilename(), helperRequest.getFilename());
-        assertEquals(request.getFilePidString(), helperRequest.getFilePidString());
+        assertEquals(request.getId(), helperRequest.getId());
         assertEquals(request.getFolder(), helperRequest.getFolder());
     }
 }

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -36,7 +36,7 @@ public class StreamingPropertiesRequestProcessor implements Processor {
         var in = exchange.getIn();
         var request = StreamingPropertiesRequestSerializationHelper.toRequest(in.getBody(String.class));
         var agent = request.getAgent();
-        var pid = PIDs.get(request.getFilePidString());
+        var pid = PIDs.get(request.getId());
 
         aclService.assertHasAccess("User does not have permission to set streaming properties",
                 pid, agent.getPrincipals(), Permission.ingest);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -59,13 +59,20 @@ public class StreamingPropertiesRequestProcessor implements Processor {
     }
 
     private String validate(StreamingPropertiesRequest request, PID pid) {
-        var folder = request.getFolder();
-        if (StringUtils.isBlank(request.getFilename()) || StringUtils.isBlank(folder)) {
-            return "Both a filename and streaming folder are required.";
+        var action = request.getAction();
+        if (StringUtils.isBlank(action)) {
+            return "An action is required.";
         }
 
-        if (!VALID_FOLDERS.contains(folder)) {
-            return "Streaming folder is not valid.";
+        if (Objects.equals(ADD, action)) {
+            var folder = request.getFolder();
+            if (StringUtils.isBlank(request.getFilename()) || StringUtils.isBlank(folder)) {
+                return "Both a filename and streaming folder are required.";
+            }
+
+            if (!VALID_FOLDERS.contains(folder)) {
+                return "Streaming folder is not valid.";
+            }
         }
 
         try {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -59,29 +59,30 @@ public class StreamingPropertiesRequestProcessor implements Processor {
     }
 
     private String validate(StreamingPropertiesRequest request, PID pid) {
+        String errorMessage = null;
         var action = request.getAction();
         if (StringUtils.isBlank(action)) {
-            return "An action is required.";
+            errorMessage = "An action is required.";
         }
 
         if (Objects.equals(ADD, action)) {
             var folder = request.getFolder();
             if (StringUtils.isBlank(request.getFilename()) || StringUtils.isBlank(folder)) {
-                return "Both a filename and streaming folder are required.";
+                errorMessage = "Both a filename and streaming folder are required.";
             }
 
             if (!VALID_FOLDERS.contains(folder)) {
-                return "Streaming folder is not valid.";
+                errorMessage = "Streaming folder is not valid.";
             }
         }
 
         try {
             repositoryObjectLoader.getFileObject(pid);
         } catch (ObjectTypeMismatchException e) {
-            return "Object is not a FileObject";
+            errorMessage = "Object is not a FileObject";
         }
         // Request is valid
-        return null;
+        return errorMessage;
     }
 
     /**

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -59,30 +59,29 @@ public class StreamingPropertiesRequestProcessor implements Processor {
     }
 
     private String validate(StreamingPropertiesRequest request, PID pid) {
-        String errorMessage = null;
         var action = request.getAction();
         if (StringUtils.isBlank(action)) {
-            errorMessage = "An action is required.";
+            return "An action is required.";
         }
 
         if (Objects.equals(ADD, action)) {
             var folder = request.getFolder();
             if (StringUtils.isBlank(request.getFilename()) || StringUtils.isBlank(folder)) {
-                errorMessage = "Both a filename and streaming folder are required.";
+                return "Both a filename and streaming folder are required.";
             }
 
             if (!VALID_FOLDERS.contains(folder)) {
-                errorMessage = "Streaming folder is not valid.";
+                return "Streaming folder is not valid.";
             }
         }
 
         try {
             repositoryObjectLoader.getFileObject(pid);
         } catch (ObjectTypeMismatchException e) {
-            errorMessage = "Object is not a FileObject";
+            return "Object is not a FileObject";
         }
         // Request is valid
-        return errorMessage;
+        return null;
     }
 
     /**

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
@@ -147,11 +147,11 @@ public class StreamingPropertiesProcessorTest {
         verify(repositoryObjectFactory).deleteProperty(eq(fileObject), eq(Cdr.streamingFolder));
     }
 
-    private Exchange createRequestExchange(String folder, String filename, String pid, String action) throws IOException {
+    private Exchange createRequestExchange(String folder, String filename, String id, String action) throws IOException {
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
         request.setFilename(filename);
-        request.setFilePidString(pid);
+        request.setId(id);
         request.setFolder(folder);
         request.setAction(action);
         return TestHelper.mockExchange(StreamingPropertiesRequestSerializationHelper.toJson(request));

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
@@ -139,7 +139,7 @@ public class StreamingPropertiesProcessorTest {
 
     @Test
     public void testStreamingPropertiesDeleteSuccess() throws IOException {
-        var exchange = createRequestExchange(OPEN, "banjo_recording.mp3", filePid.getId(), DELETE);
+        var exchange = createRequestExchange(null, null, filePid.getId(), DELETE);
         processor.process(exchange);
 
         verify(repositoryObjectFactory).deleteProperty(eq(fileObject), eq(Cdr.streamingHost));

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRouterTest.java
@@ -37,7 +37,7 @@ public class StreamingPropertiesRouterTest extends CamelSpringTestSupport {
 
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
-        request.setFilePidString(pid.getId());
+        request.setId(pid.getId());
         request.setFolder(StreamingPropertiesRequest.CLOSED);
         request.setFilename("new_file.mp3");
         var body = StreamingPropertiesRequestSerializationHelper.toJson(request);

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
@@ -33,6 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 @Controller
 public class StreamingPropertiesController {
     private static final Logger log = LoggerFactory.getLogger(StreamingPropertiesController.class);
+    private static final String ACTION = "action";
     @Autowired
     private AccessControlService accessControlService;
     @Autowired
@@ -71,7 +72,7 @@ public class StreamingPropertiesController {
 
     private StreamingPropertiesRequest buildRequest(AgentPrincipals agent, Map<String,String> params) {
         var request = new StreamingPropertiesRequest();
-        request.setAction(params.get("action"));
+        request.setAction(params.get(ACTION));
         request.setFilePidString(params.get("file"));
         request.setFolder(params.get("folder"));
         request.setFilename(params.get("filename"));
@@ -80,10 +81,11 @@ public class StreamingPropertiesController {
     }
 
     private boolean hasBadParams(Map<String,String> params) {
-        if (params.isEmpty() || StringUtils.isBlank(params.get("action")) || StringUtils.isBlank(params.get("file"))) {
+        var action = params.get(ACTION);
+        if (params.isEmpty() || StringUtils.isBlank(action) || StringUtils.isBlank(params.get("file"))) {
             return true;
         }
-        if (Objects.equals(ADD, params.get("action"))) {
+        if (Objects.equals(ADD, action)) {
             return StringUtils.isBlank(params.get("filename")) || StringUtils.isBlank(params.get("folder"));
         }
 

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
@@ -1,0 +1,89 @@
+package edu.unc.lib.boxc.web.services.rest.modify;
+
+import com.apicatalog.jsonld.StringUtils;
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.model.api.exceptions.InvalidOperationForObjectType;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest;
+import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequestSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore.getAgentPrincipals;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+/**
+ * Controller for setting streaming properties on a FileObject
+ */
+@Controller
+public class StreamingPropertiesController {
+    private static final Logger log = LoggerFactory.getLogger(StreamingPropertiesController.class);
+    @Autowired
+    private AccessControlService accessControlService;
+    @Autowired
+    private StreamingPropertiesRequestSender streamingPropertiesRequestSender;
+
+    @PutMapping(value = "/edit/streamingProperties", produces = APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public ResponseEntity<Object> updateStreamingProperties(@RequestParam Map<String,String> allParams) {
+        Map<String, Object> result = new HashMap<>();
+
+        if (hasBadParams(allParams)) {
+            result.put("error", "Streaming properties request must include action, file ID, folder, and filename");
+            return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
+        }
+
+        var fileId = allParams.get("file");
+        var pid = PIDs.get(fileId);
+        var agent = getAgentPrincipals();
+        AccessGroupSet principals = agent.getPrincipals();
+        accessControlService.assertHasAccess("Insufficient permissions to update streaming properties for " +
+                        fileId, pid, principals, Permission.ingest);
+
+        var request = buildRequest(allParams);
+        try {
+            streamingPropertiesRequestSender.sendToQueue(request);
+        } catch (IOException e) {
+            log.error("Error updating streaming properties for {}", request.getFilePidString(), e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        result.put("status", "Submitted streaming properties updates for " + fileId);
+        result.put("timestamp", System.currentTimeMillis());
+
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    private StreamingPropertiesRequest buildRequest(Map<String,String> params) {
+        var request = new StreamingPropertiesRequest();
+        request.setAction(params.get("action"));
+        request.setFilePidString(params.get("file"));
+        request.setFolder(params.get("folder"));
+        request.setFilename(params.get("filename"));
+        return request;
+    }
+
+    private boolean hasBadParams(Map<String,String> params) {
+        return params.isEmpty() ||
+                StringUtils.isBlank(params.get("action")) ||
+                StringUtils.isBlank(params.get("filename")) ||
+                StringUtils.isBlank(params.get("file")) ||
+                StringUtils.isBlank(params.get("folder"));
+    }
+}

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
@@ -111,7 +111,7 @@ public class StreamingPropertiesIT {
     @Test
     public void testDeleteStreamingPropertiesSuccess() throws Exception {
         var result = mockMvc.perform(put(
-                        "/edit/streamingProperties?action=delete&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                        "/edit/streamingProperties?action=delete&file=" + FILE_ID ))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
         Map<String, Object> respMap = MvcTestHelpers.getMapFromResponse(result);

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
@@ -7,13 +7,10 @@ import edu.unc.lib.boxc.auth.api.services.AccessControlService;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.model.api.ids.PID;
-import edu.unc.lib.boxc.model.api.objects.FileObject;
-import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequestSender;
 import edu.unc.lib.boxc.web.services.rest.MvcTestHelpers;
 import edu.unc.lib.boxc.web.services.rest.exceptions.RestResponseEntityExceptionHandler;
-import org.apache.jena.rdf.model.Statement;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +28,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.MockitoAnnotations.openMocks;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -68,20 +64,20 @@ public class StreamingPropertiesIT {
         doThrow(new AccessRestrictionException()).when(accessControlService)
                 .assertHasAccess(anyString(), eq(FILE_PID), any(), eq(Permission.ingest));
         mockMvc.perform(put(
-                "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&id=" + FILE_ID + "&folder=" + OPEN))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     public void testUpdateStreamingPropertiesNoFilename() throws Exception {
         mockMvc.perform(put(
-                "/edit/streamingProperties?action=add&file=" + FILE_ID + "&folder=" + OPEN))
+                "/edit/streamingProperties?action=add&id=" + FILE_ID + "&folder=" + OPEN))
                 .andExpect(status().isBadRequest());
     }
     @Test
     public void testUpdateStreamingPropertiesNoFolder() throws Exception {
         mockMvc.perform(put(
-                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID))
+                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&id=" + FILE_ID))
                 .andExpect(status().isBadRequest());
     }
     @Test
@@ -94,14 +90,14 @@ public class StreamingPropertiesIT {
     @Test
     public void testUpdateStreamingPropertiesNoAction() throws Exception {
         mockMvc.perform(put(
-                        "/edit/streamingProperties?&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                        "/edit/streamingProperties?&filename=banjo_sounds.mp3&id=" + FILE_ID + "&folder=" + OPEN))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     public void testAddStreamingPropertiesSuccess() throws Exception {
         var result = mockMvc.perform(put(
-                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&id=" + FILE_ID + "&folder=" + OPEN))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
         Map<String, Object> respMap = MvcTestHelpers.getMapFromResponse(result);
@@ -111,7 +107,7 @@ public class StreamingPropertiesIT {
     @Test
     public void testDeleteStreamingPropertiesSuccess() throws Exception {
         var result = mockMvc.perform(put(
-                        "/edit/streamingProperties?action=delete&file=" + FILE_ID ))
+                        "/edit/streamingProperties?action=delete&id=" + FILE_ID ))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
         Map<String, Object> respMap = MvcTestHelpers.getMapFromResponse(result);

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
@@ -1,0 +1,120 @@
+package edu.unc.lib.boxc.web.services.rest.modify;
+
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.exceptions.AccessRestrictionException;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.FileObject;
+import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequestSender;
+import edu.unc.lib.boxc.web.services.rest.MvcTestHelpers;
+import edu.unc.lib.boxc.web.services.rest.exceptions.RestResponseEntityExceptionHandler;
+import org.apache.jena.rdf.model.Statement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Map;
+
+import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.OPEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class StreamingPropertiesIT {
+    @InjectMocks
+    private StreamingPropertiesController controller;
+    @Mock
+    private AccessControlService accessControlService;
+    @Mock
+    private StreamingPropertiesRequestSender streamingPropertiesRequestSender;
+    private MockMvc mockMvc;
+    private AutoCloseable closeable;
+    private final static String USERNAME = "test_user";
+    private final static AccessGroupSet GROUPS = new AccessGroupSetImpl("adminGroup");
+    private static final String FILE_ID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    private static final PID FILE_PID = PIDs.get(FILE_ID);
+    @BeforeEach
+    public void setup() {
+        closeable = openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new RestResponseEntityExceptionHandler())
+                .build();
+        GroupsThreadStore.storeUsername(USERNAME);
+        GroupsThreadStore.storeGroups(GROUPS);
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void testUpdateStreamingPropertiesNoPermission() throws Exception {
+        doThrow(new AccessRestrictionException()).when(accessControlService)
+                .assertHasAccess(anyString(), eq(FILE_PID), any(), eq(Permission.ingest));
+        mockMvc.perform(put(
+                "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void testUpdateStreamingPropertiesNoFilename() throws Exception {
+        mockMvc.perform(put(
+                "/edit/streamingProperties?action=add&file=" + FILE_ID + "&folder=" + OPEN))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void testUpdateStreamingPropertiesNoFolder() throws Exception {
+        mockMvc.perform(put(
+                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void testUpdateStreamingPropertiesNoFileId() throws Exception {
+        mockMvc.perform(put(
+                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&folder=" + OPEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testUpdateStreamingPropertiesNoAction() throws Exception {
+        mockMvc.perform(put(
+                        "/edit/streamingProperties?&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testAddStreamingPropertiesSuccess() throws Exception {
+        var result = mockMvc.perform(put(
+                        "/edit/streamingProperties?action=add&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        Map<String, Object> respMap = MvcTestHelpers.getMapFromResponse(result);
+        assertEquals("Submitted streaming properties updates for " + FILE_ID, respMap.get("status"));
+    }
+
+    @Test
+    public void testDeleteStreamingPropertiesSuccess() throws Exception {
+        var result = mockMvc.perform(put(
+                        "/edit/streamingProperties?action=delete&filename=banjo_sounds.mp3&file=" + FILE_ID + "&folder=" + OPEN))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+        Map<String, Object> respMap = MvcTestHelpers.getMapFromResponse(result);
+        assertEquals("Submitted streaming properties updates for " + FILE_ID, respMap.get("status"));
+    }
+}


### PR DESCRIPTION
This PR adds necessary files for adding and deleting streaming properties via API endpoint. It also refactors some validations and makes the TestHelper file more generic so it's not just for Processor tests.
https://unclibrary.atlassian.net/browse/BXC-4448