### PR TITLE
BXC-4796 - Limit bulk download access

### DIFF
--- a/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/AccessPrincipalConstants.java
+++ b/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/AccessPrincipalConstants.java
@@ -23,6 +23,7 @@ public class AccessPrincipalConstants {
     public final static String PATRON_NAMESPACE = "unc:patron:";
     public final static String IP_PRINC_NAMESPACE = PATRON_NAMESPACE + "ipp:";
     public final static String ADMIN_ACCESS_PRINC = "admin_access";
+    public final static String ON_CAMPUS_PRINC = "unc:patron:ipp:on_campus";
 
     public final static Pattern PATRON_PRINC_PATTERN =
             Pattern.compile("(" + PUBLIC_PRINC

--- a/static/css/sass/cdr_ui_styles.scss
+++ b/static/css/sass/cdr_ui_styles.scss
@@ -435,14 +435,18 @@ img.data-thumb {
   max-width: 60px;
 }
 
-.child-records {
-  font-size: 16px;
-  margin: 30px 50px 25px 50px;
+.file-list-header {
+  margin: 30px 0 5px;
 
   h3 {
     font-size: 16px;
-    margin-bottom: 30px;
+    margin: 0;
+    padding: 0;
   }
+}
+
+.child-records {
+  font-size: 16px;
 
   .fa.default-img-icon {
     font-size: 32px;
@@ -1156,7 +1160,7 @@ iframe {
 
 .clover-viewer {
   margin: auto;
-  width: 90%;
+  width: 95%;
 }
 
 #information-toggle {

--- a/static/css/sass/cdr_ui_styles.scss
+++ b/static/css/sass/cdr_ui_styles.scss
@@ -919,6 +919,11 @@ a.navbar-item:hover {
   color: #3273dc;
 }
 
+.action.button.is-primary {
+  background-color: #1A698C;
+  color: #FFFFFF;
+}
+
 /*** End of Bulma overrides ***/
 
 /* Following Bulma breakpoints */

--- a/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
@@ -67,7 +67,7 @@
             <template v-if="childCount > 0">
                 <div class="file-list-header columns is-vcentered">
                     <h3 class="column">{{ $t('full_record.item_list') }} ({{ childCount }})</h3>
-                    <bulk-download :view-original-access="hasPermission(recordData, 'viewOriginal')"
+                    <bulk-download :has-bulk-download-access="recordData.canBulkDownload"
                                    :total-download-size="recordData.totalDownloadSize"
                                    :work-id="recordData.briefObject.id">
                     </bulk-download>

--- a/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
@@ -65,7 +65,7 @@
         <div class="full_record_bottom container is-fluid">
             <player :record-data="recordData"></player>
             <template v-if="childCount > 0">
-                <div class="file-list-header columns is-vcentered"">
+                <div class="file-list-header columns is-vcentered">
                     <h3 class="column">{{ $t('full_record.item_list') }} ({{ childCount }})</h3>
                     <bulk-download :view-original-access="hasPermission(recordData, 'viewOriginal')"
                                    :total-download-size="recordData.totalDownloadSize"

--- a/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
@@ -62,16 +62,22 @@
                 </div>
             </div>
         </div>
-        <div class="full_record_bottom">
+        <div class="full_record_bottom container is-fluid">
             <player :record-data="recordData"></player>
-            <file-list v-if="childCount > 0" id="file-display"
-                       :child-count="childCount"
-                       :work-id="recordData.briefObject.id"
-                       :total-download-size="recordData.totalDownloadSize"
-                       :download-access="hasDownloadAccess(recordData)"
-                       :view-original-access="hasPermission(recordData, 'viewOriginal')"
-                       :edit-access="hasPermission(recordData,'editDescription')">
-            </file-list>
+            <template v-if="childCount > 0">
+                <div class="file-list-header columns is-vcentered"">
+                    <h3 class="column">{{ $t('full_record.item_list') }} ({{ childCount }})</h3>
+                    <bulk-download :view-original-access="hasPermission(recordData, 'viewOriginal')"
+                                   :total-download-size="recordData.totalDownloadSize"
+                                   :work-id="recordData.briefObject.id">
+                    </bulk-download>
+                </div>
+                <file-list id="file-display"
+                           :work-id="recordData.briefObject.id"
+                           :download-access="hasDownloadAccess(recordData)"
+                           :edit-access="hasPermission(recordData,'editDescription')">
+                </file-list>
+            </template>
             <metadata-display :uuid="recordData.briefObject.id"
                               :can-view-metadata="hasPermission(recordData, 'viewMetadata')">
             </metadata-display>
@@ -91,11 +97,12 @@ import metadataDisplay from '@/components/full_record/metadataDisplay.vue';
 import neighborList from '@/components/full_record/neighborList.vue';
 import player from '@/components/full_record/player.vue';
 import restrictedContent from '@/components/full_record/restrictedContent.vue';
+import bulkDownload from "@/components/full_record/bulkDownload.vue";
 
 export default {
     name: 'aggregateRecord',
 
-    components: {abstract, fileList, neighborList, metadataDisplay, player, restrictedContent},
+    components: {bulkDownload, abstract, fileList, neighborList, metadataDisplay, player, restrictedContent},
 
     mixins: [fileUtils, fullRecordUtils],
 

--- a/static/js/vue-cdr-access/src/components/full_record/bulkDownload.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/bulkDownload.vue
@@ -31,7 +31,7 @@ export default {
             default: null,
             type: Number
         },
-        viewOriginalAccess: {
+        hasBulkDownloadAccess: {
             default: false,
             type: Boolean
         },
@@ -40,11 +40,11 @@ export default {
 
     computed: {
         hasDownloadableContent() {
-            return this.viewOriginalAccess && this.totalDownloadSize !== null;
+            return this.hasBulkDownloadAccess && this.totalDownloadSize !== null;
         },
 
         showTotalFilesize() {
-            return this.hasDownloadableContent && this.totalDownloadSize <= ONE_GIGABYTE;
+            return this.hasBulkDownloadAccess && this.totalDownloadSize <= ONE_GIGABYTE;
         }
     }
 }

--- a/static/js/vue-cdr-access/src/components/full_record/bulkDownload.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/bulkDownload.vue
@@ -1,6 +1,6 @@
 <template>
-    <div v-if="hasDownloadableContent" class="actionlink column pr-0 is-justify-content-flex-end">
-        <a v-if="showTotalFilesize" class="bulk-download bulk-download-link button action" :href="downloadBulkUrl(workId)">
+    <div v-if="hasDownloadableContent" class="column pr-0 has-text-right">
+        <a v-if="showTotalFilesize" class="bulk-download bulk-download-link button action is-primary" :href="downloadBulkUrl(workId)">
                     <span class="icon">
                         <i class="fa fa-archive"></i>
                     </span>

--- a/static/js/vue-cdr-access/src/components/full_record/fileList.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/fileList.vue
@@ -27,7 +27,6 @@ force it to reload
 </template>
 
 <script>
-import bulkDownload from '@/components/full_record/bulkDownload.vue';
 import fileDownloadUtils from '../../mixins/fileDownloadUtils';
 import fullRecordUtils from '../../mixins/fullRecordUtils';
 import fileUtils from '../../mixins/fileUtils';

--- a/static/js/vue-cdr-access/src/components/full_record/fileList.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/fileList.vue
@@ -7,14 +7,6 @@ force it to reload
 -->
 <template>
     <div class="child-records table-container" id="data-display">
-        <div class="columns">
-            <h3 class="column">{{ $t('full_record.item_list') }} ({{ childCount }})</h3>
-            <bulk-download :view-original-access="viewOriginalAccess"
-                           :total-download-size="totalDownloadSize"
-                           :work-id="workId">
-            </bulk-download>
-        </div>
-
         <data-table :key="workId" id="child-files" class="table is-striped is-bordered is-fullwidth"
                     :ajax="ajaxOptions"
                     :columns="columns"
@@ -51,10 +43,9 @@ export default {
 
     mixins: [fileDownloadUtils, fileUtils, fullRecordUtils],
 
-    components: {bulkDownload, DataTable},
+    components: {DataTable},
 
     props: {
-        childCount: Number,
         downloadAccess: {
             default: false,
             type: Boolean
@@ -66,14 +57,6 @@ export default {
         resourceType: {
             default: 'Work',
             type: String
-        },
-        totalDownloadSize: {
-            default: null,
-            type: String
-        },
-        viewOriginalAccess: {
-            default: false,
-            type: Boolean
         },
         workId: String
     },
@@ -91,10 +74,6 @@ export default {
     },
 
     computed: {
-        showTotalFilesize() {
-            return this.viewOriginalAccess && this.totalDownloadSize !== null
-        },
-
         // Datatables expects dataSrc to return an array
         // File objects don't have any child metadata, so wrap the file object in an array
         ajaxOptions() {
@@ -367,7 +346,6 @@ export default {
 
     @media screen and (max-width: 576px) {
         #data-display {
-            h3,
             .actionlink.column {
                 margin-bottom: 0;
             }

--- a/static/js/vue-cdr-access/tests/unit/aggregateRecord.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/aggregateRecord.spec.js
@@ -585,6 +585,10 @@ describe('aggregateRecord.vue', () => {
         expect(wrapper.find('.download-jump a').exists()).toBe(true);
     });
 
+    it("displays a header with file count", () => {
+        expect(wrapper.find('h3').text()).toEqual("List of Items in This Work (1)");
+    });
+
     it("does not display a finding aid link, if absent", () => {
         expect(wrapper.find('.finding-aid').exists()).toBe(false);
     });

--- a/static/js/vue-cdr-access/tests/unit/fileList.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/fileList.spec.js
@@ -82,10 +82,6 @@ describe('fileList.vue', () => {
         });
     });
 
-    it("displays a header with file count", () => {
-        expect(wrapper.find('h3').text()).toEqual("List of Items in This Work (3)");
-    });
-
     it("contains a table of files", () => {
         expect(wrapper.findComponent({ name: 'dataTable' }).exists()).toBe(true);
     });

--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/FullRecordController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/FullRecordController.java
@@ -21,6 +21,7 @@ import edu.unc.lib.boxc.search.solr.facets.FilterableDisplayValueFacet;
 import edu.unc.lib.boxc.search.solr.services.ChildrenCountService;
 import edu.unc.lib.boxc.search.solr.services.GetCollectionIdService;
 import edu.unc.lib.boxc.search.solr.services.NeighborQueryService;
+import edu.unc.lib.boxc.web.common.auth.PatronActionPermissionsUtil;
 import edu.unc.lib.boxc.web.common.controllers.AbstractErrorHandlingSearchController;
 import edu.unc.lib.boxc.web.common.exceptions.RenderViewException;
 import edu.unc.lib.boxc.web.common.services.AccessCopiesService;
@@ -30,6 +31,7 @@ import edu.unc.lib.boxc.web.common.services.XmlDocumentFilteringService;
 import edu.unc.lib.boxc.web.common.utils.ModsUtil;
 import edu.unc.lib.boxc.web.common.utils.SerializationUtil;
 import edu.unc.lib.boxc.web.common.view.XSLViewResolver;
+import org.apache.commons.lang3.StringUtils;
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.ON_CAMPUS_PRINC;
 import static edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
 import static edu.unc.lib.boxc.search.api.FacetConstants.MARKED_FOR_DELETION;
@@ -166,7 +169,8 @@ public class FullRecordController extends AbstractErrorHandlingSearchController 
         PID pid = PIDs.get(pidString);
         LOG.debug("Getting full record for {}", pid);
 
-        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+        var agent = getAgentPrincipals();
+        AccessGroupSet principals = agent.getPrincipals();
         aclService.assertHasAccess("Insufficient permissions to access full record for " + pidString,
                 pid, principals, Permission.viewMetadata);
 
@@ -229,10 +233,13 @@ public class FullRecordController extends AbstractErrorHandlingSearchController 
         }
 
         Long totalDownloadSize = null;
+        boolean canBulkDownload = false;
         if (ResourceType.Work.nameEquals(resourceType)) {
+            canBulkDownload = PatronActionPermissionsUtil.hasBulkDownloadPermission(aclService, pid, agent);
             totalDownloadSize = workFilesizeService.getTotalFilesize(briefObject, principals);
         }
         recordProperties.put("totalDownloadSize", totalDownloadSize);
+        recordProperties.put("canBulkDownload", canBulkDownload);
 
         accessCopiesService.populateThumbnailId(briefObject, principals, true);
 

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronActionPermissionsUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/auth/PatronActionPermissionsUtil.java
@@ -1,0 +1,34 @@
+package edu.unc.lib.boxc.web.common.auth;
+
+import edu.unc.lib.boxc.auth.api.Permission;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import org.apache.commons.lang3.StringUtils;
+
+import static edu.unc.lib.boxc.auth.api.AccessPrincipalConstants.ON_CAMPUS_PRINC;
+
+/**
+ * Utility class for determining permissions for patron actions
+ * @author bbpennel
+ */
+public class PatronActionPermissionsUtil {
+    private PatronActionPermissionsUtil() {
+    }
+
+    /**
+     * Determine if the provided agent has permission to download a bulk export zip of the provided object
+     * @param aclService
+     * @param pid
+     * @param agent
+     * @return
+     */
+    public static boolean hasBulkDownloadPermission(AccessControlService aclService, PID pid, AgentPrincipals agent) {
+        AccessGroupSet principals = agent.getPrincipals();
+        if (StringUtils.isBlank(agent.getUsername()) && !principals.contains(ON_CAMPUS_PRINC)) {
+            return false;
+        }
+        return aclService.hasAccess(pid, principals, Permission.viewOriginal);
+    }
+}

--- a/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronActionPermissionsUtilTest.java
+++ b/web-common/src/test/java/edu/unc/lib/boxc/web/common/auth/PatronActionPermissionsUtilTest.java
@@ -1,0 +1,75 @@
+package edu.unc.lib.boxc.web.common.auth;
+
+import edu.unc.lib.boxc.auth.api.AccessPrincipalConstants;
+import edu.unc.lib.boxc.auth.api.models.AccessGroupSet;
+import edu.unc.lib.boxc.auth.api.models.AgentPrincipals;
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.models.AgentPrincipalsImpl;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static edu.unc.lib.boxc.auth.api.Permission.viewOriginal;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * @author bbpennel
+ */
+public class PatronActionPermissionsUtilTest {
+    private static final String WORK_ID = "f277bb38-272c-471c-a28a-9887a1328a1f";
+    @Mock
+    private AccessControlService aclService;
+    private PID pid;
+    private final static String USERNAME = "test_user";
+    private AccessGroupSet groups = new AccessGroupSetImpl("adminGroup");
+    private AgentPrincipals agent;
+
+    private AutoCloseable autoCloseable;
+
+    @BeforeEach
+    public void setup() {
+        autoCloseable = openMocks(this);
+        pid = PIDs.get(WORK_ID);
+        agent = new AgentPrincipalsImpl(USERNAME, groups);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        autoCloseable.close();
+    }
+
+    @Test
+    public void testHasBulkDownloadPermissionPermit() {
+        when(aclService.hasAccess(eq(pid), any(), eq(viewOriginal))).thenReturn(true);
+        assertTrue(PatronActionPermissionsUtil.hasBulkDownloadPermission(aclService, pid, agent));
+    }
+
+    @Test
+    public void testHasBulkDownloadPermissionNotAuthenticatedOrOnCampusReject() {
+        when(aclService.hasAccess(eq(pid), any(), eq(viewOriginal))).thenReturn(true);
+        var unauthAgent = new AgentPrincipalsImpl(null, null);
+        assertFalse(PatronActionPermissionsUtil.hasBulkDownloadPermission(aclService, pid, unauthAgent));
+    }
+
+    @Test
+    public void testHasBulkDownloadPermissionOnCampusPermit() {
+        when(aclService.hasAccess(eq(pid), any(), eq(viewOriginal))).thenReturn(true);
+        var unauthAgent = new AgentPrincipalsImpl(null, new AccessGroupSetImpl(AccessPrincipalConstants.ON_CAMPUS_PRINC));
+        assertTrue(PatronActionPermissionsUtil.hasBulkDownloadPermission(aclService, pid, unauthAgent));
+    }
+
+    @Test
+    public void testHasBulkDownloadPermissionNoPermissionReject() {
+        when(aclService.hasAccess(eq(pid), any(), eq(viewOriginal))).thenReturn(false);
+        assertFalse(PatronActionPermissionsUtil.hasBulkDownloadPermission(aclService, pid, agent));
+    }
+}


### PR DESCRIPTION

* Limits bulk download to on campus or authenticated users (in addition to the usual originalFile check)
* Server returns a property to tell the UI if the user has permission
* Refactoring of the view code to move the bulk download button up to aggregate layer, to disentangle parameters and make it easier to get the new permission property to where it needs to be.
* Make a little more use of bulma styling