### PR TITLE
BXC-4929 add identifier search index for admin UI

### DIFF
--- a/etc/solr-config/access/conf/schema.xml
+++ b/etc/solr-config/access/conf/schema.xml
@@ -236,6 +236,7 @@
     <!-- Index fields -->
     <!-- Specific field indexes -->
     <field name="contributorIndex" type="text_ns" indexed="true" stored="false" multiValued="true"/>
+    <field name="identifierIndex" type="text" indexed="true" stored="false" multiValued="true"/>
     <!-- Index for most fields, except full text -->
     <field name="keywordIndex" type="text" indexed="true" stored="false" multiValued="true"/>
     <!-- Default, primary search field, includes everything from keyword index, plus full text -->
@@ -279,6 +280,8 @@
   <copyField source="otherSubject" dest="subjectIndex"/>
   <copyField source="contributor" dest="contributorIndex"/>
   <copyField source="creator" dest="contributorIndex"/>
+
+  <copyField source="aspaceRefId" dest="identifierIndex"/>
 
   <copyField source="title" dest="keywordIndex"/>
   <copyField source="title" dest="keywordIndex"/>

--- a/etc/solr-config/access/conf/schema.xml
+++ b/etc/solr-config/access/conf/schema.xml
@@ -281,7 +281,7 @@
   <copyField source="contributor" dest="contributorIndex"/>
   <copyField source="creator" dest="contributorIndex"/>
 
-  <copyField source="aspaceRefId" dest="identifierIndex"/>
+  <copyField source="identifier" dest="identifierIndex"/>
 
   <copyField source="title" dest="keywordIndex"/>
   <copyField source="title" dest="keywordIndex"/>

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
@@ -33,7 +33,7 @@ public class SetAspaceRefIdFilter implements IndexDocumentFilter {
                 resource.getProperty(CdrAspace.refId).getString() : null;
 
         List<String> identifiers = new ArrayList<>();
-        if (!doc.getIdentifier().isEmpty()) {
+        if (!doc.getIdentifier().isEmpty() && doc.getIdentifier() != null) {
             identifiers = doc.getIdentifier();
         }
         identifiers.add("aspaceRefId|" + refId);

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
@@ -7,6 +7,9 @@ import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Sets the ArchivesSpace Ref ID tag for WorkObjects
  * @author snluong
@@ -28,7 +31,10 @@ public class SetAspaceRefIdFilter implements IndexDocumentFilter {
 
         var refId = resource.hasProperty(CdrAspace.refId) ?
                 resource.getProperty(CdrAspace.refId).getString() : null;
+        List<String> identifiers = new ArrayList<>();
+        identifiers.add("aspaceRefId|" + refId);
 
         doc.setAspaceRefId(refId);
+        doc.setIdentifier(identifiers);
     }
 }

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
@@ -31,7 +31,11 @@ public class SetAspaceRefIdFilter implements IndexDocumentFilter {
 
         var refId = resource.hasProperty(CdrAspace.refId) ?
                 resource.getProperty(CdrAspace.refId).getString() : null;
+
         List<String> identifiers = new ArrayList<>();
+        if (!doc.getIdentifier().isEmpty()) {
+            identifiers = doc.getIdentifier();
+        }
         identifiers.add("aspaceRefId|" + refId);
 
         doc.setAspaceRefId(refId);

--- a/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
+++ b/indexing-solr/src/main/java/edu/unc/lib/boxc/indexing/solr/filter/SetAspaceRefIdFilter.java
@@ -33,7 +33,7 @@ public class SetAspaceRefIdFilter implements IndexDocumentFilter {
                 resource.getProperty(CdrAspace.refId).getString() : null;
 
         List<String> identifiers = new ArrayList<>();
-        if (!doc.getIdentifier().isEmpty() && doc.getIdentifier() != null) {
+        if (doc.getIdentifier() != null && !doc.getIdentifier().isEmpty()) {
             identifiers = doc.getIdentifier();
         }
         identifiers.add("aspaceRefId|" + refId);

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/SearchFieldKey.java
@@ -42,6 +42,7 @@ public enum SearchFieldKey {
     HOOK_ID("hookId", "hookId", "ArchivesSpace Hook ID"),
     ID("id", "id", "ID"),
     IDENTIFIER("identifier", "identifier", "Identifier"),
+    IDENTIFIER_INDEX("identifierIndex", "identifierIndex", "Identifier Index"),
     IDENTIFIER_SORT("identifierSort", "identifierSort", "Identifier Sort"),
     KEYWORD("keyword", "keyword", "Keyword"),
     LANGUAGE("language", "language", "Language"),

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -63,7 +63,7 @@ public class SolrSearchService extends AbstractQueryService {
     protected static final String DEFAULT_RELEVANCY_BOOSTS =
             "titleIndex^50 subjectIndex^10 contributorIndex^30 text^1 keywordIndex^2";
     protected static final String DEFAULT_SEARCHABLE_FIELDS =
-            "text,titleIndex,contributorIndex,subjectIndex,keywordIndex";
+            "text,titleIndex,contributorIndex,subjectIndex,keywordIndex,identifierIndex";
 
     public SolrSearchService() {
     }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SolrSearchService.java
@@ -61,7 +61,7 @@ public class SolrSearchService extends AbstractQueryService {
     protected FacetFieldUtil facetFieldUtil;
 
     protected static final String DEFAULT_RELEVANCY_BOOSTS =
-            "titleIndex^50 subjectIndex^10 contributorIndex^30 text^1 keywordIndex^2";
+            "titleIndex^50 subjectIndex^10 contributorIndex^30 text^1 keywordIndex^2 identifierIndex^2";
     protected static final String DEFAULT_SEARCHABLE_FIELDS =
             "text,titleIndex,contributorIndex,subjectIndex,keywordIndex,identifierIndex";
 

--- a/static/js/admin/src/SearchTags.js
+++ b/static/js/admin/src/SearchTags.js
@@ -3,7 +3,8 @@ define('SearchTags', ['jquery'], function($) {
         { key: 'anywhere', display_value: 'anywhere' },
         { key: 'titleIndex', display_value: 'title' },
         { key: 'contributorIndex', display_value: 'contributor' },
-        { key: 'subjectIndex', display_value: 'subject' }
+        { key: 'subjectIndex', display_value: 'subject' },
+        { key: 'identifierIndex', display_value: 'identifier'}
     ];
 
     class SearchTags {

--- a/static/templates/admin/searchMenu.html
+++ b/static/templates/admin/searchMenu.html
@@ -9,6 +9,7 @@
 						<option value="titleIndex">Title</option>
 						<option value="contributorIndex">Contributor</option>
 						<option value="subjectIndex">Subject</option>
+						<option value="identifierIndex">Identifier</option>
 					</select>
 				</div>
 				<input type="hidden" name="container" class="container_id" value="<%= container? container.id : "" %>"/>

--- a/web-admin-app/src/main/resources/search.properties
+++ b/web-admin-app/src/main/resources/search.properties
@@ -2,7 +2,7 @@ search.results.defaultPerPage=500
 search.results.maxPerPage=5000
 search.results.maxBrowsePerPage=1000
 #Fields which are searchable via keyword searches
-search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX
+search.field.searchable=ID,DEFAULT_INDEX,TITLE_INDEX,CONTRIBUTOR_INDEX,SUBJECT_INDEX,IDENTIFIER_INDEX
 #Set to one higher than you want to display as the last value indicates whether the UI should show a "show more" link
 search.facet.facetsPerGroup=15
 search.facet.expandedFacetsPerGroup=50

--- a/web-admin-app/src/main/webapp/WEB-INF/jsp/search/searchMenu.jsp
+++ b/web-admin-app/src/main/webapp/WEB-INF/jsp/search/searchMenu.jsp
@@ -13,6 +13,7 @@
 							<option value="titleIndex">Title</option>
 							<option value="contributorIndex">Contributor</option>
 							<option value="subjectIndex">Subject</option>
+							<option value="identifierIndex">Identifier</option>
 						</select>
 					</div>
 					<c:if test="${not empty resultResponse.selectedContainer}">


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4929](https://unclibrary.atlassian.net/browse/BXC-4929)

- add `identifierIndex` field to solr schema and copy `aspaceRefId` field into `identifierIndex`
- add `identifierIndex` to `SearchFieldKeys`
- update the admin UI to make this field searchable from the left hand search box, with drop down labeled "Identifier"