### PR TITLE
BXC-3584 - Do not default to setting primary object in deposits

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/AbstractFileServerToBagJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/AbstractFileServerToBagJob.java
@@ -114,7 +114,6 @@ public abstract class AbstractFileServerToBagJob extends AbstractDepositJob {
 
         if (!isFileOnlyMode()) {
             workBag.add(fileResource);
-            workBag.addProperty(Cdr.primaryObject, fileResource);
             parentBag.add(workBag);
         } else {
             parentBag.add(fileResource);

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJob.java
@@ -92,7 +92,6 @@ public class NormalizeFileObjectsJob extends AbstractDepositJob {
         Bag workBag = model.createBag(workPid.getURI());
         workBag.addProperty(RDF.type, Cdr.Work);
         workBag.addProperty(CdrDeposit.label, filename);
-        workBag.addProperty(Cdr.primaryObject, fileResc);
 
         // Add premis event for work creation
         addPremisEvent(workPid, filePid);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
@@ -340,7 +340,7 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
                 "Checksum was not set");
         assertEquals(fileLocation, originalResc.getProperty(CdrDeposit.stagingLocation).getString(),
                 "Binary location not set");
-        assertFalse(work.hasProperty(Cdr.primaryObject, file), "Primary object not set");
+        assertFalse(work.hasProperty(Cdr.primaryObject), "Would must not have a primary object");
     }
 
     private Resource getChildByLabel(Bag bagResc, String seekLabel) {

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.deposit.normalize;
 
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -339,6 +340,7 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
                 "Checksum was not set");
         assertEquals(fileLocation, originalResc.getProperty(CdrDeposit.stagingLocation).getString(),
                 "Binary location not set");
+        assertFalse(work.hasProperty(Cdr.primaryObject, file), "Primary object not set");
     }
 
     private Resource getChildByLabel(Bag bagResc, String seekLabel) {

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
@@ -340,7 +340,7 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
                 "Checksum was not set");
         assertEquals(fileLocation, originalResc.getProperty(CdrDeposit.stagingLocation).getString(),
                 "Binary location not set");
-        assertFalse(work.hasProperty(Cdr.primaryObject), "Would must not have a primary object");
+        assertFalse(work.hasProperty(Cdr.primaryObject), "Work must not have a primary object");
     }
 
     private Resource getChildByLabel(Bag bagResc, String seekLabel) {

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.deposit.normalize;
 
 import static edu.unc.lib.boxc.common.test.TestHelpers.setField;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.anyString;
@@ -112,6 +113,7 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
         Bag workBag = model.getBag(work.getURI());
         Resource file = getChildByLabel(workBag, "lorem.txt");
         assertTrue(file.hasProperty(RDF.type, Cdr.FileObject), "Type was not set");
+        assertFalse(work.hasProperty(Cdr.primaryObject, file), "Primary object was not set");
 
         Resource originalResc = DepositModelHelpers.getDatastream(file);
         String tagPath = originalResc.getProperty(CdrDeposit.stagingLocation).getString();

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
@@ -113,7 +113,7 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
         Bag workBag = model.getBag(work.getURI());
         Resource file = getChildByLabel(workBag, "lorem.txt");
         assertTrue(file.hasProperty(RDF.type, Cdr.FileObject), "Type was not set");
-        assertFalse(work.hasProperty(Cdr.primaryObject), "Would must not have a primary object");
+        assertFalse(work.hasProperty(Cdr.primaryObject), "Work must not have a primary object");
 
         Resource originalResc = DepositModelHelpers.getDatastream(file);
         String tagPath = originalResc.getProperty(CdrDeposit.stagingLocation).getString();

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
@@ -113,7 +113,7 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
         Bag workBag = model.getBag(work.getURI());
         Resource file = getChildByLabel(workBag, "lorem.txt");
         assertTrue(file.hasProperty(RDF.type, Cdr.FileObject), "Type was not set");
-        assertFalse(work.hasProperty(Cdr.primaryObject, file), "Primary object was not set");
+        assertFalse(work.hasProperty(Cdr.primaryObject), "Would must not have a primary object");
 
         Resource originalResc = DepositModelHelpers.getDatastream(file);
         String tagPath = originalResc.getProperty(CdrDeposit.stagingLocation).getString();

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJobTest.java
@@ -186,8 +186,8 @@ public class NormalizeFileObjectsJobTest extends AbstractDepositJobTest {
         // Check that the work contains the fileObject
         assertEquals(model.getBag(workResc).iterator().next().asResource(), childResc, "Folder must contain work");
 
-        // Work must have fileObject as primary
-        assertFalse(workResc.hasProperty(Cdr.primaryObject, childResc));
+        // Work should not have primaryObject assigned
+        assertFalse(workResc.hasProperty(Cdr.primaryObject));
 
         // Label still present on file object
         assertEquals(FILENAME, childResc.getProperty(CdrDeposit.label).getString());


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-3584

Add tests and assertions to verify that primary object does not get set during bag and directory ingests, and in the normalization job. Modify the jobs not to set it. This mainly affects bag and directory deposits.