### PR TITLE
BXC-4792 block jp2 processing for image/vnd.microsoft.icon

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessor.java
@@ -19,7 +19,8 @@ public class ImageDerivativeProcessor implements Processor {
 
     private static final Pattern MIMETYPE_PATTERN = Pattern.compile("^(image.*$|application.*?(photoshop|psd)$)");
 
-    private static final Pattern DISALLOWED_PATTERN = Pattern.compile(".*(vnd\\.fpx|x-icon|x-raw-panasonic).*");
+    private static final Pattern DISALLOWED_PATTERN =
+            Pattern.compile(".*(vnd\\.fpx|x-icon|x-raw-panasonic|vnd\\.microsoft\\.icon).*");
 
     /**
      * Returns true if the subject of the exchange is a binary which

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageDerivativeProcessorTest.java
@@ -73,4 +73,11 @@ public class ImageDerivativeProcessorTest {
 
         assertTrue(ImageDerivativeProcessor.allowedImageType(exchange));
     }
+
+    @Test
+    public void testAllowedImageTypeMicrosoft() {
+        when(messageIn.getHeader(CdrFcrepoHeaders.CdrBinaryMimeType)).thenReturn("image/vnd.microsoft.icon");
+
+        assertFalse(ImageDerivativeProcessor.allowedImageType(exchange));
+    }
 }


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4792](https://unclibrary.atlassian.net/browse/BXC-4792)

- block jp2 processing for image/vnd.microsoft.icon
- add test