### PR TITLE
BXC-4777 improve handing and retries of jp2 generation errors

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
@@ -46,9 +46,8 @@ public class ImageEnhancementsRouter extends RouteBuilder {
         uuidGenerator = new DefaultUuidGenerator();
 
         onException(AddDerivativeProcessor.DerivativeGenerationException.class)
-                .handled(true)
                 .maximumRedeliveries(0)
-                .log(LoggingLevel.ERROR, log, "${exception.message}");
+                .log(LoggingLevel.ERROR, "${exception.message}");
 
         onException(RepositoryException.class)
                 .redeliveryDelay("{{error.retryDelay}}")

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
@@ -48,7 +48,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
         onException(AddDerivativeProcessor.DerivativeGenerationException.class)
                 .handled(true)
                 .maximumRedeliveries(0)
-                .log(LoggingLevel.ERROR, "JP2 Derivative generation failed: ${exception.message}");
+                .log(LoggingLevel.ERROR, log, "${exception.message}");
 
         onException(RepositoryException.class)
                 .redeliveryDelay("{{error.retryDelay}}")

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.services.camel.images;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import JP2ImageConverter.errors.CommandException;
 import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
@@ -45,6 +46,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
         uuidGenerator = new DefaultUuidGenerator();
 
         onException(AddDerivativeProcessor.DerivativeGenerationException.class)
+                .handled(true)
                 .maximumRedeliveries(0)
                 .log(LoggingLevel.WARN, "JP2 Derivative generation failed: ${exception.message}");
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
@@ -44,6 +44,10 @@ public class ImageEnhancementsRouter extends RouteBuilder {
 
         uuidGenerator = new DefaultUuidGenerator();
 
+        onException(AddDerivativeProcessor.DerivativeGenerationException.class)
+                .maximumRedeliveries(0)
+                .log(LoggingLevel.WARN, "JP2 Derivative generation failed: ${exception.message}");
+
         onException(RepositoryException.class)
                 .redeliveryDelay("{{error.retryDelay}}")
                 .maximumRedeliveries("{{error.maxRedeliveries}}")

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouter.java
@@ -48,7 +48,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
         onException(AddDerivativeProcessor.DerivativeGenerationException.class)
                 .handled(true)
                 .maximumRedeliveries(0)
-                .log(LoggingLevel.WARN, "JP2 Derivative generation failed: ${exception.message}");
+                .log(LoggingLevel.ERROR, "JP2 Derivative generation failed: ${exception.message}");
 
         onException(RepositoryException.class)
                 .redeliveryDelay("{{error.retryDelay}}")


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4777](https://unclibrary.atlassian.net/browse/BXC-4777)

- skip retries for `DerivativeGenerationException` errors