### PR TITLE
BXC-4541 - Tuning of cantaloupe cache invalidation

### DIFF
--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -98,6 +98,8 @@
     <!-- ACL related beans -->
     <bean id="httpClientConnectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"
             destroy-method="shutdown">
+        <property name="maxTotal" value="100" />
+        <property name="defaultMaxPerRoute" value="5"/>
     </bean>
     
     <bean id="sparqlQueryService" class="edu.unc.lib.boxc.model.fcrepo.sparql.FusekiSparqlQueryServiceImpl">


### PR DESCRIPTION
Part of https://unclibrary.atlassian.net/browse/BXC-4541

* Set explicit sizes for thread pool used in services camel, granting a somewhat larger pool thank default. 
* Perform calls for cantaloupe cache invalidation in a separate thread so that it won't block jp2 generation from continuing
* Use rate limiting to avoid overwhelming cantaloupe with requests