### PR TITLE
BXC-4701 - Update clients/tests to solr 9 (#1791) (repeat to merge solr-9-development into main)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,17 @@ jobs:
       run: |
         docker run -d --rm -p 43030:3030 atomgraph/fuseki --mem /test
 
+    - name: Make directory for solr config
+      run: mkdir -p /tmp/solr-config
+
+    # Need to copy the config is outside of the source path, otherwise it produces permission conflicts
+    - name: Copy Solr Config into container
+      run: sudo cp -r ${{ github.workspace }}/etc/solr-config/* /tmp/solr-config/
+
+    - name: Run solr container as command to trigger core creation
+      run: |
+        docker run -v /tmp/solr-config:/solr_config -d --rm -p 48983:8983 solr:9 solr-precreate access /solr_config/access
+
     - name: Checkout submodules
       run: git submodule update --init --recursive
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,13 @@ services:
     ports:
       - "43030:3030"
     command: --mem /test
+  solr:
+    image: solr:9
+    ports:
+      - "48983:8983"
+    volumes:
+      - ./etc/solr-config:/solr_config/config
+    command:
+      - solr-precreate
+      - access
+      - /solr_config/config

--- a/etc/solr-config/access/conf/solrconfig.xml
+++ b/etc/solr-config/access/conf/solrconfig.xml
@@ -18,7 +18,7 @@
 
 <!--
      For more details about configurations options that may appear in
-     this file, see http://wiki.apache.org/solr/SolrConfigXml.
+     this file, see https://solr.apache.org/guide/solr/latest/configuration-guide/configuring-solrconfig-xml.html.
 -->
 <config>
   <!-- In all configuration below, a prefix of "solr." for class names
@@ -35,7 +35,7 @@
        that you fully re-index after changing this setting as it can
        affect both how text is indexed and queried.
   -->
-  <luceneMatchVersion>8.8.1</luceneMatchVersion>
+  <luceneMatchVersion>9.8</luceneMatchVersion>
 
   <!-- <lib/> directives can be used to instruct Solr to load any Jars
        identified and use them to resolve any "plugins" specified in
@@ -69,10 +69,10 @@
        If a 'dir' option (with or without a regex) is used and nothing
        is found that matches, a warning will be logged.
 
-       The example below can be used to load a solr-contrib along
+       The example below can be used to load a Solr Module along
        with their external dependencies.
     -->
-    <!-- <lib dir="${solr.install.dir:../../../..}/dist/" regex="solr-ltr-\d.*\.jar" /> -->
+  <!-- <lib dir="${solr.install.dir:../../../..}/modules/ltr/lib" regex=".*\.jar" /> -->
 
   <!-- an exact 'path' can be used instead of a 'dir' to specify a
        specific jar file.  This will cause a serious error to be logged
@@ -100,8 +100,8 @@
        wraps solr.StandardDirectoryFactory and caches small files in memory
        for better NRT performance.
 
-       One can force a particular implementation via solr.MMapDirectoryFactory,
-       solr.NIOFSDirectoryFactory, or solr.SimpleFSDirectoryFactory.
+       One can force a particular implementation via solr.MMapDirectoryFactory
+       or solr.NIOFSDirectoryFactory.
 
        solr.RAMDirectoryFactory is memory based and not persistent.
     -->
@@ -202,7 +202,7 @@
                    'simple' is the default
 
          More details on the nuances of each LockFactory...
-         http://wiki.apache.org/lucene-java/AvailableLockFactories
+         https://cwiki.apache.org/confluence/display/lucene/AvailableLockFactories
     -->
     <lockType>${solr.lock.type:native}</lockType>
 
@@ -247,24 +247,8 @@
     <!-- <infoStream file="INFOSTREAM.txt">false</infoStream> -->
   </indexConfig>
 
-
-  <!-- JMX
-
-       This example enables JMX if and only if an existing MBeanServer
-       is found, use this if you want to configure JMX through JVM
-       parameters. Remove this to disable exposing Solr configuration
-       and statistics to JMX.
-
-       For more details see http://wiki.apache.org/solr/SolrJmx
-    -->
-<!--  <jmx />-->
-  <!-- If you want to connect to a particular server, specify the
-       agentId
-    -->
-  <!-- <jmx agentId="myAgent" /> -->
-  <!-- If you want to start a new MBeanServer, specify the serviceUrl -->
-  <!-- <jmx serviceUrl="service:jmx:rmi:///jndi/rmi://localhost:9999/solr"/>
-    -->
+  <!-- box-c addition -->
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
 
   <!-- The default high-performance update handler -->
   <updateHandler class="solr.DirectUpdateHandler2">
@@ -293,7 +277,7 @@
          Instead of enabling autoCommit, consider using "commitWithin"
          when adding documents.
 
-         http://wiki.apache.org/solr/UpdateXmlMessages
+         https://solr.apache.org/guide/solr/latest/indexing-guide/indexing-with-update-handlers.html
 
          maxDocs - Maximum number of documents to add since the last
                    commit before automatically triggering a new commit.
@@ -320,7 +304,7 @@
       -->
 
     <autoSoftCommit>
-      <maxTime>${solr.autoSoftCommit.maxTime:-1}</maxTime>
+      <maxTime>${solr.autoSoftCommit.maxTime:3000}</maxTime>
     </autoSoftCommit>
 
     <!-- Update Related Event Listeners
@@ -368,30 +352,18 @@
   <query>
 
     <!-- Maximum number of clauses allowed when parsing a boolean query string.
-         
+
          This limit only impacts boolean queries specified by a user as part of a query string,
          and provides per-collection controls on how complex user specified boolean queries can
-         be.  Query strings that specify more clauses then this will result in an error.
-         
-         If this per-collection limit is greater then the global `maxBooleanClauses` limit
+         be.  Query strings that specify more clauses than this will result in an error.
+
+         If this per-collection limit is greater than the global `maxBooleanClauses` limit
          specified in `solr.xml`, it will have no effect, as that setting also limits the size
          of user specified boolean queries.
       -->
     <maxBooleanClauses>${solr.max.booleanClauses:1024}</maxBooleanClauses>
 
     <!-- Solr Internal Query Caches
-
-         There are four implementations of cache available for Solr:
-         LRUCache, based on a synchronized LinkedHashMap, 
-         LFUCache and FastLRUCache, based on a ConcurrentHashMap, and CaffeineCache -
-         a modern and robust cache implementation. Note that in Solr 9.0
-         only CaffeineCache will be available, other implementations are now
-         deprecated.
-
-         FastLRUCache has faster gets and slower puts in single
-         threaded operation and thus is generally faster than LRUCache
-         when the hit ratio of the cache is high (> 75%), and may be
-         faster under other scenarios on multi-cpu systems.
          Starting with Solr 9.0 the default cache implementation used is CaffeineCache.
     -->
 
@@ -401,13 +373,12 @@
          unordered sets of *all* documents that match a query.  When a
          new searcher is opened, its caches may be prepopulated or
          "autowarmed" using data from caches in the old searcher.
-         autowarmCount is the number of items to prepopulate.  For
-         LRUCache, the autowarmed items will be the most recently
+         autowarmCount is the number of items to prepopulate. For
+         CaffeineCache, the autowarmed items will be the most recently
          accessed items.
 
          Parameters:
-           class - the SolrCache implementation LRUCache or
-               (LRUCache or FastLRUCache)
+           class - the SolrCache implementation (CaffeineCache by default)
            size - the maximum number of entries in the cache
            initialSize - the initial capacity (number of entries) of
                the cache.  (see java.util.HashMap)
@@ -425,7 +396,7 @@
 
          Caches results of searches - ordered lists of document ids
          (DocList) based on a query, a sort, and the range of documents requested.
-         Additional supported parameter by LRUCache:
+         Additional supported parameter by CaffeineCache:
             maxRamMB - the maximum amount of RAM (in MB) that this cache is allowed
                        to occupy
       -->
@@ -445,6 +416,7 @@
 
     <!-- custom cache currently used by block join -->
     <cache name="perSegFilter"
+           class="solr.CaffeineCache"
            size="10"
            initialSize="0"
            autowarmCount="10"
@@ -459,7 +431,7 @@
     <!--
        <fieldValueCache size="512"
                         autowarmCount="128"
-                        showItems="32" />
+                        />
       -->
 
     <!-- Custom Cache
@@ -473,6 +445,7 @@
       -->
     <!--
        <cache name="myUserCache"
+              class="solr.CaffeineCache"
               size="4096"
               initialSize="1024"
               autowarmCount="1024"
@@ -524,19 +497,19 @@
       -->
     <queryResultMaxDocsCached>200</queryResultMaxDocsCached>
 
-  <!-- Use Filter For Sorted Query
+    <!-- Use Filter For Sorted Query
 
-   A possible optimization that attempts to use a filter to
-   satisfy a search.  If the requested sort does not include
-   score, then the filterCache will be checked for a filter
-   matching the query. If found, the filter will be used as the
-   source of document ids, and then the sort will be applied to
-   that.
+     A possible optimization that attempts to use a filter to
+     satisfy a search.  If the requested sort does not include
+     score, then the filterCache will be checked for a filter
+     matching the query. If found, the filter will be used as the
+     source of document ids, and then the sort will be applied to
+     that.
 
-   For most situations, this will not be useful unless you
-   frequently get the same search repeatedly with different sort
-   options, and none of them ever use "score"
--->
+     For most situations, this will not be useful unless you
+     frequently get the same search repeatedly with different sort
+     options, and none of them ever use "score"
+  -->
     <!--
        <useFilterForSortedQuery>true</useFilterForSortedQuery>
       -->
@@ -562,19 +535,19 @@
       -->
     <listener event="newSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
-        <!--
-           <lst><str name="q">solr</str><str name="sort">price asc</str></lst>
-           <lst><str name="q">rocks</str><str name="sort">weight asc</str></lst>
-          -->
+        <lst>
+          <str name="fq">resourceType:Collection</str>
+        </lst>
       </arr>
     </listener>
     <listener event="firstSearcher" class="solr.QuerySenderListener">
       <arr name="queries">
-        <!--
         <lst>
-          <str name="q">static firstSearcher warming in solrconfig.xml</str>
+          <str name="fq">resourceType:Collection</str>
         </lst>
-        -->
+        <lst>
+          <str name="fq">resourceType:(AdminUnit OR Collection OR Folder OR Work)</str>
+        </lst>
       </arr>
     </listener>
 
@@ -589,65 +562,6 @@
 
   </query>
 
-  <!-- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-     Circuit Breaker Section - This section consists of configurations for
-     circuit breakers
-     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
-
-    <!-- Circuit Breakers
-
-     Circuit breakers are designed to allow stability and predictable query
-     execution. They prevent operations that can take down the node and cause
-     noisy neighbour issues.
-
-     This flag is the uber control switch which controls the activation/deactivation of all circuit
-     breakers. If a circuit breaker wishes to be independently configurable,
-     they are free to add their specific configuration but need to ensure that this flag is always
-     respected - this should have veto over all independent configuration flags.
-    -->
-    <circuitBreakers enabled="true">
-
-    <!-- Memory Circuit Breaker Configuration
-
-     Specific configuration for max JVM heap usage circuit breaker. This configuration defines whether
-     the circuit breaker is enabled and the threshold percentage of maximum heap allocated beyond which queries will be rejected until the
-     current JVM usage goes below the threshold. The valid value range for this value is 50-95.
-
-     Consider a scenario where the max heap allocated is 4 GB and memoryCircuitBreakerThreshold is
-     defined as 75. Threshold JVM usage will be 4 * 0.75 = 3 GB. Its generally a good idea to keep this value between 75 - 80% of maximum heap
-     allocated.
-
-     If, at any point, the current JVM heap usage goes above 3 GB, queries will be rejected until the heap usage goes below 3 GB again.
-     If you see queries getting rejected with 503 error code, check for "Circuit Breakers tripped"
-     in logs and the corresponding error message should tell you what transpired (if the failure
-     was caused by tripped circuit breakers).
-
-     If, at any point, the current JVM heap usage goes above 3 GB, queries will be rejected until the heap usage goes below 3 GB again.
-     If you see queries getting rejected with 503 error code, check for "Circuit Breakers tripped"
-     in logs and the corresponding error message should tell you what transpired (if the failure
-     was caused by tripped circuit breakers).
-    -->
-    <!--
-   <memBreaker enabled="true" threshold="75"/>
-    -->
-
-      <!-- CPU Circuit Breaker Configuration
-
-     Specific configuration for CPU utilization based circuit breaker. This configuration defines whether the circuit breaker is enabled
-     and the average load over the last minute at which the circuit breaker should start rejecting queries.
-
-     Consider a scenario where the max heap allocated is 4 GB and memoryCircuitBreakerThreshold is
-     defined as 75. Threshold JVM usage will be 4 * 0.75 = 3 GB. Its generally a good idea to keep this value between 75 - 80% of maximum heap
-     allocated.
-    -->
-
-      <!--
-       <cpuBreaker enabled="true" threshold="75"/>
-      -->
-
-  </circuitBreakers>
-
-
   <!-- Request Dispatcher
 
        This section contains instructions for how the SolrDispatchFilter
@@ -660,9 +574,6 @@
          These settings indicate how Solr Requests may be parsed, and
          what restrictions may be placed on the ContentStreams from
          those requests
-
-         enableRemoteStreaming - enables use of the stream.file
-         and stream.url parameters for specifying remote streams.
 
          multipartUploadLimitInKB - specifies the max size (in KiB) of
          Multipart File Uploads that Solr will allow in a Request.
@@ -679,12 +590,7 @@
          Solr components, but may be useful when developing custom
          plugins.
 
-         *** WARNING ***
-         Before enabling remote streaming, you should make sure your
-         system has authentication enabled.
-
-    <requestParsers enableRemoteStreaming="false"
-                    multipartUploadLimitInKB="-1"
+    <requestParsers multipartUploadLimitInKB="-1"
                     formdataUploadLimitInKB="-1"
                     addHttpRequestToContext="false"/>
       -->
@@ -746,90 +652,26 @@
 
   <!-- Request Handlers
 
-       http://wiki.apache.org/solr/SolrRequestHandler
+       https://solr.apache.org/guide/solr/latest/configuration-guide/requesthandlers-searchcomponents.html
 
-       Incoming queries will be dispatched to a specific handler by name
-       based on the path specified in the request.
+       Incoming queries will be dispatched to a specific handler by name based on the path specified in the request.
 
-       If a Request Handler is declared with startup="lazy", then it will
-       not be initialized until the first request that uses it.
+       All handlers (Search Handlers, Update Request Handlers, and other specialized types) can have default parameters (defaults, appends and invariants).
 
+       Search Handlers can also (append, prepend or even replace) default or defined Search Components.
+
+       Update Request Handlers can leverage Update Request Processors to pre-process documents after they are loaded
+       and before they are indexed/stored.
+
+       Not all Request Handlers are defined in the solrconfig.xml, many are implicit.
     -->
-  <!-- SearchHandler
 
-       http://wiki.apache.org/solr/SearchHandler
-
-       For processing Search Queries, the primary Request Handler
-       provided with Solr is "SearchHandler" It delegates to a sequent
-       of SearchComponents (see below) and supports distributed
-       queries across multiple shards
-    -->
+  <!-- Primary search handler, expected by most clients, examples and UI frameworks -->
   <requestHandler name="/select" class="solr.SearchHandler">
-    <!-- default values for query parameters can be specified, these
-         will be overridden by parameters in the request
-      -->
     <lst name="defaults">
       <str name="echoParams">explicit</str>
       <int name="rows">10</int>
-      <!-- Default search field
-         <str name="df">text</str> 
-        -->
-      <!-- Change from JSON to XML format (the default prior to Solr 7.0)
-         <str name="wt">xml</str> 
-        -->
     </lst>
-    <!-- In addition to defaults, "appends" params can be specified
-         to identify values which should be appended to the list of
-         multi-val params from the query (or the existing "defaults").
-      -->
-    <!-- In this example, the param "fq=instock:true" would be appended to
-         any query time fq params the user may specify, as a mechanism for
-         partitioning the index, independent of any user selected filtering
-         that may also be desired (perhaps as a result of faceted searching).
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "appends" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="appends">
-         <str name="fq">inStock:true</str>
-       </lst>
-      -->
-    <!-- "invariants" are a way of letting the Solr maintainer lock down
-         the options available to Solr clients.  Any params values
-         specified here are used regardless of what values may be specified
-         in either the query, the "defaults", or the "appends" params.
-
-         In this example, the facet.field and facet.query params would
-         be fixed, limiting the facets clients can use.  Faceting is
-         not turned on by default - but if the client does specify
-         facet=true in the request, these are the only facets they
-         will be able to see counts for; regardless of what other
-         facet.field or facet.query params they may specify.
-
-         NOTE: there is *absolutely* nothing a client can do to prevent these
-         "invariants" values from being used, so don't use this mechanism
-         unless you are sure you always want it.
-      -->
-    <!--
-       <lst name="invariants">
-         <str name="facet.field">cat</str>
-         <str name="facet.field">manu_exact</str>
-         <str name="facet.query">price:[* TO 500]</str>
-         <str name="facet.query">price:[500 TO *]</str>
-       </lst>
-      -->
-    <!-- If the default list of SearchComponents is not desired, that
-         list can either be overridden completely, or components can be
-         prepended or appended to the default list.  (see below)
-      -->
-    <!--
-       <arr name="components">
-         <str>nameOfCustomComponent1</str>
-         <str>nameOfCustomComponent2</str>
-       </arr>
-      -->
   </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->
@@ -841,106 +683,64 @@
     </lst>
   </requestHandler>
 
-  <initParams path="/update/**,/query,/select,/spell">
+  <!-- Shared parameters for multiple Request Handlers -->
+  <initParams path="/update/**,/query,/select">
     <lst name="defaults">
       <str name="df">_text_</str>
     </lst>
   </initParams>
-
-  <!-- Search Components
-
-       Search components are registered to SolrCore and used by
-       instances of SearchHandler (which can access them by name)
-
-       By default, the following components are available:
-
-       <searchComponent name="query"     class="solr.QueryComponent" />
-       <searchComponent name="facet"     class="solr.FacetComponent" />
-       <searchComponent name="mlt"       class="solr.MoreLikeThisComponent" />
-       <searchComponent name="highlight" class="solr.HighlightComponent" />
-       <searchComponent name="stats"     class="solr.StatsComponent" />
-       <searchComponent name="debug"     class="solr.DebugComponent" />
-
-       Default configuration in a requestHandler would look like:
-
-       <arr name="components">
-         <str>query</str>
-         <str>facet</str>
-         <str>mlt</str>
-         <str>highlight</str>
-         <str>stats</str>
-         <str>debug</str>
-       </arr>
-
-       If you register a searchComponent to one of the standard names,
-       that will be used instead of the default.
-
-       To insert components before or after the 'standard' components, use:
-
-       <arr name="first-components">
-         <str>myFirstComponentName</str>
-       </arr>
-
-       <arr name="last-components">
-         <str>myLastComponentName</str>
-       </arr>
-
-       NOTE: The component registered with the name "debug" will
-       always be executed after the "last-components"
-
-     -->
 
   <!-- Spell Check
 
        The spell check component can return a list of alternative spelling
        suggestions.
 
-       http://wiki.apache.org/solr/SpellCheckComponent
+       https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html
     -->
-  <searchComponent name="spellcheck" class="solr.SpellCheckComponent">
+  <!-- <searchComponent name="spellcheck" class="solr.SpellCheckComponent"> -->
 
-    <str name="queryAnalyzerFieldType">text_general</str>
+  <!-- <str name="queryAnalyzerFieldType">text_general</str> -->
 
-    <!-- Multiple "Spell Checkers" can be declared and used by this
-         component
-      -->
-
-    <!-- a spellchecker built from a field of the main index -->
-    <lst name="spellchecker">
-      <str name="name">default</str>
-      <str name="field">_text_</str>
-      <str name="classname">solr.DirectSolrSpellChecker</str>
-      <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
-      <str name="distanceMeasure">internal</str>
-      <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
-      <float name="accuracy">0.5</float>
-      <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
-      <int name="maxEdits">2</int>
-      <!-- the minimum shared prefix when enumerating terms -->
-      <int name="minPrefix">1</int>
-      <!-- maximum number of inspections per result. -->
-      <int name="maxInspections">5</int>
-      <!-- minimum length of a query term to be considered for correction -->
-      <int name="minQueryLength">4</int>
-      <!-- maximum threshold of documents a query term can appear to be considered for correction -->
-      <float name="maxQueryFrequency">0.01</float>
-      <!-- uncomment this to require suggestions to occur in 1% of the documents
-        <float name="thresholdTokenFrequency">.01</float>
-      -->
-    </lst>
-
-    <!-- a spellchecker that can break or combine words.  See "/spell" handler below for usage -->
-    <!--
-    <lst name="spellchecker">
-      <str name="name">wordbreak</str>
-      <str name="classname">solr.WordBreakSolrSpellChecker</str>
-      <str name="field">name</str>
-      <str name="combineWords">true</str>
-      <str name="breakWords">true</str>
-      <int name="maxChanges">10</int>
-    </lst>
+  <!-- Multiple "Spell Checkers" can be declared and used by this
+       component
     -->
-  </searchComponent>
+
+  <!-- a spellchecker built from a field of the main index -->
+  <!-- <lst name="spellchecker"> -->
+  <!-- <str name="name">default</str> -->
+  <!-- <str name="field">_text_</str> -->
+  <!-- <str name="classname">solr.DirectSolrSpellChecker</str> -->
+  <!-- the spellcheck distance measure used, the default is the internal levenshtein -->
+  <!-- <str name="distanceMeasure">internal</str> -->
+  <!-- minimum accuracy needed to be considered a valid spellcheck suggestion -->
+  <!-- <float name="accuracy">0.5</float> -->
+  <!-- the maximum #edits we consider when enumerating terms: can be 1 or 2 -->
+  <!-- <int name="maxEdits">2</int> -->
+  <!-- the minimum shared prefix when enumerating terms -->
+  <!-- <int name="minPrefix">1</int> -->
+  <!-- maximum number of inspections per result. -->
+  <!-- <int name="maxInspections">5</int> -->
+  <!-- minimum length of a query term to be considered for correction -->
+  <!-- <int name="minQueryLength">4</int> -->
+  <!-- maximum threshold of documents a query term can appear to be considered for correction -->
+  <!-- <float name="maxQueryFrequency">0.01</float> -->
+  <!-- uncomment this to require suggestions to occur in 1% of the documents
+    <float name="thresholdTokenFrequency">.01</float>
+  -->
+  <!-- </lst> -->
+
+  <!-- a spellchecker that can break or combine words.  See "/spell" handler below for usage -->
+  <!--
+  <lst name="spellchecker">
+    <str name="name">wordbreak</str>
+    <str name="classname">solr.WordBreakSolrSpellChecker</str>
+    <str name="field">name</str>
+    <str name="combineWords">true</str>
+    <str name="breakWords">true</str>
+    <int name="maxChanges">10</int>
+  </lst>
+  -->
+  <!-- </searchComponent> -->
 
   <!-- A request handler for demonstrating the spellcheck component.
 
@@ -952,56 +752,38 @@
        IN OTHER WORDS, THERE IS REALLY GOOD CHANCE THE SETUP BELOW IS
        NOT WHAT YOU WANT FOR YOUR PRODUCTION SYSTEM!
 
-       See http://wiki.apache.org/solr/SpellCheckComponent for details
+       See https://solr.apache.org/guide/solr/latest/query-guide/spell-checking.html for details
        on the request parameters.
     -->
-  <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy">
-    <lst name="defaults">
-      <!-- Solr will use suggestions from both the 'default' spellchecker
-           and from the 'wordbreak' spellchecker and combine them.
-           collations (re-written queries) can include a combination of
-           corrections from both spellcheckers -->
-      <str name="spellcheck.dictionary">default</str>
-      <str name="spellcheck">on</str>
-      <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.count">10</str>
-      <str name="spellcheck.alternativeTermCount">5</str>
-      <str name="spellcheck.maxResultsForSuggest">5</str>
-      <str name="spellcheck.collate">true</str>
-      <str name="spellcheck.collateExtendedResults">true</str>
-      <str name="spellcheck.maxCollationTries">10</str>
-      <str name="spellcheck.maxCollations">5</str>
-    </lst>
-    <arr name="last-components">
-      <str>spellcheck</str>
-    </arr>
-  </requestHandler>
-
-  <!-- Terms Component
-
-       http://wiki.apache.org/solr/TermsComponent
-
-       A component to return terms and document frequency of those
-       terms
-    -->
-  <searchComponent name="terms" class="solr.TermsComponent"/>
-
-  <!-- A request handler for demonstrating the terms component -->
-  <requestHandler name="/terms" class="solr.SearchHandler" startup="lazy">
-    <lst name="defaults">
-      <bool name="terms">true</bool>
-      <bool name="distrib">false</bool>
-    </lst>
-    <arr name="components">
-      <str>terms</str>
-    </arr>
-  </requestHandler>
+  <!-- <requestHandler name="/spell" class="solr.SearchHandler" startup="lazy"> -->
+  <!-- <lst name="defaults"> -->
+  <!-- Solr will use suggestions from both the 'default' spellchecker
+       and from the 'wordbreak' spellchecker and combine them.
+       collations (re-written queries) can include a combination of
+       corrections from both spellcheckers -->
+  <!-- <str name="spellcheck.dictionary">default</str> -->
+  <!-- <str name="spellcheck">on</str> -->
+  <!-- <str name="spellcheck.extendedResults">true</str> -->
+  <!-- <str name="spellcheck.count">10</str> -->
+  <!-- <str name="spellcheck.alternativeTermCount">5</str> -->
+  <!-- <str name="spellcheck.maxResultsForSuggest">5</str> -->
+  <!-- <str name="spellcheck.collate">true</str> -->
+  <!-- <str name="spellcheck.collateExtendedResults">true</str> -->
+  <!-- <str name="spellcheck.maxCollationTries">10</str> -->
+  <!-- <str name="spellcheck.maxCollations">5</str> -->
+  <!-- </lst> -->
+  <!-- <arr name="last-components"> -->
+  <!-- <str>spellcheck</str> -->
+  <!-- </arr> -->
+  <!-- </requestHandler> -->
 
   <!-- Highlighting Component
 
-       http://wiki.apache.org/solr/HighlightingParameters
+       https://solr.apache.org/guide/solr/latest/query-guide/highlighting.html
     -->
   <searchComponent class="solr.HighlightComponent" name="highlight">
+    <!-- note: the hl.method=unified highlighter is not configured here; it's completely configured
+    via parameters.  The below configuration supports hl.method=original and fastVector. -->
     <highlighting>
       <!-- Configure the standard fragmenter -->
       <!-- This could most likely be commented out in the "default" case -->
@@ -1103,21 +885,90 @@
     </highlighting>
   </searchComponent>
 
-  <!-- Update Processors
+  <!-- Update Request Processors
+       https://solr.apache.org/guide/solr/latest/configuration-guide/update-request-processors.html
 
-       Chains of Update Processor Factories for dealing with Update
-       Requests can be declared, and then used by name in Update
-       Request Processors
-
-       http://wiki.apache.org/solr/UpdateRequestProcessor
-
+       Chains or individual Update Request Processor Factories can be declared and referenced
+       to preprocess documents sent to Update Request Handlers.
     -->
 
-  <schemaFactory class="ClassicIndexSchemaFactory"/>
+  <!-- Add unknown fields to the schema
+
+       Field type guessing update request processors that will
+       attempt to parse string-typed field values as Booleans, Longs,
+       Doubles, or Dates, and then add schema fields with the guessed
+       field types Text content will be indexed as "text_general" as
+       well as a copy to a plain string version in *_str.
+       See the updateRequestProcessorChain defined later for the order they are executed in.
+
+       These require that the schema is both managed and mutable, by
+       declaring schemaFactory as ManagedIndexSchemaFactory, with
+       mutable specified as true.
+
+       See https://solr.apache.org/guide/solr/latest/indexing-guide/schemaless-mode.html for further explanation.
+
+    -->
+  <!-- <updateProcessor class="solr.UUIDUpdateProcessorFactory" name="uuid"/> -->
+  <!-- <updateProcessor class="solr.RemoveBlankFieldUpdateProcessorFactory" name="remove-blank"/> -->
+  <!-- <updateProcessor class="solr.FieldNameMutatingUpdateProcessorFactory" name="field-name-mutating"> -->
+  <!-- <str name="pattern">[^\w-\.]</str> -->
+  <!-- <str name="replacement">_</str> -->
+  <!-- </updateProcessor> -->
+  <!-- <updateProcessor class="solr.ParseBooleanFieldUpdateProcessorFactory" name="parse-boolean"/> -->
+  <!-- <updateProcessor class="solr.ParseLongFieldUpdateProcessorFactory" name="parse-long"/> -->
+  <!-- <updateProcessor class="solr.ParseDoubleFieldUpdateProcessorFactory" name="parse-double"/> -->
+  <!-- <updateProcessor class="solr.ParseDateFieldUpdateProcessorFactory" name="parse-date"> -->
+  <!-- <arr name="format"> -->
+  <!-- <str>yyyy-MM-dd['T'[HH:mm[:ss[.SSS]][z</str> -->
+  <!-- <str>yyyy-MM-dd['T'[HH:mm[:ss[,SSS]][z</str> -->
+  <!-- <str>yyyy-MM-dd HH:mm[:ss[.SSS]][z</str> -->
+  <!-- <str>yyyy-MM-dd HH:mm[:ss[,SSS]][z</str> -->
+  <!-- <str>[EEE, ]dd MMM yyyy HH:mm[:ss] z</str> -->
+  <!-- <str>EEEE, dd-MMM-yy HH:mm:ss z</str> -->
+  <!-- <str>EEE MMM ppd HH:mm:ss [z ]yyyy</str> -->
+  <!-- </arr> -->
+  <!-- </updateProcessor> -->
+  <!-- <updateProcessor class="solr.AddSchemaFieldsUpdateProcessorFactory" name="add-schema-fields"> -->
+  <!-- <lst name="typeMapping"> -->
+  <!-- <str name="valueClass">java.lang.String</str> -->
+  <!-- <str name="fieldType">text_general</str> -->
+  <!-- <lst name="copyField"> -->
+  <!-- <str name="dest">*_str</str> -->
+  <!-- <int name="maxChars">256</int> -->
+  <!-- </lst> -->
+  <!-- Use as default mapping instead of defaultFieldType -->
+  <!-- <bool name="default">true</bool> -->
+  <!-- </lst> -->
+  <!-- <lst name="typeMapping"> -->
+  <!-- <str name="valueClass">java.lang.Boolean</str> -->
+  <!-- <str name="fieldType">booleans</str> -->
+  <!-- </lst> -->
+  <!-- <lst name="typeMapping"> -->
+  <!-- <str name="valueClass">java.util.Date</str> -->
+  <!-- <str name="fieldType">pdates</str> -->
+  <!-- </lst> -->
+  <!-- <lst name="typeMapping"> -->
+  <!-- <str name="valueClass">java.lang.Long</str> -->
+  <!-- <str name="valueClass">java.lang.Integer</str> -->
+  <!-- <str name="fieldType">plongs</str> -->
+  <!-- </lst> -->
+  <!-- <lst name="typeMapping"> -->
+  <!-- <str name="valueClass">java.lang.Number</str> -->
+  <!-- <str name="fieldType">pdoubles</str> -->
+  <!-- </lst> -->
+  <!-- </updateProcessor> -->
+
+  <!-- The update.autoCreateFields property can be turned to false to disable schemaless mode -->
+  <!-- <updateRequestProcessorChain name="add-unknown-fields-to-the-schema" default="${update.autoCreateFields:true}" -->
+  <!-- processor="uuid,remove-blank,field-name-mutating,parse-boolean,parse-long,parse-double,parse-date,add-schema-fields"> -->
+  <!-- <processor class="solr.LogUpdateProcessorFactory"/> -->
+  <!-- <processor class="solr.DistributedUpdateProcessorFactory"/> -->
+  <!-- <processor class="solr.RunUpdateProcessorFactory"/> -->
+  <!-- </updateRequestProcessorChain> -->
 
   <!-- Deduplication
 
-       An example dedup update processor that creates the "id" field
+       An example dedup update request processor chain that creates the "id" field
        on the fly based on the hash code of some other fields.  This
        example has overwriteDupes set to false since we are using the
        id field as the signatureField and Solr will maintain
@@ -1129,7 +980,6 @@
        <processor class="solr.processor.SignatureUpdateProcessorFactory">
          <bool name="enabled">true</bool>
          <str name="signatureField">id</str>
-         <bool name="overwriteDupes">false</bool>
          <str name="fields">name,features,cat</str>
          <str name="signatureClass">solr.processor.Lookup3Signature</str>
        </processor>
@@ -1138,9 +988,18 @@
      </updateRequestProcessorChain>
     -->
 
+  <!-- box-c addition -->
+  <updateRequestProcessorChain name="tolerant-chain">
+    <processor class="solr.TolerantUpdateProcessorFactory">
+      <int name="maxErrors">-1</int>
+    </processor>
+    <processor class="solr.RunUpdateProcessorFactory" />
+  </updateRequestProcessorChain>
+
+
   <!-- Response Writers
 
-       http://wiki.apache.org/solr/QueryResponseWriter
+       https://solr.apache.org/guide/solr/latest/query-guide/response-writers.html
 
        Request responses will be written using the writer specified by
        the 'wt' request parameter matching the name of a registered
@@ -1165,17 +1024,19 @@
      <queryResponseWriter name="schema.xml" class="solr.SchemaXmlResponseWriter"/>
     -->
 
-  <queryResponseWriter name="json" class="solr.JSONResponseWriter">
-    <!-- For the purposes of the tutorial, JSON responses are written as
-     plain text so that they are easy to read in *any* browser.
-     If you expect a MIME type of "application/json" just remove this override.
-    -->
-    <str name="content-type">text/plain; charset=UTF-8</str>
-  </queryResponseWriter>
+  <!-- Overriding the content-type of the response writer.
+       For example, Default content-type of JSON is application/json. This can be overridden to
+       text/plain so that response is easy to read in *any* browser.
+   -->
+  <!--
+     <queryResponseWriter name="json" class="solr.JSONResponseWriter">
+        <str name="content-type">text/plain; charset=UTF-8</str>
+      </queryResponseWriter>
+   -->
 
   <!-- Query Parsers
 
-       https://lucene.apache.org/solr/guide/query-syntax-and-parsing.html
+       https://solr.apache.org/guide/solr/latest/query-guide/query-syntax-and-parsers.html
 
        Multiple QParserPlugins can be registered by name, and then
        used in either the "defType" param for the QueryComponent (used
@@ -1188,7 +1049,7 @@
 
   <!-- Function Parsers
 
-       http://wiki.apache.org/solr/FunctionQuery
+       https://solr.apache.org/guide/solr/latest/query-guide/function-queries.html
 
        Multiple ValueSourceParsers can be registered by name, and then
        used as function names when using the "func" QParser.
@@ -1201,7 +1062,7 @@
 
 
   <!-- Document Transformers
-       http://wiki.apache.org/solr/DocTransformers
+       https://solr.apache.org/guide/solr/latest/query-guide/document-transformers.html
     -->
   <!--
      Could be something like:

--- a/etc/solr-config/access/core.properties
+++ b/etc/solr-config/access/core.properties
@@ -1,4 +1,1 @@
-collection.name=access
 name=access
-collection=access
-coreNodeName=access

--- a/etc/solr-config/log4j2.xml
+++ b/etc/solr-config/log4j2.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!-- Default production configuration is asnychronous logging -->
+<Configuration>
+    <Appenders>
+
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout>
+                <Pattern>
+                    %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+                </Pattern>
+            </PatternLayout>
+        </Console>
+
+        <RollingRandomAccessFile
+                name="MainLogFile"
+                fileName="${sys:solr.log.dir}/solr.log"
+                filePattern="${sys:solr.log.dir}/solr.log.%i" >
+            <PatternLayout>
+                <Pattern>
+                    %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+                </Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="32 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingRandomAccessFile>
+
+        <RollingRandomAccessFile
+                name="SlowLogFile"
+                fileName="${sys:solr.log.dir}/solr_slow_requests.log"
+                filePattern="${sys:solr.log.dir}/solr_slow_requests.log.%i" >
+            <PatternLayout>
+                <Pattern>
+                    %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ t:%X{trace_id}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+                </Pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy />
+                <SizeBasedTriggeringPolicy size="32 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingRandomAccessFile>
+
+    </Appenders>
+    <Loggers>
+        <!-- Use <AsyncLogger/<AsyncRoot and <Logger/<Root for asynchronous logging or synchonous logging respectively -->
+        <AsyncLogger name="org.apache.hadoop" level="warn"/>
+        <AsyncLogger name="org.apache.solr.update.LoggingInfoStream" level="off"/>
+        <AsyncLogger name="org.apache.zookeeper" level="warn"/>
+        <!-- HttpSolrCall adds markers denoting the handler class to allow fine grained control, metrics are
+             very noisy so by default the metrics handler is turned off to see metrics logging set DENY to ACCEPT -->
+        <AsyncLogger name="org.apache.solr.servlet.HttpSolrCall" level="info">
+            <MarkerFilter marker="org.apache.solr.handler.admin.MetricsHandler" onMatch="DENY" onMismatch="ACCEPT"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.apache.solr.core.SolrCore.SlowRequest" level="info" additivity="false">
+            <AppenderRef ref="SlowLogFile"/>
+        </AsyncLogger>
+        <AsyncLogger name="org.eclipse.jetty.deploy" level="warn"/>
+        <AsyncLogger name="org.eclipse.jetty.webapp" level="warn"/>
+        <AsyncLogger name="org.eclipse.jetty.server.session" level="warn"/>
+
+        <AsyncRoot level="info">
+            <AppenderRef ref="MainLogFile"/>
+            <AppenderRef ref="STDOUT"/>
+        </AsyncRoot>
+    </Loggers>
+</Configuration>

--- a/indexing-solr/pom.xml
+++ b/indexing-solr/pom.xml
@@ -97,8 +97,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>
-            <artifactId>solr-dataimporthandler</artifactId>
-            <scope>test</scope>
+            <artifactId>solr-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.solr</groupId>

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/BaseEmbeddedSolrTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/action/BaseEmbeddedSolrTest.java
@@ -38,9 +38,8 @@ public class BaseEmbeddedSolrTest extends Assertions {
         dataDir.mkdir();
 
         System.setProperty("solr.data.dir", dataDir.getAbsolutePath());
-        container = CoreContainer.createAndLoad(Paths.get("../etc/solr-config"),
-                Paths.get("../etc/solr-config/solr.xml"));
-        container.load();
+        container = CoreContainer.createAndLoad(Paths.get("../etc/solr-config").toAbsolutePath(),
+                Paths.get("../etc/solr-config/solr.xml").toAbsolutePath());
 
         server = new EmbeddedSolrServer(container, "access");
 

--- a/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
+++ b/indexing-solr/src/test/java/edu/unc/lib/boxc/indexing/solr/filter/SetContentTypeFilterTest.java
@@ -26,7 +26,6 @@ import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
 import edu.unc.lib.boxc.search.solr.models.IndexDocumentBean;
 import edu.unc.lib.boxc.search.solr.responses.SearchResultResponse;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
-import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -171,9 +170,9 @@ public class SetContentTypeFilterTest {
 
         filter.filter(dip);
 
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatType()));
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatDescription()));
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatCategory()));
+        assertNull(idb.getFileFormatType());
+        assertNull(idb.getFileFormatDescription());
+        assertNull(idb.getFileFormatCategory());
     }
 
     @Test
@@ -335,9 +334,9 @@ public class SetContentTypeFilterTest {
 
         filter.filter(dip);
 
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatType()));
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatDescription()));
-        assertTrue(CollectionUtils.isEmpty(idb.getFileFormatCategory()));
+        assertTrue(idb.getFileFormatType().isEmpty());
+        assertTrue(idb.getFileFormatDescription().isEmpty());
+        assertTrue(idb.getFileFormatCategory().isEmpty());
     }
 
     @Test

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -48,67 +48,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <executions>
-                    <execution>
-                        <id>install-solr</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <url>https://www.apache.org/dyn/closer.lua/lucene/solr/${solr.version}/solr-${solr.version}.tgz?action=download</url>
-                    <unpack>true</unpack>
-                    <outputDirectory>${project.build.directory}/solr/</outputDirectory>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>Start solr</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <async>true</async>
-                            <executable>${project.build.directory}/solr/solr-${solr.version}/bin/solr</executable>
-                            <commandlineArgs>start -p 48983 -s ${project.build.directory}/../../etc/solr-config/</commandlineArgs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>Stop solr</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>post-integration-test</phase>
-                        <configuration>
-                            <async>true</async>
-                            <executable>${project.build.directory}/solr/solr-${solr.version}/bin/solr</executable>
-                            <arguments>
-                                <argument>stop</argument>
-                                <argument>-p</argument>
-                                <argument>48983</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>solr.solr.home</name>
-                            <value>${project.build.directory}/../../etc/solr-config/</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>9.4.19.v20190610</version>

--- a/integration/src/test/resources/spring-test/solr-embedded-context.xml
+++ b/integration/src/test/resources/spring-test/solr-embedded-context.xml
@@ -50,8 +50,8 @@
         <constructor-arg value="../etc/solr-config/solr.xml" />
     </bean>
 
-    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" init-method="load">
-        <constructor-arg value="#{solrHomePath.toPath()}" />
-        <constructor-arg value="#{solrConfigPath.toPath()}" />
+    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" destroy-method="shutdown">
+        <constructor-arg value="#{solrHomePath.toPath().toAbsolutePath()}" />
+        <constructor-arg value="#{solrConfigPath.toPath().toAbsolutePath()}" />
     </bean>
 </beans>

--- a/model-fcrepo/pom.xml
+++ b/model-fcrepo/pom.xml
@@ -40,6 +40,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
         <!-- Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -103,9 +103,5 @@
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,7 @@
         <fcrepo.client.version>5.0.0</fcrepo.client.version>
         <mock.server.version>5.4.1</mock.server.version>
         <awaitility.version>4.0.3</awaitility.version>
-        <!-- Stuck on this version due to jetty tie-ins, can upgrade when solr uses newer jetty versions -->
-        <wiremock.version>2.32.0</wiremock.version>
+        <wiremock.version>2.35.2</wiremock.version>
         
         <jackson.version>2.13.2</jackson.version>
         <jackson.databind.version>2.13.4.2</jackson.databind.version>
@@ -96,7 +95,7 @@
         
         <httpclient.version>4.5.13</httpclient.version>
         <commons-compress.version>1.26.0</commons-compress.version>
-        <commons-codec.version>1.11</commons-codec.version>
+        <commons-codec.version>1.17.1</commons-codec.version>
         <commons-io.version>2.7</commons-io.version>
         <commons-csv.version>1.6</commons-csv.version>
         <commons-lang3.version>3.8.1</commons-lang3.version>
@@ -126,7 +125,7 @@
         <jsp-api.version>2.3.6</jsp-api.version>
 
         <jedis.version>3.10.0</jedis.version>
-        <solr.version>8.10.1</solr.version>
+        <solr.version>9.6.1</solr.version>
         <metrics.version>5.0.0</metrics.version>
         <jena.version>4.4.0</jena.version>
 
@@ -694,7 +693,7 @@
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8</artifactId>
+                <artifactId>wiremock-jre8-standalone</artifactId>
                 <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
@@ -938,9 +937,8 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.solr</groupId>
-                <artifactId>solr-dataimporthandler</artifactId>
+                <artifactId>solr-api</artifactId>
                 <version>${solr.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.solr</groupId>

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/BaseEmbeddedSolrTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/test/BaseEmbeddedSolrTest.java
@@ -45,9 +45,8 @@ public class BaseEmbeddedSolrTest {
         Files.createDirectory(dataBaseDir.resolve("dataDir"));
 
         System.setProperty("solr.data.dir", dataDir.getAbsolutePath());
-        container = CoreContainer.createAndLoad(Paths.get("../etc/solr-config"),
-                Paths.get("../etc/solr-config/solr.xml"));
-        container.load();
+        container = CoreContainer.createAndLoad(Paths.get("../etc/solr-config").toAbsolutePath(),
+                Paths.get("../etc/solr-config/solr.xml").toAbsolutePath());
 
         server = new EmbeddedSolrServer(container, "access");
 
@@ -86,6 +85,7 @@ public class BaseEmbeddedSolrTest {
 
     @AfterEach
     public void tearDown() throws Exception {
+        container.shutdown();
         server.close();
         log.debug("Cleaning up data directory");
         FileUtils.deleteDirectory(dataDir);

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -226,7 +226,7 @@
     </dependency>
     <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
+        <artifactId>wiremock-jre8-standalone</artifactId>
     </dependency>
 
     <dependency>
@@ -280,10 +280,6 @@
     <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock-jre8</artifactId>
     </dependency>
     </dependencies>
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/streaming/StreamingPropertiesRequestProcessor.java
@@ -14,7 +14,7 @@ import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequest;
 import edu.unc.lib.boxc.operations.jms.streaming.StreamingPropertiesRequestSerializationHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -116,9 +116,9 @@
         <constructor-arg value="../etc/solr-config/solr.xml" />
     </bean>
 
-    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" init-method="load">
-        <constructor-arg value="#{solrHomePath.toPath()}" />
-        <constructor-arg value="#{solrConfigPath.toPath()}" />
+    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" destroy-method="shutdown">
+        <constructor-arg value="#{solrHomePath.toPath().toAbsolutePath()}" />
+        <constructor-arg value="#{solrConfigPath.toPath().toAbsolutePath()}" />
     </bean>
     
     <bean id="solrSearchService" class="edu.unc.lib.boxc.search.solr.services.SolrSearchService">

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -118,8 +118,7 @@
       </dependency>
       <dependency>
           <groupId>com.github.tomakehurst</groupId>
-          <artifactId>wiremock-jre8</artifactId>
-          <scope>test</scope>
+          <artifactId>wiremock-jre8-standalone</artifactId>
       </dependency>
       <dependency>
           <groupId>edu.unc.lib.cdr</groupId>

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/AnalyticsTrackerUtil.java
@@ -5,7 +5,7 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.search.api.models.ContentObjectRecord;
 import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
 import edu.unc.lib.boxc.search.solr.services.SolrSearchService;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.matomo.java.tracking.MatomoRequest;
 import org.matomo.java.tracking.MatomoTracker;
 import org.matomo.java.tracking.TrackerConfiguration;
@@ -17,7 +17,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.util.Random;
 
 /**
  * Utility for performing asynchronous analytics tracking events when unable to use the javascript api

--- a/web-services-app/pom.xml
+++ b/web-services-app/pom.xml
@@ -163,8 +163,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <scope>test</scope>
+            <artifactId>wiremock-jre8-standalone</artifactId>
         </dependency>
         <dependency>
             <groupId>info.freelibrary</groupId>

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/IiifV3ManifestService.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/processing/IiifV3ManifestService.java
@@ -31,7 +31,7 @@ import info.freelibrary.iiif.presentation.v3.properties.Metadata;
 import info.freelibrary.iiif.presentation.v3.properties.RequiredStatement;
 import info.freelibrary.iiif.presentation.v3.properties.ViewingDirection;
 import info.freelibrary.iiif.presentation.v3.services.ImageService3;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvIT.java
@@ -35,7 +35,7 @@ import edu.unc.lib.boxc.web.services.processing.ExportCsvService;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.junit.jupiter.api.BeforeEach;

--- a/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/web-services-app/src/test/resources/spring-test/solr-indexing-context.xml
@@ -130,9 +130,9 @@
         <constructor-arg value="../etc/solr-config/solr.xml" />
     </bean>
 
-    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" init-method="load">
-        <constructor-arg value="#{solrHomePath.toPath()}" />
-        <constructor-arg value="#{solrConfigPath.toPath()}" />
+    <bean id="coreContainer" class="org.apache.solr.core.CoreContainer" factory-method="createAndLoad" destroy-method="shutdown">
+        <constructor-arg value="#{solrHomePath.toPath().toAbsolutePath()}" />
+        <constructor-arg value="#{solrConfigPath.toPath().toAbsolutePath()}" />
     </bean>
 
     <bean id="solrAccessRestrictionUtil" class="edu.unc.lib.boxc.search.solr.utils.AccessRestrictionUtil">


### PR DESCRIPTION
* Update to solr 9, and wiremock 3 due to jetty versions. Update some commons usages which were referencing libraries pulled in by old solr versons

* Update solr config, make paths absolute since it is now required, and don't double load config

* Switch over to wiremock-jre8-standalone to avoid jetty version conflicts with solr

* Running solr 9 in docker for the integration tests that ran it in jetty, since it was failing to start. Add solr logging config

* Adjusting ghactions

* Try solr as docker run

* Reenable build

* Explicitly add solr-api as compile scope, otherwise solr-core pulls it in as test. Add commons-codec directly in a lower module, since it was previously being imported via transitive dependencies, but no longer is