### PR TITLE
BXC-4590 - Skip Derivatives for icon files

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessor.java
@@ -20,7 +20,7 @@ public class ImageDerivativeProcessor implements Processor {
 
     private static final Pattern MIMETYPE_PATTERN = Pattern.compile("^(image.*$|application.*?(photoshop|psd)$)");
 
-    private static final Pattern DISALLOWED_PATTERN = Pattern.compile(".*(vnd\\.fpx).*");
+    private static final Pattern DISALLOWED_PATTERN = Pattern.compile(".*(vnd\\.fpx|x-icon).*");
 
     /**
      * Returns true if the subject of the exchange is a binary which

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouterTest.java
@@ -36,12 +36,9 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-
-import edu.unc.lib.boxc.services.camel.images.AddDerivativeProcessor;
 
 public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
     private static final String EVENT_NS = "http://fedora.info/definitions/v4/event#";
@@ -423,6 +420,7 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
     public void testAccessCopyRejection() throws Exception {
         createContext(accessCopyRoute);
 
+        when(addAccessCopyProcessor.needsRun(any())).thenReturn(true);
         getMockEndpoint("mock:process.enhancement.imageAccessCopy").expectedMessageCount(0);
 
         Map<String, Object> headers = createEvent(fileID, eventTypes, "false");
@@ -438,6 +436,7 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
     public void testAccessCopyDisallowedImageType() throws Exception {
         createContext(accessCopyRoute);
 
+        when(addAccessCopyProcessor.needsRun(any())).thenReturn(true);
         getMockEndpoint("mock:exec:/bin/sh").expectedMessageCount(0);
 
         Map<String, Object> headers = createEvent(fileID, eventTypes, "false");
@@ -445,6 +444,23 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
 
         template.sendBodyAndHeaders("", headers);
 
+        verify(addAccessCopyProcessor, never()).process(any(Exchange.class));
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testAccessCopyIconFile() throws Exception {
+        createContext(accessCopyRoute);
+
+        when(addAccessCopyProcessor.needsRun(any())).thenReturn(true);
+        getMockEndpoint("mock:exec:/bin/sh").expectedMessageCount(0);
+
+        Map<String, Object> headers = createEvent(fileID, eventTypes, "false");
+        headers.put(CdrBinaryMimeType, "image/x-icon");
+
+        template.sendBodyAndHeaders("", headers);
+
+        verify(addAccessCopyProcessor).needsRun(any(Exchange.class));
         verify(addAccessCopyProcessor, never()).process(any(Exchange.class));
         assertMockEndpointsSatisfied();
     }


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4590

* Add icon files to the list of image types not to attempt to produce derivatives for. 
* Add missing mock statements to some tests that were passing for the wrong reason