### PR TITLE
BXC-4787 - Consolidate deposit directory logic and add alt text path getter

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/PreconstructedDepositJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/normalize/PreconstructedDepositJob.java
@@ -37,8 +37,6 @@ public class PreconstructedDepositJob extends AbstractDepositJob {
     @Override
     public void runJob() {
         try {
-            DepositDirectoryManager dirManager = new DepositDirectoryManager(
-                    depositPID, getDepositsDirectory().toPath(), true);
             Map<String, String> depositStatus = getDepositStatus();
             // Determine if we are importing an external deposit dir, or starting from one already in place
             String sourceUriProp = depositStatus.get(DepositField.sourceUri.name());
@@ -53,7 +51,7 @@ public class PreconstructedDepositJob extends AbstractDepositJob {
                 }
             }
             // Check to see if there is a model file to import
-            Path modelPath = dirManager.getModelPath();
+            Path modelPath = depositDirectoryManager.getModelPath();
             if (Files.exists(modelPath)) {
                 log.info("Importing preconstructed model file included in deposit directory");
                 Model importModel = RDFModelUtil.createModel(Files.newInputStream(modelPath), "N3");

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -160,7 +160,6 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         job = new IngestContentObjectsJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         job.setPremisLoggerFactory(premisLoggerFactory);
         setField(job, "pidMinter", pidMinter);
         setField(job, "aclService", aclService);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -181,7 +181,6 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
         job = new IngestContentObjectsJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "premisLoggerFactory", mockPremisLoggerFactory);
         setField(job, "aclService", aclService);
         setField(job, "depositModelManager", depositModelManager);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestDepositRecordJobIT.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestDepositRecordJobIT.java
@@ -73,7 +73,6 @@ public class IngestDepositRecordJobIT extends AbstractFedoraDepositJobIT {
         job = new IngestDepositRecordJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         job.setPremisLoggerFactory(premisLoggerFactory);
         setField(job, "pidMinter", pidMinter);
         setField(job, "depositModelManager", depositModelManager);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/StaffOnlyPermissionJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/StaffOnlyPermissionJobTest.java
@@ -40,7 +40,7 @@ public class StaffOnlyPermissionJobTest extends AbstractDepositJobTest {
 
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
+        setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "depositStatusFactory", depositStatusFactory);
         setField(job, "jobStatusFactory", jobStatusFactory);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/BagIt2N3BagJobTest.java
@@ -66,7 +66,6 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
     private void initJob(String uuid) {
         job = new BagIt2N3BagJob();
         job.setDepositUUID(uuid);
-        job.setDepositDirectory(depositDir);
         job.setExecutorService(executorService);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "depositsDirectory", depositsDirectory);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/CDRMETS2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/CDRMETS2N3BagJobTest.java
@@ -85,7 +85,6 @@ public class CDRMETS2N3BagJobTest extends AbstractNormalizationJobTest {
 
         job = new CDRMETS2N3BagJob(jobUUID, depositUUID);
         setField(job, "depositModelManager", depositModelManager);
-        job.setDepositDirectory(depositDir);
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "depositStatusFactory", depositStatusFactory);
         setField(job, "metsSipSchema", metsSipSchema);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/DirectoryToBagJobTest.java
@@ -64,11 +64,10 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 
         job = new DirectoryToBagJob();
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         job.setPremisLoggerFactory(premisLoggerFactory);
         setField(job, "depositModelManager", depositModelManager);
-        setField(job, "depositsDirectory", depositDirectory);
+        setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "depositStatusFactory", depositStatusFactory);
 
         job.init();

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/NormalizeFileObjectsJobTest.java
@@ -73,7 +73,6 @@ public class NormalizeFileObjectsJobTest extends AbstractDepositJobTest {
     public void init() {
         job = new NormalizeFileObjectsJob();
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         job.setDepositStatusFactory(depositStatusFactory);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "premisLoggerFactory", mockPremisLoggerFactory);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/PreconstructedDepositJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/PreconstructedDepositJobTest.java
@@ -41,11 +41,11 @@ public class PreconstructedDepositJobTest extends AbstractDepositJobTest {
 
         job = new PreconstructedDepositJob();
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "depositStatusFactory", depositStatusFactory);
+        job.init();
     }
 
     @Test
@@ -69,7 +69,7 @@ public class PreconstructedDepositJobTest extends AbstractDepositJobTest {
         Files.createDirectory(externalBasePath);
         DepositDirectoryManager extDirManager = new DepositDirectoryManager(depositPid, externalBasePath, true);
         status.put(DepositField.sourceUri.name(), extDirManager.getDepositDir().toUri().toString());
-        Files.createFile(extDirManager.getPremisPath(depositPid));
+        Files.createFile(extDirManager.getPremisPath(depositPid, true));
 
         job.run();
 
@@ -87,7 +87,7 @@ public class PreconstructedDepositJobTest extends AbstractDepositJobTest {
         DepositDirectoryManager preDirManager = new DepositDirectoryManager(
                 depositPid, depositsDirectory.toPath(), true);
         status.put(DepositField.sourceUri.name(), preDirManager.getDepositDir().toUri().toString());
-        Files.createFile(preDirManager.getPremisPath(depositPid));
+        Files.createFile(preDirManager.getPremisPath(depositPid, true));
 
         job.run();
 
@@ -130,7 +130,7 @@ public class PreconstructedDepositJobTest extends AbstractDepositJobTest {
         importModel.write(writer, "N3");
 
         status.put(DepositField.sourceUri.name(), extDirManager.getDepositDir().toUri().toString());
-        Files.createFile(extDirManager.getPremisPath(depositPid));
+        Files.createFile(extDirManager.getPremisPath(depositPid, true));
 
         job.run();
 

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/Simple2N3BagJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/Simple2N3BagJobTest.java
@@ -46,7 +46,6 @@ public class Simple2N3BagJobTest extends AbstractNormalizationJobTest {
 
         job = new Simple2N3BagJob();
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         job.setPremisLoggerFactory(premisLoggerFactory);
         setField(job, "depositModelManager", depositModelManager);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/VocabularyEnforcementJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/normalize/VocabularyEnforcementJobTest.java
@@ -60,13 +60,13 @@ public class VocabularyEnforcementJobTest extends AbstractNormalizationJobTest {
     public void setup() throws Exception {
         job = new VocabularyEnforcementJob();
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "jobStatusFactory", jobStatusFactory);
         setField(job, "depositStatusFactory", depositStatusFactory);
         setField(job, "vocabManager", vocabManager);
         setField(job, "depositModelManager", depositModelManager);
+        job.init();
 
         PID depositPid = pidMinter.mintContentPid();
         depositStatus = new HashMap<>();

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -134,7 +134,6 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         fitsCommand = new File(fitsHome, "fits.sh").toPath();
 
         job = new ExtractTechnicalMetadataJob(jobUUID, depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         job.setHttpClient(httpClient);
         job.setFitsHomePath(fitsHome.getAbsolutePath());

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
@@ -76,7 +76,7 @@ public class ValidateContentModelJobTest extends AbstractDepositJobTest {
         job.setAclValidator(aclValidator);
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
+        setField(job, "depositsDirectory", depositsDirectory);
         job.setDepositStatusFactory(depositStatusFactory);
         job.setRepositoryObjectLoader(repoObjectLoader);
         setField(job, "pidMinter", pidMinter);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateDescriptionJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateDescriptionJobTest.java
@@ -41,7 +41,6 @@ public class ValidateDescriptionJobTest extends AbstractDepositJobTest {
         job = new ValidateDescriptionJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "depositsDirectory", depositsDirectory);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateFileAvailabilityJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateFileAvailabilityJobTest.java
@@ -59,7 +59,6 @@ public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
         job = new ValidateFileAvailabilityJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         setField(job, "pidMinter", pidMinter);
         job.setIngestSourceManager(sourceManager);
         setField(job, "depositModelManager", depositModelManager);

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/VirusScanJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/VirusScanJobTest.java
@@ -101,7 +101,6 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
         job = new VirusScanJob();
         job.setJobUUID(jobUUID);
         job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
         job.setMaxStreamSize(300l);
         setField(job, "pidMinter", pidMinter);
         job.setClamClient(clamClient);

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
@@ -171,10 +171,6 @@ public class DepositDirectoryManager {
         return makeMetadataFilePath(eventsDir, pid, ".nt", createDirs);
     }
 
-    private Path makeMetadataFilePath(Path parentPath, PID pid, String extension) {
-        return makeMetadataFilePath(parentPath, pid, extension, false);
-    }
-
     private Path makeMetadataFilePath(Path parentPath, PID pid, String extension, boolean createDirs) {
         Path mdPath = parentPath;
         if (hashNesting) {

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
@@ -1,29 +1,22 @@
 package edu.unc.lib.boxc.deposit.impl.model;
 
+import edu.unc.lib.boxc.deposit.api.DepositConstants;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static edu.unc.lib.boxc.deposit.api.DepositConstants.DESCRIPTION_DIR;
 import static edu.unc.lib.boxc.deposit.api.DepositConstants.EVENTS_DIR;
 import static edu.unc.lib.boxc.deposit.api.DepositConstants.HISTORY_DIR;
 import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.HASHED_PATH_SIZE;
 import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
-import static java.nio.file.Files.newOutputStream;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import edu.unc.lib.boxc.deposit.api.DepositConstants;
-import org.apache.commons.io.FileUtils;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
-
-import edu.unc.lib.boxc.model.api.DatastreamType;
-import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
-import edu.unc.lib.boxc.model.api.ids.PID;
 
 /**
  * Manages a deposit directory for a single deposit
@@ -33,15 +26,15 @@ import edu.unc.lib.boxc.model.api.ids.PID;
 public class DepositDirectoryManager {
     public static final String MODEL_FILENAME = "model.n3";
 
-    private Path depositDir;
-    private Path descriptionDir;
-    private Path historyDir;
-    private Path eventsDir;
-    private Path altTextDir;
-    private Path techMdDir;
-    private Path dataDir;
-    private PID depositPid;
-    private boolean hashNesting;
+    private final Path depositDir;
+    private final Path descriptionDir;
+    private final Path historyDir;
+    private final Path eventsDir;
+    private final Path altTextDir;
+    private final Path techMdDir;
+    private final Path dataDir;
+    private final PID depositPid;
+    private final boolean hashNesting;
 
     public DepositDirectoryManager(PID depositPid, Path depositBaseDir, boolean hashNesting) {
         this(depositPid, depositBaseDir, hashNesting, true);
@@ -82,25 +75,6 @@ public class DepositDirectoryManager {
             FileUtils.deleteDirectory(depositDir.toFile());
         } catch (IOException e) {
             throw new RepositoryException("Failed to cleanup deposit directory: " + depositDir, e);
-        }
-    }
-
-    /**
-     * Write the provided MODS out to file in the deposit
-     *
-     * @param pid
-     * @param modsEl
-     */
-    public void writeMods(PID pid, Element modsEl) {
-        Path modsPath = getModsPath(pid);
-
-        try (OutputStream fos = newOutputStream(modsPath)) {
-            // Make a new document for just the MODS, which should add in the xml declaration
-            Document modsDoc = new Document();
-            modsDoc.addContent(modsEl.clone());
-            new XMLOutputter(Format.getPrettyFormat()).output(modsDoc, fos);
-        } catch (IOException e) {
-            throw new RepositoryException("Unable to write MODS for " + pid.getId(), e);
         }
     }
 

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
@@ -14,6 +14,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import edu.unc.lib.boxc.deposit.api.DepositConstants;
 import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -36,6 +37,9 @@ public class DepositDirectoryManager {
     private Path descriptionDir;
     private Path historyDir;
     private Path eventsDir;
+    private Path altTextDir;
+    private Path techMdDir;
+    private Path dataDir;
     private PID depositPid;
     private boolean hashNesting;
 
@@ -49,6 +53,9 @@ public class DepositDirectoryManager {
         this.descriptionDir = depositDir.resolve(DESCRIPTION_DIR);
         this.historyDir = depositDir.resolve(HISTORY_DIR);
         this.eventsDir = depositDir.resolve(EVENTS_DIR);
+        this.altTextDir = depositDir.resolve(DepositConstants.ALT_TEXT_DIR);
+        this.techMdDir = depositDir.resolve(DepositConstants.TECHMD_DIR);
+        this.dataDir = depositDir.resolve(DepositConstants.DATA_DIR);
         this.hashNesting = hashNesting;
 
         if (createDirs) {
@@ -62,6 +69,9 @@ public class DepositDirectoryManager {
             Files.createDirectories(descriptionDir);
             Files.createDirectories(historyDir);
             Files.createDirectories(eventsDir);
+            Files.createDirectories(altTextDir);
+            Files.createDirectories(techMdDir);
+            Files.createDirectories(dataDir);
         } catch (IOException e) {
             throw new RepositoryException("Failed to create deposit directory: " + depositDir, e);
         }
@@ -99,11 +109,29 @@ public class DepositDirectoryManager {
      * @return get the path to where the MODS file for the given PID should be located
      */
     public Path getModsPath(PID pid) {
-        return makeMetadataFilePath(descriptionDir, pid, ".xml");
+        return getModsPath(pid, false);
+    }
+
+    public Path getModsPath(PID pid, boolean createDirs) {
+        return makeMetadataFilePath(descriptionDir, pid, ".xml", createDirs);
+    }
+
+    public Path getAltTextPath(PID pid) {
+        return getAltTextPath(pid, false);
+    }
+
+    /**
+     * Get the path to the alt text file for the provided object
+     * @param pid
+     * @param createDirs
+     * @return
+     */
+    public Path getAltTextPath(PID pid, boolean createDirs) {
+        return makeMetadataFilePath(altTextDir, pid, ".txt", createDirs);
     }
 
     public Path writeHistoryFile(PID pid, DatastreamType type, InputStream historyStream) {
-        Path historyPath = makeMetadataFilePath(historyDir, pid, type.getId() + ".xml");
+        Path historyPath = makeMetadataFilePath(historyDir, pid, type.getId() + ".xml", true);
 
         try {
             Files.copy(historyStream, historyPath);
@@ -115,7 +143,18 @@ public class DepositDirectoryManager {
     }
 
     public Path getHistoryFile(PID pid, DatastreamType type) {
-        return makeMetadataFilePath(historyDir, pid, type.getId() + ".xml");
+        return getHistoryFile(pid, type, false);
+    }
+
+    /**
+     * Get the path to the history file for the provided object for the provided datastream type
+     * @param pid
+     * @param type
+     * @param createDirs
+     * @return
+     */
+    public Path getHistoryFile(PID pid, DatastreamType type, boolean createDirs) {
+        return makeMetadataFilePath(historyDir, pid, type.getId() + ".xml", createDirs);
     }
 
     /**
@@ -125,18 +164,28 @@ public class DepositDirectoryManager {
      * @return
      */
     public Path getPremisPath(PID pid) {
-        return makeMetadataFilePath(eventsDir, pid, ".nt");
+        return getPremisPath(pid, false);
+    }
+
+    public Path getPremisPath(PID pid, boolean createDirs) {
+        return makeMetadataFilePath(eventsDir, pid, ".nt", createDirs);
     }
 
     private Path makeMetadataFilePath(Path parentPath, PID pid, String extension) {
+        return makeMetadataFilePath(parentPath, pid, extension, false);
+    }
+
+    private Path makeMetadataFilePath(Path parentPath, PID pid, String extension, boolean createDirs) {
         Path mdPath = parentPath;
         if (hashNesting) {
             String hashing = idToPath(pid.getId(), HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
             mdPath = mdPath.resolve(hashing);
-            try {
-                Files.createDirectories(mdPath);
-            } catch (IOException e) {
-                throw new RepositoryException("Failed to create hashed metadata directory: " + mdPath, e);
+            if (createDirs) {
+                try {
+                    Files.createDirectories(mdPath);
+                } catch (IOException e) {
+                    throw new RepositoryException("Failed to create hashed metadata directory: " + mdPath, e);
+                }
             }
         }
         return mdPath.resolve(pid.getId() + extension);
@@ -149,19 +198,66 @@ public class DepositDirectoryManager {
         return depositDir.resolve(MODEL_FILENAME);
     }
 
+    /**
+     * @return the directory containing all files related to the deposit
+     */
     public Path getDepositDir() {
         return depositDir;
     }
 
+    /**
+     * @return the directory where description files are stored
+     */
     public Path getDescriptionDir() {
         return descriptionDir;
     }
 
+    /**
+     * @return the directory where history files are stored
+     */
     public Path getHistoryDir() {
         return historyDir;
     }
 
+    /**
+     * @return the directory where PREMIS event log files are stored
+     */
     public Path getEventsDir() {
         return eventsDir;
+    }
+
+    /**
+     * @return the directory where alt text files are stored
+     */
+    public Path getAltTextDir() {
+        return altTextDir;
+    }
+
+    /**
+     * @return the directory where technical metadata files are stored
+     */
+    public Path getTechMdDir() {
+        return techMdDir;
+    }
+
+    public Path getTechMdPath(PID pid) {
+        return getTechMdPath(pid, false);
+    }
+
+    /**
+     * Get the path to the technical metadata file for the provided object
+     * @param pid
+     * @param createDirs
+     * @return
+     */
+    public Path getTechMdPath(PID pid, boolean createDirs) {
+        return makeMetadataFilePath(techMdDir, pid, ".xml", createDirs);
+    }
+
+    /**
+     * @return Directory where local data files are stored
+     */
+    public Path getDataDir() {
+        return dataDir;
     }
 }

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManagerTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManagerTest.java
@@ -1,0 +1,163 @@
+package edu.unc.lib.boxc.deposit.impl.model;
+
+import edu.unc.lib.boxc.deposit.api.DepositConstants;
+import edu.unc.lib.boxc.model.api.DatastreamType;
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bbpennel
+ */
+public class DepositDirectoryManagerTest {
+    private static final String OBJECT_ID = "60f617ca-2107-4e7a-bfdb-7243c62fccc2";
+    private static final String OBJECT_PATH = "60/f6/17/ca";
+    private static final String DEPOSIT_ID = "0f71ea28-b44e-41f4-a7d6-6666da8ad140";
+    @TempDir
+    public Path tmpFolder;
+
+    private DepositDirectoryManager manager;
+    private PID depositPid;
+    private PID objectPid;
+
+    @BeforeEach
+    void setUp() {
+        depositPid = PIDs.get(DEPOSIT_ID);
+        objectPid = PIDs.get(OBJECT_ID);
+        manager = new DepositDirectoryManager(depositPid, tmpFolder, true, false);
+    }
+
+    @Test
+    void testGetDepositDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID);
+        assertEquals(expectedPath, manager.getDepositDir(), "Deposit directory path is incorrect");
+    }
+
+    @Test
+    void testGetDescriptionDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.DESCRIPTION_DIR);
+        assertEquals(expectedPath, manager.getDescriptionDir(), "Description directory path is incorrect");
+    }
+
+    @Test
+    void testGetHistoryDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.HISTORY_DIR);
+        assertEquals(expectedPath, manager.getHistoryDir(), "History directory path is incorrect");
+    }
+
+    @Test
+    void testGetEventsDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.EVENTS_DIR);
+        assertEquals(expectedPath, manager.getEventsDir(), "Events directory path is incorrect");
+    }
+
+    @Test
+    void testGetAltTextDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.ALT_TEXT_DIR);
+        assertEquals(expectedPath, manager.getAltTextDir(), "Alt text directory path is incorrect");
+    }
+
+    @Test
+    void testGetTechMdDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.TECHMD_DIR);
+        assertEquals(expectedPath, manager.getTechMdDir(), "Technical metadata directory path is incorrect");
+    }
+
+    @Test
+    void testGetDataDir() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.DATA_DIR);
+        assertEquals(expectedPath, manager.getDataDir(), "Data directory path is incorrect");
+    }
+
+    @Test
+    void testGetModelPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositDirectoryManager.MODEL_FILENAME);
+        assertEquals(expectedPath, manager.getModelPath(), "Model file path is incorrect");
+    }
+
+    @Test
+    void testGetModsPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.DESCRIPTION_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + ".xml");
+        assertEquals(expectedPath, manager.getModsPath(objectPid), "MODS path is incorrect");
+    }
+
+    @Test
+    void testGetAltTextPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.ALT_TEXT_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + ".txt");
+        Path resultPath = manager.getAltTextPath(objectPid);
+        assertEquals(expectedPath, resultPath, "Alt text path is incorrect");
+        assertFalse(Files.exists(resultPath.getParent()), "Alt text directory was not created");
+    }
+
+    @Test
+    void testGetAltTextCreateDirsPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.ALT_TEXT_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + ".txt");
+        Path resultPath = manager.getAltTextPath(objectPid, true);
+        assertEquals(expectedPath, resultPath, "Alt text path is incorrect");
+        assertTrue(Files.exists(resultPath.getParent()), "Alt text directory was not created");
+        assertFalse(Files.exists(resultPath), "Alt text file should not be created");
+    }
+
+    @Test
+    void testGetPremisPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.EVENTS_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + ".nt");
+        assertEquals(expectedPath, manager.getPremisPath(objectPid), "PREMIS path is incorrect");
+    }
+
+    @Test
+    void testGetTechMdPath() {
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.TECHMD_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + ".xml");
+        assertEquals(expectedPath, manager.getTechMdPath(objectPid), "Technical metadata path is incorrect");
+    }
+
+    @Test
+    void testGetHistoryFile() {
+        DatastreamType dsType = DatastreamType.MD_DESCRIPTIVE;
+
+        Path expectedPath = tmpFolder.resolve(DEPOSIT_ID).resolve(DepositConstants.HISTORY_DIR)
+                .resolve(OBJECT_PATH).resolve(OBJECT_ID + "md_descriptive.xml");
+        assertEquals(expectedPath, manager.getHistoryFile(objectPid, dsType), "History file path is incorrect");
+    }
+
+    @Test
+    void testCreateAndCleanupDirs() {
+        manager.createDepositDirectory();
+        assertTrue(Files.exists(manager.getDepositDir()), "Deposit directory was not created");
+        assertTrue(Files.exists(manager.getDescriptionDir()), "Description directory was not created");
+        assertTrue(Files.exists(manager.getHistoryDir()), "History directory was not created");
+        assertTrue(Files.exists(manager.getEventsDir()), "Events directory was not created");
+        assertTrue(Files.exists(manager.getAltTextDir()), "Alt text directory was not created");
+        assertTrue(Files.exists(manager.getTechMdDir()), "Technical metadata directory was not created");
+        assertTrue(Files.exists(manager.getDataDir()), "Data directory was not created");
+
+        manager.cleanupDepositDirectory();
+        assertFalse(Files.exists(manager.getDepositDir()), "Deposit directory was not deleted");
+    }
+
+    @Test
+    void testCreateDirsConstructor() {
+        manager = new DepositDirectoryManager(depositPid, tmpFolder, true, true);
+
+        assertTrue(Files.exists(manager.getDepositDir()), "Deposit directory was not created");
+        assertTrue(Files.exists(manager.getDescriptionDir()), "Description directory was not created");
+        assertTrue(Files.exists(manager.getHistoryDir()), "History directory was not created");
+        assertTrue(Files.exists(manager.getEventsDir()), "Events directory was not created");
+        assertTrue(Files.exists(manager.getAltTextDir()), "Alt text directory was not created");
+        assertTrue(Files.exists(manager.getTechMdDir()), "Technical metadata directory was not created");
+        assertTrue(Files.exists(manager.getDataDir()), "Data directory was not created");
+    }
+}


### PR DESCRIPTION
Relates to https://unclibrary.atlassian.net/browse/BXC-4787

* Consolidated deposit directory logic into DepositDirectoryManager.
* Added alt text getter methods. 
* Directory getter methods no longer default to creating parent directories, but there are no overridden methods which can be used for that