### PR TITLE
BXC-4869 display archival collection id in additional locations

### DIFF
--- a/static/css/admin/search_results.css
+++ b/static/css/admin/search_results.css
@@ -393,7 +393,7 @@
 	width: 100%;
 }
 
-result_table colgroup > .collection_id, .result_table .column_headers > .collection_id > a {
+.result_table colgroup > .collection_id, .result_table .column_headers > .collection_id > a {
 	width: 120px;
 }
 
@@ -473,6 +473,14 @@ result_table colgroup > .collection_id, .result_table .column_headers > .collect
 
 .itemdetails > div > .warning_symbol {
 	font-size: 110%;
+}
+
+.res_entry > .collection_id > div {
+	font-size: 70%;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 114px;
 }
 
 .res_entry > .creator > div {

--- a/static/css/admin/search_results.css
+++ b/static/css/admin/search_results.css
@@ -393,6 +393,10 @@
 	width: 100%;
 }
 
+result_table colgroup > .collection_id, .result_table .column_headers > .collection_id > a {
+	width: 120px;
+}
+
 .result_table colgroup > .creator, .result_table .column_headers > .creator > a {
 	width: 120px;
 }

--- a/static/js/admin/src/ResultView.js
+++ b/static/js/admin/src/ResultView.js
@@ -76,6 +76,7 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 						"select" : {name : "", colClass : "narrow", dataType : "index", sortField : "collection"},
 						"resourceType" : {name : "", colClass : "narrow", sortField : "resourceType"},
 						"title" : {name : "Title", colClass : "itemdetails", dataType : "title", sortField : "title"},
+						"collectionId" : {name : "Collection Id", colClass : "collection_id", sortField : "collectionId"},
 						"creator" : {name : "Creator", colClass : "creator", sortField : "creator"},
 						"dateAdded" : {name : "Deposited", colClass : "date_added", sortField : "dateAdded"},
 						"dateModified" : {name : "Modified", colClass : "date_added", sortField : "dateUpdated"},

--- a/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
@@ -14,10 +14,10 @@
                         <dt>{{ $t('full_record.date_added') }}</dt>
                         <dd>{{ formatDate(recordData.briefObject.added) }}</dd>
                     </template>
-                  <template v-if="fieldExists(recordData.briefObject.collectionId)">
-                    <dt>{{ $t('full_record.collection_id') }}</dt>
-                    <dd>{{ formatDate(recordData.briefObject.collectionId) }}</dd>
-                  </template>
+                    <template v-if="fieldExists(recordData.briefObject.collectionId)">
+                      <dt>{{ $t('full_record.collection_id') }}</dt>
+                      <dd>{{ formatDate(recordData.briefObject.collectionId) }}</dd>
+                    </template>
                     <template v-if="fieldExists(recordData.findingAidUrl)">
                         <dt>{{ $t('full_record.finding_aid') }}</dt>
                         <dd><a class="finding-aid" :href="recordData.findingAidUrl">{{ recordData.findingAidUrl }}</a></dd>

--- a/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
@@ -15,7 +15,7 @@
                         <dd>{{ formatDate(recordData.briefObject.added) }}</dd>
                     </template>
                     <template v-if="fieldExists(recordData.briefObject.collectionId)">
-                      <dt>{{ $t('full_record.collection_id') }}</dt>
+                      <dt>{{ $t('display.collection_id') }}</dt>
                       <dd>{{ recordData.briefObject.collectionId }}</dd>
                     </template>
                     <template v-if="fieldExists(recordData.findingAidUrl)">

--- a/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
@@ -16,7 +16,7 @@
                     </template>
                     <template v-if="fieldExists(recordData.briefObject.collectionId)">
                       <dt>{{ $t('full_record.collection_id') }}</dt>
-                      <dd>{{ formatDate(recordData.briefObject.collectionId) }}</dd>
+                      <dd>{{ recordData.briefObject.collectionId }}</dd>
                     </template>
                     <template v-if="fieldExists(recordData.findingAidUrl)">
                         <dt>{{ $t('full_record.finding_aid') }}</dt>

--- a/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
+++ b/static/js/vue-cdr-access/src/components/full_record/collectionRecord.vue
@@ -14,6 +14,10 @@
                         <dt>{{ $t('full_record.date_added') }}</dt>
                         <dd>{{ formatDate(recordData.briefObject.added) }}</dd>
                     </template>
+                  <template v-if="fieldExists(recordData.briefObject.collectionId)">
+                    <dt>{{ $t('full_record.collection_id') }}</dt>
+                    <dd>{{ formatDate(recordData.briefObject.collectionId) }}</dd>
+                  </template>
                     <template v-if="fieldExists(recordData.findingAidUrl)">
                         <dt>{{ $t('full_record.finding_aid') }}</dt>
                         <dd><a class="finding-aid" :href="recordData.findingAidUrl">{{ recordData.findingAidUrl }}</a></dd>

--- a/static/js/vue-cdr-access/src/components/listDisplay.vue
+++ b/static/js/vue-cdr-access/src/components/listDisplay.vue
@@ -100,7 +100,7 @@ Renders search results in a list view display format
             },
 
             showCollection(record) {
-                return record.type !== 'AdminUnit' && record.type !== 'Collection' &&
+                return record.type !== 'AdminUnit' && record.type === 'Collection' &&
                     record.objectPath[2].collectionId !== null;
             }
         }

--- a/static/js/vue-cdr-access/src/components/listDisplay.vue
+++ b/static/js/vue-cdr-access/src/components/listDisplay.vue
@@ -100,8 +100,7 @@ Renders search results in a list view display format
             },
 
             showCollection(record) {
-                return record.type !== 'AdminUnit' && record.type === 'Collection' &&
-                    record.objectPath[2].collectionId !== null;
+                return record.type !== 'AdminUnit' && record.objectPath[2].collectionId !== null;
             }
         }
     }

--- a/static/templates/admin/resultEntry.html
+++ b/static/templates/admin/resultEntry.html
@@ -36,7 +36,7 @@
 	</td>
 	<td class="collection_id">
 		<div title="<%= metadata.collectionId ? metadata.collectionId : '' %>">
-			<%= metadata.collectionId? metadata.collectionId[0] : '-' %>
+			<%= metadata.collectionId? metadata.collectionId : '-' %>
 		</div>
 	</td>
 	<td class="creator">

--- a/static/templates/admin/resultEntry.html
+++ b/static/templates/admin/resultEntry.html
@@ -34,11 +34,15 @@
 			<% } %>
 		</div>
 	</td>
-	<td class="collection_id">
-		<div title="<%= metadata.collectionId ? metadata.collectionId : '' %>">
-			<%= metadata.collectionId? metadata.collectionId : '-' %>
-		</div>
-	</td>
+	<% if (metadata.type == "Collection") { %>
+		<td class="collection_id">
+			<div title="<%= metadata.collectionId ? metadata.collectionId : '' %>">
+				<%= metadata.collectionId? metadata.collectionId : '-' %>
+			</div>
+		</td>
+	<% } else { %>
+		<td class="collection_id" style="display:none"></td>
+	<% } %>
 	<td class="creator">
 		<div>
 			<%= metadata.creator? metadata.creator[0] : '-' %><%= metadata.creator && metadata.creator.length > 1? '&nbsp;et al' : '' %> 

--- a/static/templates/admin/resultEntry.html
+++ b/static/templates/admin/resultEntry.html
@@ -36,7 +36,7 @@
 	</td>
 	<td class="collection_id">
 		<div title="<%= metadata.collectionId ? metadata.collectionId : '' %>">
-			<%= metadata.collectionId? metadata.collectionId.substring(0, metadata.collectionId.indexOf('T')) : '-' %>
+			<%= metadata.collectionId? metadata.collectionId[0] : '-' %>
 		</div>
 	</td>
 	<td class="creator">

--- a/static/templates/admin/resultEntry.html
+++ b/static/templates/admin/resultEntry.html
@@ -34,6 +34,11 @@
 			<% } %>
 		</div>
 	</td>
+	<td class="collection_id">
+		<div title="<%= metadata.collectionId ? metadata.collectionId : '' %>">
+			<%= metadata.collectionId? metadata.collectionId.substring(0, metadata.collectionId.indexOf('T')) : '-' %>
+		</div>
+	</td>
 	<td class="creator">
 		<div>
 			<%= metadata.creator? metadata.creator[0] : '-' %><%= metadata.creator && metadata.creator.length > 1? '&nbsp;et al' : '' %> 

--- a/static/templates/admin/resultEntry.html
+++ b/static/templates/admin/resultEntry.html
@@ -40,8 +40,6 @@
 				<%= metadata.collectionId? metadata.collectionId : '-' %>
 			</div>
 		</td>
-	<% } else { %>
-		<td class="collection_id" style="display:none"></td>
 	<% } %>
 	<td class="creator">
 		<div>

--- a/static/templates/admin/resultTableView.html
+++ b/static/templates/admin/resultTableView.html
@@ -5,16 +5,14 @@
 			<table class="result_table">
 				<colgroup>
 					<% _.each(resultFields, function(resultField) { %>
-						<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
-						<% } else { %>
+						<% if (resultField.colClass != "collection_id" || container.type == "AdminUnit") { %>
 							<col class="<%= resultField.colClass %>">
 					<% }}); %>
 				</colgroup>
 				<thead>
 					<tr class="column_headers">
 						<% _.each(resultFields, function(resultField) { %>
-							<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
-							<% } else { %>
+							<% if (resultField.colClass != "collection_id" || container.type == "AdminUnit") { %>
 								<th class="<%= resultField.colClass%><%= ('sortField' in resultField)? ' sort_col' : '' %>" <%=
 								('sortField' in resultField)? ' data-field="' + resultField.sortField + '"' : '' %> <%=
 								('dataType' in resultField)? ' data-type="' + resultField.dataType + '"' : '' %>><a><%= resultField.name %></a></th>

--- a/static/templates/admin/resultTableView.html
+++ b/static/templates/admin/resultTableView.html
@@ -5,17 +5,23 @@
 			<table class="result_table">
 				<colgroup>
 					<% _.each(resultFields, function(resultField) { %>
-						<col class="<%= resultField.colClass %>">
-					<% }); %>
+						<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
+							<col class="<%= resultField.colClass %>" style="display:none">
+						<% } else { %>
+							<col class="<%= resultField.colClass %>">
+					<% }}); %>
 				</colgroup>
 				<thead>
 					<tr class="column_headers">
 						<% _.each(resultFields, function(resultField) { %>
-							<th class="<%= resultField.colClass 
-									%><%= ('sortField' in resultField)? ' sort_col' : '' %>" <%= 
-									('sortField' in resultField)? ' data-field="' + resultField.sortField + '"' : '' %> <%= 
-									('dataType' in resultField)? ' data-type="' + resultField.dataType + '"' : '' %>><a><%= resultField.name %></a></th>
-						<% }); %>
+							<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
+								<th class="<%= resultField.colClass
+										%><%= ('sortField' in resultField)? ' sort_col' : '' %>" style="display:none"></th>
+							<% } else { %>
+								<th class="<%= resultField.colClass%><%= ('sortField' in resultField)? ' sort_col' : '' %>" <%=
+								('sortField' in resultField)? ' data-field="' + resultField.sortField + '"' : '' %> <%=
+								('dataType' in resultField)? ' data-type="' + resultField.dataType + '"' : '' %>><a><%= resultField.name %></a></th>
+						<% }}); %>
 					</tr>
 				</thead>
 				<tbody>

--- a/static/templates/admin/resultTableView.html
+++ b/static/templates/admin/resultTableView.html
@@ -6,7 +6,6 @@
 				<colgroup>
 					<% _.each(resultFields, function(resultField) { %>
 						<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
-							<col class="<%= resultField.colClass %>" style="display:none">
 						<% } else { %>
 							<col class="<%= resultField.colClass %>">
 					<% }}); %>
@@ -15,8 +14,6 @@
 					<tr class="column_headers">
 						<% _.each(resultFields, function(resultField) { %>
 							<% if (resultField.colClass == "collection_id" && container.type != "AdminUnit") { %>
-								<th class="<%= resultField.colClass
-										%><%= ('sortField' in resultField)? ' sort_col' : '' %>" style="display:none"></th>
 							<% } else { %>
 								<th class="<%= resultField.colClass%><%= ('sortField' in resultField)? ' sort_col' : '' %>" <%=
 								('sortField' in resultField)? ' data-field="' + resultField.sortField + '"' : '' %> <%=

--- a/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/AbstractSearchController.java
+++ b/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/AbstractSearchController.java
@@ -24,8 +24,8 @@ public class AbstractSearchController extends AbstractSolrSearchController {
     protected ChildrenCountService childrenCountService;
 
     protected static List<String> resultsFieldList = Arrays.asList(SearchFieldKey.ID.name(),
-            SearchFieldKey.TITLE.name(), SearchFieldKey.CREATOR.name(), SearchFieldKey.DATASTREAM.name(),
-            SearchFieldKey.DATE_ADDED.name(), SearchFieldKey.DATE_UPDATED.name(),
+            SearchFieldKey.TITLE.name(), SearchFieldKey.COLLECTION_ID.name(), SearchFieldKey.CREATOR.name(),
+            SearchFieldKey.DATASTREAM.name(), SearchFieldKey.DATE_ADDED.name(), SearchFieldKey.DATE_UPDATED.name(),
             SearchFieldKey.RESOURCE_TYPE.name(),
             SearchFieldKey.STATUS.name(), SearchFieldKey.VERSION.name(),SearchFieldKey.ROLE_GROUP.name(),
             SearchFieldKey.FILE_FORMAT_CATEGORY.name(), SearchFieldKey.FILE_FORMAT_TYPE.name(),

--- a/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/ResultEntryController.java
+++ b/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/ResultEntryController.java
@@ -31,7 +31,8 @@ import edu.unc.lib.boxc.web.common.utils.SerializationUtil;
 @Controller
 public class ResultEntryController extends AbstractSearchController {
     private final List<String> resultsFieldList = Arrays.asList(SearchFieldKey.ID.name(), SearchFieldKey.TITLE.name(),
-            SearchFieldKey.CREATOR.name(), SearchFieldKey.DATASTREAM.name(), SearchFieldKey.DATE_ADDED.name(),
+            SearchFieldKey.COLLECTION_ID.name(), SearchFieldKey.CREATOR.name(),
+            SearchFieldKey.DATASTREAM.name(), SearchFieldKey.DATE_ADDED.name(),
             SearchFieldKey.DATE_UPDATED.name(), SearchFieldKey.RESOURCE_TYPE.name(),
             SearchFieldKey.STATUS.name(), SearchFieldKey.ANCESTOR_PATH.name(), SearchFieldKey.STREAMING_TYPE.name(),
             SearchFieldKey.STREAMING_URL.name(), SearchFieldKey.VERSION.name(), SearchFieldKey.ROLE_GROUP.name(),

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
@@ -113,43 +113,43 @@ public class SerializationUtil {
         }
 
         if (metadata.getId() != null) {
-            result.put("id", metadata.getId());
+            result.put(SearchFieldKey.ID.getUrlParam(), metadata.getId());
         }
 
         if (metadata.getTitle() != null) {
-            result.put("title", metadata.getTitle());
+            result.put(SearchFieldKey.TITLE.getUrlParam(), metadata.getTitle());
         }
 
         if (metadata.get_version_() != null) {
-            result.put("_version_", metadata.get_version_());
+            result.put(SearchFieldKey.VERSION.getUrlParam(), metadata.get_version_());
         }
 
         if (metadata.getStatus() != null && !metadata.getStatus().isEmpty()) {
-            result.put("status", metadata.getStatus());
+            result.put(SearchFieldKey.STATUS.getUrlParam(), metadata.getStatus());
         }
 
         if (metadata.getContentStatus() != null && !metadata.getContentStatus().isEmpty()) {
-            result.put("contentStatus", metadata.getContentStatus());
+            result.put(SearchFieldKey.CONTENT_STATUS.getUrlParam(), metadata.getContentStatus());
         }
 
         if (metadata.getSubject() != null) {
-            result.put("subject", metadata.getSubject());
+            result.put(SearchFieldKey.SUBJECT.getUrlParam(), metadata.getSubject());
         }
 
         if (metadata.getResourceType() != null) {
-            result.put("type", metadata.getResourceType());
+            result.put(SearchFieldKey.RESOURCE_TYPE.getUrlParam(), metadata.getResourceType());
         }
 
         if (metadata.getCollectionId() != null) {
-            result.put("collectionId", metadata.getCollectionId());
+            result.put(SearchFieldKey.COLLECTION_ID.getUrlParam(), metadata.getCollectionId());
         }
 
         if (metadata.getCreator() != null) {
-            result.put("creator", metadata.getCreator());
+            result.put(SearchFieldKey.CREATOR.getUrlParam(), metadata.getCreator());
         }
 
         if (metadata.getDatastream() != null) {
-            result.put("datastream", metadata.getDatastream());
+            result.put(SearchFieldKey.DATASTREAM.getUrlParam(), metadata.getDatastream());
         }
 
         if (metadata.getFileFormatCategory() != null) {

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
@@ -121,7 +121,7 @@ public class SerializationUtil {
         }
 
         if (metadata.get_version_() != null) {
-            result.put(SearchFieldKey.VERSION.getUrlParam(), metadata.get_version_());
+            result.put("_version_", metadata.get_version_());
         }
 
         if (metadata.getStatus() != null && !metadata.getStatus().isEmpty()) {

--- a/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
+++ b/web-common/src/main/java/edu/unc/lib/boxc/web/common/utils/SerializationUtil.java
@@ -140,6 +140,10 @@ public class SerializationUtil {
             result.put("type", metadata.getResourceType());
         }
 
+        if (metadata.getCollectionId() != null) {
+            result.put("collectionId", metadata.getCollectionId());
+        }
+
         if (metadata.getCreator() != null) {
             result.put("creator", metadata.getCreator());
         }


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4869](https://unclibrary.atlassian.net/browse/BXC-4869)

- add `collectionId` sortable field to admin UI
- if the `collectionId` is present, display `collectionId` in collection browse and under the collection name when collection results are returned