### PR TITLE
BXC-4604 - Use label as filename for TechMD extract

### DIFF
--- a/common-utils/src/main/java/edu/unc/lib/boxc/common/http/MimetypeHelpers.java
+++ b/common-utils/src/main/java/edu/unc/lib/boxc/common/http/MimetypeHelpers.java
@@ -21,7 +21,7 @@ public class MimetypeHelpers {
      * @return true if the given mimetype appears to be a valid mimetype
      */
     public static boolean isValidMimetype(String mimetype) {
-        if (StringUtils.isBlank(mimetype)) {
+        if (StringUtils.isBlank(mimetype) || mimetype.contains("symlink")) {
             return false;
         }
         return VALID_MIMETYPE_PATTERN.matcher(mimetype).matches();

--- a/common-utils/src/test/java/edu/unc/lib/boxc/common/http/MimetypeHelpersTest.java
+++ b/common-utils/src/test/java/edu/unc/lib/boxc/common/http/MimetypeHelpersTest.java
@@ -1,0 +1,61 @@
+package edu.unc.lib.boxc.common.http;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bbpennel
+ */
+public class MimetypeHelpersTest {
+    @Test
+    public void isValidMimetypeNullTest() {
+        String mimetype = null;
+        assertFalse(MimetypeHelpers.isValidMimetype(mimetype));
+    }
+
+    @Test
+    public void isValidMimetypeBlankTest() {
+        String mimetype = "";
+        assertFalse(MimetypeHelpers.isValidMimetype(mimetype));
+    }
+
+    @Test
+    public void isValidMimetypeSymlinkTest() {
+        String mimetype = "inode/symlink";
+        assertFalse(MimetypeHelpers.isValidMimetype(mimetype));
+    }
+
+    @Test
+    public void isValidMimetypeInvalidFormatTest() {
+        String mimetype = "invalid format";
+        assertFalse(MimetypeHelpers.isValidMimetype(mimetype));
+    }
+
+    @Test
+    public void isValidMimetypeNefTest() {
+        String mimetype = "image/x-nikon-nef";
+        assertTrue(MimetypeHelpers.isValidMimetype(mimetype));
+    }
+
+    @Test
+    public void formatMimetypeNullTest() {
+        String mimetype = null;
+        assertNull(MimetypeHelpers.formatMimetype(mimetype));
+    }
+
+    @Test
+    public void formatMimetypeWithParamsTest() {
+        String mimetype = "text/plain; charset=UTF-8";
+        assertEquals("text/plain", MimetypeHelpers.formatMimetype(mimetype));
+    }
+
+    @Test
+    public void formatMimetypeRegularTest() {
+        String mimetype = "text/plain";
+        assertEquals("text/plain", MimetypeHelpers.formatMimetype(mimetype));
+    }
+}

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJob.java
@@ -337,7 +337,7 @@ public class ExtractTechnicalMetadataJob extends AbstractConcurrentDepositJob {
 
     /**
      * Creates a symlink to the provided stagedUri, where the symlink is sanitized of problematic characters
-     * and uses the label as the filename to ensure the original file extensions is present, if available.
+     * and uses the label as the filename to ensure the original file extension is present, if available.
      * @param objPid
      * @param stagedUriString
      * @param label


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4604

* Update TechnicalMetadata FITS job to always use a symlink before processing, and use the provided label for the filename if present. 
    * Files with unicode characters can be processed by the FITS web app now since the paths get sanitized there now too
* Ignore symlink mimetype when deciding which mimetype to use, since everything is going to return symlink now