### PR TITLE
BXC-4612 - Update solr indexing to allow for streaming only files

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJob.java
@@ -1,9 +1,9 @@
 package edu.unc.lib.boxc.deposit.validate;
 
 import static edu.unc.lib.boxc.deposit.work.DepositGraphUtils.getChildIterator;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_SOUND;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_VIDEO;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_SOUND;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_VIDEO;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -73,7 +73,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static edu.unc.lib.boxc.persist.impl.storage.StorageLocationTestHelper.LOC1_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -5,7 +5,7 @@ import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.TECHNICAL_METADATA;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static edu.unc.lib.boxc.persist.impl.storage.StorageLocationTestHelper.LOC1_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
@@ -2,9 +2,9 @@ package edu.unc.lib.boxc.deposit.validate;
 
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.CONTENT_BASE;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_SOUND;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_VIDEO;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_SOUND;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_VIDEO;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -4,15 +4,19 @@ import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.boxc.indexing.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.boxc.indexing.solr.utils.TechnicalMetadataService;
+import edu.unc.lib.boxc.model.api.StreamingConstants;
+import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.api.objects.FileObject;
 import edu.unc.lib.boxc.model.api.objects.FolderObject;
 import edu.unc.lib.boxc.model.api.objects.RepositoryObjectLoader;
 import edu.unc.lib.boxc.model.api.objects.WorkObject;
+import edu.unc.lib.boxc.model.api.rdf.Cdr;
 import edu.unc.lib.boxc.model.api.services.ContentPathFactory;
 import edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
 import edu.unc.lib.boxc.search.api.ContentCategory;
 import edu.unc.lib.boxc.search.api.SearchFieldKey;
 import edu.unc.lib.boxc.search.api.facets.CutoffFacet;
@@ -39,11 +43,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static edu.unc.lib.boxc.indexing.solr.test.MockRepositoryObjectHelpers.makeFileObject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -381,6 +387,40 @@ public class SetContentTypeFilterTest {
         assertHasFileDescriptions(idb, "Extensible Markup Language");
         assertHasCategories(idb, ContentCategory.text);
         verify(solrSearchService, never()).getAncestorPath(anyString(), any(AccessGroupSet.class));
+    }
+
+    @Test
+    public void testStreamingOnlyVideo() throws Exception {
+        var filePid = TestHelper.makePid();
+        var fileObj =  makeFileObject(filePid, repositoryObjectLoader);
+        when(dip.getContentObject()).thenReturn(fileObj);
+        doThrow(NotFoundException.class).when(fileObj).getOriginalFile();
+        var fileResc = fileObj.getResource();
+        fileResc.addLiteral(Cdr.streamingUrl, "http://example.com/streaming/video");
+        fileResc.addLiteral(Cdr.streamingType, StreamingConstants.STREAMING_TYPE_VIDEO);
+
+        filter.filter(dip);
+
+        assertNull(idb.getFileFormatType());
+        assertHasFileDescriptions(idb, "Streaming Video");
+        assertHasCategories(idb, ContentCategory.video);
+    }
+
+    @Test
+    public void testStreamingOnlySound() throws Exception {
+        var filePid = TestHelper.makePid();
+        var fileObj =  makeFileObject(filePid, repositoryObjectLoader);
+        when(dip.getContentObject()).thenReturn(fileObj);
+        doThrow(NotFoundException.class).when(fileObj).getOriginalFile();
+        var fileResc = fileObj.getResource();
+        fileResc.addLiteral(Cdr.streamingUrl, "http://example.com/streaming/audio");
+        fileResc.addLiteral(Cdr.streamingType, StreamingConstants.STREAMING_TYPE_SOUND);
+
+        filter.filter(dip);
+
+        assertNull(idb.getFileFormatType());
+        assertHasFileDescriptions(idb, "Streaming Audio");
+        assertHasCategories(idb, ContentCategory.audio);
     }
 
     private void mockFile(String filename, String identity, String mimetype) {

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -409,7 +409,7 @@ public class SetContentTypeFilterTest {
     @Test
     public void testStreamingOnlySound() throws Exception {
         var filePid = TestHelper.makePid();
-        var fileObj =  makeFileObject(filePid, repositoryObjectLoader);
+        var fileObj = makeFileObject(filePid, repositoryObjectLoader);
         when(dip.getContentObject()).thenReturn(fileObj);
         doThrow(NotFoundException.class).when(fileObj).getOriginalFile();
         var fileResc = fileObj.getResource();

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/StreamingConstants.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/StreamingConstants.java
@@ -1,0 +1,14 @@
+package edu.unc.lib.boxc.model.api;
+
+/**
+ * Constants related to streaming media
+ *
+ * @author bbpennel
+ */
+public class StreamingConstants {
+
+    // If you change this value it also needs to be updated in static/js/admin/src/EditStreamingPropertiesForm.js
+    public static final String STREAMREAPER_PREFIX_URL = "https://durastream.lib.unc.edu/player";
+    public static final String STREAMING_TYPE_SOUND = "sound";
+    public static final String STREAMING_TYPE_VIDEO = "video";
+}

--- a/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequest.java
+++ b/operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequest.java
@@ -8,10 +8,6 @@ import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
  * Request object for updating the streaming properties of a FileObject
  */
 public class StreamingPropertiesRequest {
-    // If you change this value it also needs to be updated in static/js/admin/src/EditStreamingPropertiesForm.js
-    public static final String STREAMREAPER_PREFIX_URL = "https://durastream.lib.unc.edu/player";
-    public static final String STREAMING_TYPE_SOUND = "sound";
-    public static final String STREAMING_TYPE_VIDEO = "video";
     public static String ADD = "add";
     public static String DELETE = "delete";
     @JsonDeserialize(as = AgentPrincipalsImpl.class)

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSenderTest.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.operations.jms.streaming;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.StreamingConstants;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import org.junit.jupiter.api.AfterEach;
@@ -42,7 +43,7 @@ public class StreamingPropertiesRequestSenderTest {
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
         request.setId(filePidString);
-        request.setUrl(StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL + "?params=more");
+        request.setUrl(StreamingConstants.STREAMREAPER_PREFIX_URL + "?params=more");
         request.setAction("add");
         request.setType("video");
 

--- a/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSerializationHelperTest.java
+++ b/operations-jms/src/test/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequestSerializationHelperTest.java
@@ -11,8 +11,8 @@ import java.io.IOException;
 import java.util.UUID;
 
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.ADD;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_SOUND;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_SOUND;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StreamingPropertiesRequestSerializationHelperTest {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -21,9 +21,9 @@ import java.util.Objects;
 
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.ADD;
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.DELETE;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_SOUND;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMING_TYPE_VIDEO;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_SOUND;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMING_TYPE_VIDEO;
 
 /**
  * Processing requests to edit streaming properties on a FileObject

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesProcessorTest.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.ADD;
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.DELETE;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRouterTest.java
@@ -3,6 +3,7 @@ package edu.unc.lib.boxc.services.camel.streaming;
 import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
 import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
 import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.StreamingConstants;
 import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest;
 import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequestSerializationHelper;
 import edu.unc.lib.boxc.services.camel.TestHelper;
@@ -38,7 +39,7 @@ public class StreamingPropertiesRouterTest extends CamelSpringTestSupport {
         var request = new StreamingPropertiesRequest();
         request.setAgent(agent);
         request.setId(pid.getId());
-        request.setUrl(StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL);
+        request.setUrl(StreamingConstants.STREAMREAPER_PREFIX_URL);
         request.setType("video");
         var body = StreamingPropertiesRequestSerializationHelper.toJson(request);
         template.sendBody(body);

--- a/static/js/admin/src/EditStreamingPropertiesForm.js
+++ b/static/js/admin/src/EditStreamingPropertiesForm.js
@@ -24,7 +24,7 @@ define('EditStreamingPropertiesForm', [ 'jquery', 'jquery-ui', 'underscore', 'Re
         EditStreamingPropertiesForm.prototype.validationErrors = function(resultObject) {
             /**
              If you change this value it also needs to be updated in
-             operations-jms/src/main/java/edu/unc/lib/boxc/operations/jms/streaming/StreamingPropertiesRequest.java
+             model-api/src/main/java/edu/unc/lib/boxc/model/api/StreamingConstants.java
              **/
             const STREAMREAPER_PREFIX_URL = "https://durastream.lib.unc.edu/player"
             let errors = [];

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesController.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 
 import static edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.ADD;
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 /**

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/StreamingPropertiesIT.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Map;
 
-import static edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest.STREAMREAPER_PREFIX_URL;
+import static edu.unc.lib.boxc.model.api.StreamingConstants.STREAMREAPER_PREFIX_URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;


### PR DESCRIPTION
Part of https://unclibrary.atlassian.net/browse/BXC-4612

* Update indexing filters to allow for streaming only file objects
* Move streaming constants to their own file in the model-api module so they can be used everywhere
* Refactored getAlternativeTitle to cut down on unnecessary data retrieval by using early returns, since I had to expand it anyways.