### PR TITLE
BXC-4807/4757 - Thumbnail size, linking, and pagination

### DIFF
--- a/static/css/cdrui_styles.css
+++ b/static/css/cdrui_styles.css
@@ -29,19 +29,24 @@
 	background-position: top center;
 	background-repeat: no-repeat;
 	background-size: contain;
-	width: 64px;
-	height: 64px;
+	width: 100px;
+	height: 100px;
 	margin: 0 auto;
 }
 
 .thumbnail.thumbnail-size-medium .thumbnail-viewer {
-	width: 112px;
-	height: 112px;
+	width: 160px;
+	height: 160px;
+
+	@media screen and (max-width: 768px) {
+		width: 125px;
+		height: 125px;
+	}
 }
 
 .thumbnail.thumbnail-size-large .thumbnail-viewer {
-	width: 128px;
-	height: 128px;
+	width: 250px;
+	height: 250px;
 	margin-top: .25rem;
 }
 
@@ -75,15 +80,15 @@
 }
 
 .thumbnail .placeholder {
-	font-size: 64px;
+	font-size: 100px;
 }
 
 .thumbnail.thumbnail-size-medium .placeholder {
-	font-size: 112px;
+	font-size: 160px;
 }
 
 .thumbnail.thumbnail-size-large .placeholder {
-	font-size: 128px;
+	font-size: 250px;
 }
 
 .thumbnail-badge .background {

--- a/static/css/sass/cdr_ui_styles.scss
+++ b/static/css/sass/cdr_ui_styles.scss
@@ -271,7 +271,7 @@ p.spacing {
 }
 
 img.data-thumb {
-  max-width: 60px;
+  max-width: 100px;
 }
 
 .child-records {
@@ -455,6 +455,11 @@ table.dataTable {
       top: 0;
     }
   }
+
+  img + .thumbnail-badge {
+    margin-left: 85px !important;
+    margin-top: -20px !important;
+  }
 }
 
 /* MODs display for work and file pages, plus modalMetadata.vue component */
@@ -492,7 +497,7 @@ table.dataTable {
 .relateditem {
   .thumbnail {
     .thumbnail-badge {
-      right: 40px;
+      right: 10px;
     }
 
     .thumbnail-viewer {

--- a/static/js/vue-cdr-access/src/components/full_record/adminUnit.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/adminUnit.vue
@@ -2,7 +2,7 @@
     <div class="full_record pb-4">
         <div class="columns is-6-desktop browse-top container is-mobile is-1-mobile">
             <div class="column is-narrow">
-                <thumbnail :thumbnail-data="recordData"></thumbnail>
+                <thumbnail :thumbnail-data="recordData" :as-link="false"></thumbnail>
             </div>
             <div class="column content is-medium">
                 <h2 :class="isDeleted" class="title is-2 is-text-unc-blue">

--- a/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/aggregateRecord.vue
@@ -2,7 +2,7 @@
     <div class="full_record">
         <div class="columns is-6-desktop browse-top container is-mobile is-1-mobile">
             <div class="column is-narrow-desktop is-5-mobile" :class="isDeleted">
-                <thumbnail :thumbnail-data="recordData"></thumbnail>
+                <thumbnail :thumbnail-data="recordData" :as-link="false"></thumbnail>
                 <div class="download-jump mt-5 has-text-centered">
                     <a class="button action is-primary is-responsive" :href="filesLink">
                         <span class="icon"><i class="fa fa-download" aria-hidden="true"></i></span><span>Skip to Download</span>

--- a/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
@@ -2,7 +2,7 @@
     <div class="full_record">
         <div class="columns is-6-desktop browse-top container is-mobile is-1-mobile">
             <div class="column is-narrow-desktop is-5-mobile" :class="{restrictedContent: 'is-8'}">
-                <thumbnail :thumbnail-data="recordData"></thumbnail>
+                <thumbnail :thumbnail-data="recordData" :as-link="false"></thumbnail>
             </div>
             <div class="column content is-7-mobile pb-4">
                 <h2 :class="isDeleted" class="title is-3 is-text-unc-blue">

--- a/static/js/vue-cdr-access/src/components/full_record/fileList.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/fileList.vue
@@ -149,7 +149,8 @@ export default {
 
                         if ('thumbnail_url' in row && this.hasPermission(row,'viewAccessCopies')) {
                             const thumbnail_title = this.$t('full_record.thumbnail_title', { title: row.title })
-                            img = `<img class="data-thumb" loading="lazy" src="${row.thumbnail_url}"` +
+                            const thumbnail_url = row.thumbnail_url.replace('/large', '/small');;
+                            img = `<img class="data-thumb" loading="lazy" src="${thumbnail_url}"` +
                                 ` alt="${thumbnail_title}">`;
                         } else {
                             const thumbnail_default = this.$t('full_record.thumbnail_default');

--- a/static/js/vue-cdr-access/src/components/full_record/fileRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/fileRecord.vue
@@ -2,7 +2,7 @@
 <div class="full_record">
         <div class="columns is-6-desktop browse-top container is-mobile is-1-mobile">
             <div class="column is-narrow" :class="isDeleted">
-                <thumbnail :thumbnail-data="recordData"></thumbnail>
+                <thumbnail :thumbnail-data="recordData" :as-link="false"></thumbnail>
             </div>
             <div class="column content">
                 <h2 :class="isDeleted" class="title is-3 is-text-unc-blue">

--- a/static/js/vue-cdr-access/src/components/full_record/folderRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/folderRecord.vue
@@ -2,7 +2,7 @@
     <div class="full_record">
         <div class="columns is-6-desktop browse-top container is-mobile is-1-mobile">
             <div class="column is-narrow" :class="{restrictedContent: 'is-8'}">
-                <thumbnail :thumbnail-data="recordData"></thumbnail>
+                <thumbnail :thumbnail-data="recordData" :as-link="false"></thumbnail>
             </div>
             <div class="column content pb-4">
                 <h2 :class="isDeleted" class="title is-3 is-text-unc-blue">

--- a/static/js/vue-cdr-access/src/components/full_record/thumbnail.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/thumbnail.vue
@@ -1,6 +1,6 @@
 <template>
     <component :is="wrapperTag" :to="linkToPath" v-bind="linkAttributes" class="thumbnail" :class="imgClasses">
-        <div v-if="src !== ''" :style="{ 'background-image': 'url(' + objectData.thumbnail_url + ')'}"
+        <div v-if="src !== ''" :style="{ 'background-image': 'url(' + src + ')'}"
              :aria-label="imageAltText"
              role="img"
              class="thumbnail-viewer"
@@ -37,7 +37,7 @@ export default {
         },
         size: {
             type: String,
-            default: 'large'
+            default: 'medium'
         },
         asLink: {
             type: Boolean,
@@ -135,6 +135,9 @@ export default {
 
         src() {
             if (this.objectData.thumbnail_url !== undefined && this.canView()) {
+                if (this.size === 'medium' || this.size === 'small') {
+                    return this.objectData.thumbnail_url.replace('/large', '/small');
+                }
                 return this.objectData.thumbnail_url;
             }
 

--- a/static/js/vue-cdr-access/src/components/full_record/thumbnail.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/thumbnail.vue
@@ -1,5 +1,5 @@
 <template>
-    <router-link :to="linkToPath" :title="tooltip" :aria-label="linkAltText" class="thumbnail" :class="imgClasses">
+    <component :is="wrapperTag" :to="linkToPath" v-bind="linkAttributes" class="thumbnail" :class="imgClasses">
         <div v-if="src !== ''" :style="{ 'background-image': 'url(' + objectData.thumbnail_url + ')'}"
              :aria-label="imageAltText"
              role="img"
@@ -12,7 +12,7 @@
                 <i class="fas fa-stack-1x foreground" :class="badgeIcon"></i>
             </div>
         </div>
-    </router-link>
+    </component>
 </template>
 
 <script>
@@ -38,6 +38,10 @@ export default {
         size: {
             type: String,
             default: 'large'
+        },
+        asLink: {
+            type: Boolean,
+            default: true
         }
     },
 
@@ -48,6 +52,19 @@ export default {
     },
 
     computed: {
+        wrapperTag() {
+            return this.asLink ? 'router-link' : 'div';
+        },
+
+        linkAttributes() {
+            // Return attributes only if the wrapper is a router-link
+            return this.asLink ? {
+                    title: this.tooltip,
+                    'aria-label': this.linkAltText,
+                }
+                : {};
+        },
+
         altText() {
             let text = this.objectData.altText;
             if (!text) {
@@ -107,6 +124,9 @@ export default {
         },
 
         linkToPath() {
+            if (!this.asLink) {
+                return undefined;
+            }
             if (this.linkToUrl !== '') {
                 return this.linkToUrl;
             }
@@ -140,8 +160,12 @@ export default {
 </script>
 
 <style scoped lang="scss">
+    .thumbnail {
+        color: #1A698C;
+    }
+
     @media screen and (max-width: 600px) {
-        a {
+        .thumbnail {
             margin-right: 15px;
         }
     }

--- a/static/js/vue-cdr-access/src/components/galleryDisplay.vue
+++ b/static/js/vue-cdr-access/src/components/galleryDisplay.vue
@@ -3,9 +3,9 @@ Renders search results in a gallery view display in full record pages.
 -->
 <template>
     <div class="browse-records-display">
-        <div class="grid is-col-min-9 is-column-gap-3 is-row-gap-6">
+        <div class="grid is-col-min-10 is-column-gap-3 is-row-gap-6">
             <div v-for="record in recordList" class="cell">
-                <thumbnail :thumbnail-data="record" :link-to-url="recordUrl(record, 'gallery-display')"></thumbnail>
+                <thumbnail :thumbnail-data="record" :link-to-url="recordUrl(record, 'gallery-display')" size="large"></thumbnail>
                 <div class="record-title mt-4" :class="{deleted: markedForDeletion(record)}">
                     <router-link :to="recordUrl(record, 'gallery-display')">{{ record.title }}</router-link>
                 </div>

--- a/static/js/vue-cdr-access/src/components/listDisplay.vue
+++ b/static/js/vue-cdr-access/src/components/listDisplay.vue
@@ -6,7 +6,7 @@ Renders search results in a list view display format
         <div class="columns">
             <div class="column">
                 <div v-for="(record, index) in recordList" class="columns is-mobile browseitem py-5" :class="{'has-background-white-ter': index % 2 === 0}">
-                    <div class="column is-narrow pt-4">
+                    <div class="column is-narrow pt-3">
                         <thumbnail :thumbnail-data="record" size="medium" :link-to-url="recordUrl(record, linkBrowseType)"></thumbnail>
                     </div>
                     <div class="column metadata-fields">

--- a/static/js/vue-cdr-access/tests/unit/pagination.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/pagination.spec.js
@@ -47,8 +47,6 @@ describe('pagination.vue', () => {
             data() {
                 return {
                     pageLimit: 5,
-                    pageOffset: 2,
-                    startRecord: 1,
                     totalPageCount: 1
                 }
             }
@@ -68,28 +66,84 @@ describe('pagination.vue', () => {
         expect(wrapper.vm.totalPageCount).toEqual(10);
     });
 
-    it("calculates the pages to display", () => {
-        expect(wrapper.vm.currentPageList).toEqual([1, 2, 3, 4, 5]);
+    it("calculates the pages to display with fewer than page limit number of pages", async () => {
+        await wrapper.setProps({ numberOfRecords: 70 });
+        await changeToPage(1);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3]);
+        await changeToPage(2);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3]);
+        await changeToPage(3);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3]);
+        await changeToPage(4);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3]);
     });
+
+    it("calculates correct the pages to display with large number of pages", async () => {
+        await wrapper.setProps({ numberOfRecords: 1000 });
+        await changeToPage(1);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(2);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(3);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(4);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(5);
+        expect(wrapper.vm.currentPageList).toEqual([3, 4, 5, 6, 7]);
+        await changeToPage(25);
+        expect(wrapper.vm.currentPageList).toEqual([23, 24, 25, 26, 27]);
+        await changeToPage(45);
+        expect(wrapper.vm.currentPageList).toEqual([43, 44, 45, 46, 47]);
+        await changeToPage(46);
+        expect(wrapper.vm.currentPageList).toEqual([44, 45, 46, 47, 48]);
+        await changeToPage(47);
+        expect(wrapper.vm.currentPageList).toEqual([45, 46, 47, 48, 49]);
+        await changeToPage(48);
+        expect(wrapper.vm.currentPageList).toEqual([45, 46, 47, 48, 49]);
+        await changeToPage(49);
+        expect(wrapper.vm.currentPageList).toEqual([45, 46, 47, 48, 49]);
+        await changeToPage(50);
+        expect(wrapper.vm.currentPageList).toEqual([45, 46, 47, 48, 49]);
+    });
+
+    it("calculates correct the pages to display with page limit number of pages plus first and last page", async () => {
+        await wrapper.setProps({ numberOfRecords: 140 });
+        await changeToPage(1);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(2);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(3);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(4);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(5);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        await changeToPage(7);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+    });
+    
+    async function changeToPage(page) {
+        await router.push('/record/1234?start=' + (page - 1) * 20);
+    }
 
     it("displays a list of pages if the user is on the first page and there are <= pages than the page limit", async () => {
         await wrapper.setProps({ numberOfRecords: 24 });
-        expect(wrapper.findAll('.page-number').length).toEqual(2);
+        expect(wrapper.findAll('.pagination-link').length).toEqual(2);
     });
 
     it("displays a list of pages if the user is on the first page and there are more pages than the page limit", () => {
-        expect(wrapper.findAll('.page-number').length).toEqual(6);
+        expect(wrapper.findAll('.pagination-link').length).toEqual(7);
     });
 
     it("updates the page when a page is selected", async () => {
-        await wrapper.findAll('.page-number')[3].trigger('click');
+        await wrapper.findAll('.pagination-link')[3].trigger('click');
         await flushPromises();
         expect(wrapper.vm.currentPage).toEqual(4);
         expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
     });
 
     it("updates the start record when a 'display' page is selected",  async () => {
-        await wrapper.findAll('.page-number')[1].trigger('click');
+        await wrapper.findAll('.pagination-link')[1].trigger('click');
         await flushPromises();
         expect(parseInt(wrapper.vm.$router.currentRoute.value.query.start)).toEqual(20);
     });
@@ -99,59 +153,57 @@ describe('pagination.vue', () => {
             browseType: 'search'
         });
 
-        await wrapper.findAll('.page-number')[1].trigger('click');
+        await wrapper.findAll('.pagination-link')[1].trigger('click');
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.start).toEqual('20');
     });
 
     it("displays a link to jump to the first page if the user in on a page beyond the pageLimit", async () => {
-        await wrapper.findAll('.page-number')[5].trigger('click');
+        await wrapper.findAll('.pagination-link')[5].trigger('click');
         await flushPromises();
-        await wrapper.findAll('.page-number')[1].trigger('click');
+        await wrapper.findAll('.pagination-link')[1].trigger('click');
         await flushPromises();
 
         expect(wrapper.find('#first-page-link').isVisible()).toBe(true);
     });
 
-    it("displays a link to jump to the last page if the user in on a page that is before the pageLimit and" +
+    it("displays a link to jump to the last page if the user is on a page that is before the pageLimit and" +
         "there are more pages than the pageLimit",  () => {
         expect(wrapper.find('#last-page-link').isVisible()).toBe(true);
     });
 
-    it("does not display a link to jump to the first page if the user in on a page before the pageLimit and" +
-        "there are less than or eqaul number of pages than the pageLimit", async () => {
+    it("displays links to all pages if on the page before the page limit", async () => {
         await wrapper.setProps({
             numberOfRecords: 100
         });
 
-        await wrapper.findAll('.page-number')[4].trigger('click');
+        await wrapper.findAll('.pagination-link')[4].trigger('click');
         await flushPromises();
-        expect(wrapper.find('#first-page-link').exists()).toBe(false);
+        let page_links = wrapper.findAll('.pagination-link');
+        expect(page_links.map((link) => link.text())).toEqual(['1', '2', '3', '4', '5']);
     });
 
-    it("does not display a link to jump to the last page if the user in on a page before the pageLimit and" +
-        "there are less than or eqaul number of pages than the pageLimit", async () => {
+    it("displays all links if on the second page and there are fewer pages than the page limit", async () => {
         await wrapper.setProps({
             numberOfRecords: 100
         });
 
-        await wrapper.findAll('.page-number')[1].trigger('click');
+        await wrapper.findAll('.pagination-link')[1].trigger('click');
         await flushPromises();
-        expect(wrapper.find('#last-page-link').exists()).toBe(false);
+        let page_links = wrapper.findAll('.pagination-link');
+        expect(page_links.map((link) => link.text())).toEqual(['1', '2', '3', '4', '5']);
     });
 
     it("displays a back link", async () => {
-        await wrapper.findAll('.page-number')[2].trigger('click');
+        await wrapper.findAll('.pagination-link')[2].trigger('click');
         await flushPromises();
-        let start_btn = wrapper.find('.start');
-        expect(start_btn.classes('back-next')).toBe(true);
-        expect(start_btn.classes('no-link')).toBe(false);
+        let prev_btn = wrapper.find('.pagination-previous');
+        expect(prev_btn.classes('is-disabled')).toBe(false);
 
-        await wrapper.findAll('.page-number')[0].trigger('click');
+        await wrapper.findAll('.pagination-link')[0].trigger('click');
         await flushPromises();
-        start_btn = wrapper.find('.start');
-        expect(start_btn.classes('back-next')).toBe(false);
-        expect(start_btn.classes('no-link')).toBe(true);
+        prev_btn = wrapper.find('.pagination-previous');
+        expect(prev_btn.classes('is-disabled')).toBe(true);
     });
 
     it("displays a next link", async () => {
@@ -159,18 +211,56 @@ describe('pagination.vue', () => {
             numberOfRecords: 100
         });
 
-        expect(wrapper.find('.end').classes('back-next')).toBe(true);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(false);
 
-        await wrapper.findAll('.page-number')[4].trigger('click');
+        await wrapper.findAll('.pagination-link')[4].trigger('click');
         await flushPromises();
-        expect(wrapper.find('.end').classes('back-next')).toBe(false);
-        expect(wrapper.find('.end').classes('no-link')).toBe(true);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(true);
     });
 
     it("maintains the base path when changing search pages", async () => {
         // Change pages
-        wrapper.vm.pageUrl(2);
-        await flushPromises();
+        await changeToPage(2);
         expect(wrapper.vm.$route.path).toEqual('/record/1234');
+    });
+
+    it("if user is on the first page, then correct page is selected and previous button is disabled", async () => {
+        await changeToPage(1);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        expect(wrapper.find('.pagination-previous').classes('is-disabled')).toBe(true);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-link.is-current').text()).toEqual('1');
+        expect(wrapper.find('.pagination-ellipsis-start').exists()).toBe(false);
+        expect(wrapper.find('.pagination-ellipsis-end').exists()).toBe(true);
+    });
+
+    it("if user is on the second page, then correct page is selected and previous button is enabled", async () => {
+        await changeToPage(2);
+        expect(wrapper.vm.currentPageList).toEqual([2, 3, 4, 5, 6]);
+        expect(wrapper.find('.pagination-previous').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-link.is-current').text()).toEqual('2');
+        expect(wrapper.find('.pagination-ellipsis-start').exists()).toBe(false);
+        expect(wrapper.find('.pagination-ellipsis-end').exists()).toBe(true);
+    });
+
+    it("if user is on the middle page, then correct page is selected and all ellipses are shown", async () => {
+        await changeToPage(5);
+        expect(wrapper.vm.currentPageList).toEqual([3, 4, 5, 6, 7]);
+        expect(wrapper.find('.pagination-previous').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-link.is-current').text()).toEqual('5');
+        expect(wrapper.find('.pagination-ellipsis-start').exists()).toBe(true);
+        expect(wrapper.find('.pagination-ellipsis-end').exists()).toBe(true);
+    });
+
+    it("if user is on the last page, then correct page is selected and previous button is enabled", async () => {
+        await changeToPage(10);
+        expect(wrapper.vm.currentPageList).toEqual([5, 6, 7, 8, 9]);
+        expect(wrapper.find('.pagination-previous').classes('is-disabled')).toBe(false);
+        expect(wrapper.find('.pagination-next').classes('is-disabled')).toBe(true);
+        expect(wrapper.find('.pagination-link.is-current').text()).toEqual('10');
+        expect(wrapper.find('.pagination-ellipsis-start').exists()).toBe(true);
+        expect(wrapper.find('.pagination-ellipsis-end').exists()).toBe(false);
     });
 });

--- a/static/js/vue-cdr-access/tests/unit/thumbnail.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/thumbnail.spec.js
@@ -132,7 +132,7 @@ describe('thumbnail.vue', () => {
         expect(wrapper.find('.thumbnail .thumbnail-viewer').exists()).toBe(true);
         expect(wrapper.find('i.placeholder').exists()).toBe(false);
         expect(wrapper.find('a').attributes('class'))
-            .toEqual('thumbnail thumbnail-size-large has_tooltip');
+            .toEqual('thumbnail thumbnail-size-medium has_tooltip');
         let linkText = wrapper.find('a').attributes('aria-label');
         expect(linkText).toBe('Visit testCollection');
         let altText = wrapper.find('.thumbnail .thumbnail-viewer').attributes('aria-label');
@@ -164,7 +164,7 @@ describe('thumbnail.vue', () => {
         await wrapper.setProps({ thumbnailData: updatedRecordData });
         expect(wrapper.find('.thumbnail .placeholder').exists()).toBe(true);
         expect(wrapper.find('a').attributes('class'))
-            .toEqual('thumbnail thumbnail-size-large has_tooltip')
+            .toEqual('thumbnail thumbnail-size-medium has_tooltip')
     });
 
     it('displays a "file" placeholder for files, if no thumbnail', async () => {
@@ -223,7 +223,7 @@ describe('thumbnail.vue', () => {
         await wrapper.setProps({ thumbnailData: updatedRecordData });
         expect(wrapper.find('.fa-trash').exists()).toBe(true);
         expect(wrapper.find('a').attributes('class'))
-            .toEqual('thumbnail thumbnail-size-large deleted has_tooltip')
+            .toEqual('thumbnail thumbnail-size-medium deleted has_tooltip')
     });
 
     it('displays no icon if an item is not restricted or marked for deletion', async () => {
@@ -237,7 +237,19 @@ describe('thumbnail.vue', () => {
 
     it('sets the src for the image', () => {
         expect(wrapper.find('.thumbnail-viewer').attributes('style'))
+            .toEqual('background-image: url(https://localhost:8080/services/api/thumb/fc77a9be-b49d-4f4e-b656-1644c9e964fc/small);');
+    });
+
+    it('sets the src to large for large thumbnail', async () => {
+        await wrapper.setProps({ thumbnailData: recordData, size: 'large' });
+        expect(wrapper.find('.thumbnail-viewer').attributes('style'))
             .toEqual('background-image: url(https://localhost:8080/services/api/thumb/fc77a9be-b49d-4f4e-b656-1644c9e964fc/large);');
+    });
+
+    it('sets the src to small for small thumbnail', async () => {
+        await wrapper.setProps({ thumbnailData: recordData, size: 'small' });
+        expect(wrapper.find('.thumbnail-viewer').attributes('style'))
+            .toEqual('background-image: url(https://localhost:8080/services/api/thumb/fc77a9be-b49d-4f4e-b656-1644c9e964fc/small);');
     });
 
     it('sets the url for the image', () => {
@@ -281,7 +293,7 @@ describe('thumbnail.vue', () => {
         expect(wrapper.find('i.placeholder').exists()).toBe(false);
         expect(wrapper.find('a').exists()).toBe(false);
         let thumbWrapper = wrapper.find('div.thumbnail');
-        expect(thumbWrapper.attributes('class')).toEqual('thumbnail thumbnail-size-large has_tooltip');
+        expect(thumbWrapper.attributes('class')).toEqual('thumbnail thumbnail-size-medium has_tooltip');
         expect(thumbWrapper.attributes('aria-label')).toBe(undefined);
         expect(thumbWrapper.attributes('title')).toBe(undefined);
     });

--- a/static/js/vue-cdr-access/tests/unit/thumbnail.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/thumbnail.spec.js
@@ -273,4 +273,16 @@ describe('thumbnail.vue', () => {
         await wrapper.setProps({ thumbnailData: updatedRecordData });
         expect(wrapper.find('a').attributes('title')).toEqual('View the contents of testCollection')
     });
+
+    it('with asLink=false, does not wrap with a link', async () => {
+        await wrapper.setProps({ thumbnailData: recordData, asLink: false });
+
+        expect(wrapper.find('.thumbnail .thumbnail-viewer').exists()).toBe(true);
+        expect(wrapper.find('i.placeholder').exists()).toBe(false);
+        expect(wrapper.find('a').exists()).toBe(false);
+        let thumbWrapper = wrapper.find('div.thumbnail');
+        expect(thumbWrapper.attributes('class')).toEqual('thumbnail thumbnail-size-large has_tooltip');
+        expect(thumbWrapper.attributes('aria-label')).toBe(undefined);
+        expect(thumbWrapper.attributes('title')).toBe(undefined);
+    });
 });

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DatastreamController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DatastreamController.java
@@ -61,7 +61,7 @@ public class DatastreamController {
     private static final Logger log = LoggerFactory.getLogger(DatastreamController.class);
     private static final String SMALL = "small";
     private static final String LARGE = "large";
-    private static final Map<String, Integer> THUMB_SIZE_MAP = Map.of(SMALL, 64, LARGE, 128);
+    private static final Map<String, Integer> THUMB_SIZE_MAP = Map.of(SMALL, 160, LARGE, 250);
 
     @Autowired
     private FedoraContentService fedoraContentService;

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DatastreamRestControllerIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DatastreamRestControllerIT.java
@@ -210,7 +210,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         var filename = "bunny.jpg";
         var formattedBasePath = "/iiif/v3/" + ImageServerUtil.getImageServerEncodedId(id);
-        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!64,64/0/default.jpg"))
+        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!160,160/0/default.jpg"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBody(filename)
@@ -235,7 +235,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         var filename = "bunny.jpg";
         var formattedBasePath = "/iiif/v3/" + ImageServerUtil.getImageServerEncodedId(filePid.getId());
-        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!128,128/0/default.jpg"))
+        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!250,250/0/default.jpg"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBody(filename)
@@ -261,7 +261,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         var filename = "bunny.jpg";
         var formattedBasePath = "/iiif/v3/" + ImageServerUtil.getImageServerEncodedId(collectionPid.getId());
-        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!128,128/0/default.jpg"))
+        stubFor(WireMock.get(urlMatching(formattedBasePath + "/full/!250,250/0/default.jpg"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBody(filename)
@@ -311,7 +311,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
         var placeholder = "placeholder.png";
         var id = URLEncoder.encode("/default_images/placeholder.png", UTF_8);
 
-        stubFor(WireMock.get(urlMatching("/iiif/v3/" + id + "/full/!128,128/0/default.png"))
+        stubFor(WireMock.get(urlMatching("/iiif/v3/" + id + "/full/!250,250/0/default.png"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBodyFile(placeholder)


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4757
https://unclibrary.atlassian.net/browse/BXC-4807

* BXC-4757 - Change thumbnail sizes from 64px and 128px to 160px and 250px. 
    * Thumbnail component now defaults to medium size, where both medium and small use the 'small' thumbnail image size.
    * Only the gallery view uses large at the moment, whereas before everything used large 
* BXC-4807 - Add asLink attribute for thumbnails to allow thumbnails to not be links, set this attribute for full record thumbnails
* Convert pagination to using bulma component. Always shows 7 pages now, if there are at least 7 pages