### PR TITLE
BXC-4521 - Handle client connections being closed early during single use link downloads

### DIFF
--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/FedoraContentController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/FedoraContentController.java
@@ -31,6 +31,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
@@ -107,7 +108,7 @@ public class FedoraContentController {
     private void handleIOException(PID pid, String datastream, IOException e) {
         var cause = ExceptionUtils.getRootCause(e);
         if (cause != null) {
-            if (cause.getMessage().contains("Connection reset by peer")) {
+            if (cause.getMessage().contains("Connection reset by peer") || cause instanceof EOFException) {
                 log.debug("Client reset connection while downloading {}/{}", pid.getId(), datastream);
                 return;
             }

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/SingleUseKeyController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/SingleUseKeyController.java
@@ -74,24 +74,19 @@ public class SingleUseKeyController {
 
     @RequestMapping(value = "/single_use_link/{key}", method = RequestMethod.GET)
     public void download(@PathVariable("key") String accessKey, HttpServletRequest request,
-                                                HttpServletResponse response) {
-        try {
-            if (singleUseKeyService.keyIsValid(accessKey)) {
-                var id = singleUseKeyService.getId(accessKey);
-                var pid = PIDs.get(id);
-                var datastream = ORIGINAL_FILE.getId();
-                var principals = getAgentPrincipals().getPrincipals();
+                                                HttpServletResponse response) throws IOException {
+        if (singleUseKeyService.keyIsValid(accessKey)) {
+            var id = singleUseKeyService.getId(accessKey);
+            var pid = PIDs.get(id);
+            var datastream = ORIGINAL_FILE.getId();
+            var principals = getAgentPrincipals().getPrincipals();
 
-                singleUseKeyService.invalidate(accessKey);
-                fedoraContentService.streamData(pid, datastream, true, response);
-                log.info("Single use link used. Access Key: {}, UUID: {}", accessKey, id);
-                analyticsTracker.trackEvent(request, "download", pid, principals);
-            } else {
-                throw new NotFoundException("Single use key is not valid: " + accessKey);
-            }
-        } catch (IOException e) {
-            log.error("Download single use link did not work:", e);
-            throw new RepositoryException("Failed to download file using single use access key: " + accessKey);
+            singleUseKeyService.invalidate(accessKey);
+            fedoraContentService.streamData(pid, datastream, true, response);
+            log.info("Single use link used. Access Key: {}, UUID: {}", accessKey, id);
+            analyticsTracker.trackEvent(request, "download", pid, principals);
+        } else {
+            throw new NotFoundException("Single use key is not valid: " + accessKey);
         }
     }
 }


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4521

* Handle uncaught EOFExceptions (which are thrown when the client disconnects early) by demoting it to a debug statement. 
* Allow download methods in the services app to throw IOExceptions rather than handling them locally, so that general error handling can deal with them, and specifically deal with EOFExceptions. 
* Exception handling methods now should now have a fall back for all exceptions, not just RuntimeExceptions