### PR TITLE
BXC-4524 - Cleanup warnings when invalid facet key provided

### DIFF
--- a/search-solr/pom.xml
+++ b/search-solr/pom.xml
@@ -117,5 +117,11 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchStateFactory.java
@@ -308,11 +308,16 @@ public class SearchStateFactory {
                 String parameterPairArray[] = parameterPair.split(":", 2);
                 if (parameterPairArray.length > 1) {
                     try {
-                        facetFieldUtil.setFacetLimit(searchSettings.searchFieldKey(parameterPairArray[0]),
-                                Integer.parseInt(parameterPairArray[1]), searchState);
-                    } catch (Exception e) {
-                        log.warn("Failed to add facet limit {} to field {}", new Object[] { parameterPairArray[0],
-                                parameterPairArray[1] }, e);
+                        var fieldKey = searchSettings.searchFieldKey(parameterPairArray[0]);
+                        if (fieldKey == null) {
+                            log.warn("Unknown facet limit field key: {}", parameterPairArray[0]);
+                            continue;
+                        }
+                        facetFieldUtil.setFacetLimit(fieldKey, Integer.parseInt(parameterPairArray[1]), searchState);
+                    } catch (IllegalArgumentException | InvalidFacetException e) {
+                        log.warn("Failed to add facet limit {} to field {}: {}", parameterPairArray[0],
+                                parameterPairArray[1], e.getMessage());
+                        log.debug("Exception from invalid facet limit", e);
                     }
                 }
             }
@@ -492,5 +497,9 @@ public class SearchStateFactory {
 
     public void setFacetFieldFactory(FacetFieldFactory facetFieldFactory) {
         this.facetFieldFactory = facetFieldFactory;
+    }
+
+    public void setFacetFieldUtil(FacetFieldUtil facetFieldUtil) {
+        this.facetFieldUtil = facetFieldUtil;
     }
 }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/utils/FacetFieldUtil.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/utils/FacetFieldUtil.java
@@ -171,4 +171,8 @@ public class FacetFieldUtil {
     public void setSolrSettings(SolrSettings solrSettings) {
         this.solrSettings = solrSettings;
     }
+
+    public void setFacetFieldFactory(FacetFieldFactory facetFieldFactory) {
+        this.facetFieldFactory = facetFieldFactory;
+    }
 }


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4524

* Add special handling of field name not existing when setting facetLimits, and reduce logging of other facet class errors.
* Increase test coverage of the SearchStateFactory createSearchState method
* Add mockito-inline jar so that we can mock static methods (this is built into mockito-core in version 5)