### PR TITLE
BXC-4589 - Prevent attempt to update work before it is indexed

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solrUpdate/AggregateUpdateProcessor.java
@@ -50,7 +50,10 @@ public class AggregateUpdateProcessor implements Processor {
         }
         for (Object idObj : idCollection) {
             PID pid = PIDs.get(idObj.toString());
-            messageSender.sendIndexingOperation(null, pid, actionType);
+            // Make sure the object exists in solr before attempting to update it
+            if (solrClient.getById(pid.getId()) != null) {
+                messageSender.sendIndexingOperation(null, pid, actionType);
+            }
         }
     }
 

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -16,6 +16,7 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.common.SolrDocument;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  *
@@ -236,6 +238,8 @@ public class SolrUpdateRouterTest {
 
     @Test
     public void multipleWorkFromFile() throws Exception {
+        when(solrClient.getById(any(String.class))).thenReturn(new SolrDocument());
+
         PID targetPid1 = pidMinter.mintContentPid();
         PID targetPid2 = pidMinter.mintContentPid();
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4589

* Verify that an object exists in solr before attempting to update it via AggregateUpdateProcessor, which is currently only used for the workflow that triggers indexing of the parent work when a binary is updated.