### PR TITLE
BXC-4959 update deposit pipeline to receive refIds

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import edu.unc.lib.boxc.operations.impl.altText.AltTextUpdateService;
 import edu.unc.lib.boxc.operations.jms.altText.AltTextUpdateRequest;
 import org.apache.http.HttpStatus;
@@ -792,6 +793,9 @@ public class IngestContentObjectsJob extends AbstractDepositJob {
         }
         if (dResc.hasProperty(Cdr.streamingType)) {
             aResc.addProperty(Cdr.streamingType, dResc.getProperty(Cdr.streamingType).getString());
+        }
+        if (dResc.hasProperty(CdrAspace.refId)) {
+            aResc.addProperty(CdrAspace.refId, dResc.getProperty(CdrAspace.refId).getString());
         }
     }
 

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJob.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJob.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Model;
@@ -107,6 +108,9 @@ public class ValidateContentModelJob extends AbstractDepositJob{
 
         // Validate member order property
         validateMemberOrder(model);
+
+        // Validate ref id property
+        validateAspaceRefId(model);
     }
 
     private void validatePrimaryObjects(Model model) {
@@ -256,6 +260,19 @@ public class ValidateContentModelJob extends AbstractDepositJob{
         if (!url.startsWith(STREAMREAPER_PREFIX_URL) ||
                 (!streamingType.equals(STREAMING_TYPE_SOUND) && !streamingType.equals(STREAMING_TYPE_VIDEO))) {
             failJob(null, "Invalid streaming properties on FileObject {0}", resource.getURI());
+        }
+    }
+
+    private void validateAspaceRefId(Model model) {
+        StmtIterator iterator = model.listStatements((Resource) null, CdrAspace.refId, (RDFNode) null);
+
+        while (iterator.hasNext()) {
+            Statement statement = iterator.next();
+
+            Resource subj = statement.getSubject();
+            if (!subj.hasProperty(RDF.type, Cdr.Work)) {
+                failJob(null, "Ref id property only valid on Work Objects", subj.getURI());
+            }
         }
     }
 

--- a/deposit-app/src/main/resources/cdr-schema.ttl
+++ b/deposit-app/src/main/resources/cdr-schema.ttl
@@ -9,6 +9,7 @@
 @prefix pcdm:  <http://pcdm.org/models#> .
 @prefix cdr:  <http://cdr.unc.edu/definitions/model#> .
 @prefix cdr-acl:  <http://cdr.unc.edu/definitions/acl#> .
+@prefix cdr-aspace: <http://cdr.unc.edu/definitions/aspace#> .
 
 ###### Content Object Classes ###### 
 cdr:FileObject a rdfs:Class ;

--- a/deposit-app/src/main/resources/cdr-schema.ttl
+++ b/deposit-app/src/main/resources/cdr-schema.ttl
@@ -185,3 +185,10 @@ cdr-acl:unitOwner a rdfs:Property ;
     rdfs:domain cdr:AdminUnit ;
     rdfs:range xsd:string ;
     rdfs:comment "User granted ownership of an administrative unit. Has all access and administrative permissions, as well as permission to permanently destroy objects, create collections, and assign staff permissions. Applies to cdr:AdminUnit objects." .
+
+###### Aspace Properties ######
+cdr-aspace:refId a rdfs:Property ;
+    rdfs:label "Aspace Ref Id" ;
+    rdfs:domain cdr:Work ;
+    rdfs:range xsd:string ;
+    rdfs:comment "ArchivesSpace Ref Id. Applies to cdr:Work objects."

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import edu.unc.lib.boxc.model.api.exceptions.NotFoundException;
+import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import edu.unc.lib.boxc.operations.impl.altText.AltTextUpdateService;
 import edu.unc.lib.boxc.operations.jms.altText.AltTextUpdateRequest;
 import org.apache.commons.io.FileUtils;
@@ -877,6 +878,28 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
 
         Resource workAipResc = modelCaptor.getValue().getResource(workPid.getRepositoryPath());
         assertTrue(workAipResc.hasProperty(Cdr.memberOrder), "Work object did not contain member order");
+    }
+
+    @Test
+    public void ingestWorkWithAspaceRefIds() throws Exception {
+        PID workPid = makePid(RepositoryPathConstants.CONTENT_BASE);
+        WorkObject work = mock(WorkObject.class);
+        Bag workBag = setupWork(workPid, work);
+        workBag.addProperty(CdrAspace.refId, "2817ec3c77e5ea9846d5c070d58d402b");
+
+        job.closeModel();
+
+        when(work.addDataFile(any(PID.class), any(URI.class),
+                anyString(), anyString(), isNull(), isNull(), any(Model.class)))
+                .thenReturn(mockFileObj);
+        when(repoObjLoader.getWorkObject(eq(workPid))).thenReturn(work);
+
+        job.run();
+
+        verify(repoObjFactory).createWorkObject(eq(workPid), modelCaptor.capture());
+
+        Resource workAipResc = modelCaptor.getValue().getResource(workPid.getRepositoryPath());
+        assertTrue(workAipResc.hasProperty(CdrAspace.refId));
     }
 
     private PID addFileObject(Bag parent, String stagingLocation, String mimetype) throws Exception {

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
+import edu.unc.lib.boxc.model.api.rdf.CdrAspace;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -558,6 +559,45 @@ public class ValidateContentModelJobTest extends AbstractDepositJobTest {
             doNothing().doThrow(new InvalidAssignmentException()).when(aclValidator).validate(any(Resource.class));
 
             depBag.add(objBag);
+
+            job.closeModel();
+
+            job.run();
+        });
+    }
+
+    @Test
+    public void workValidAspaceRefIdTest() {
+        PID objPid = makePid(CONTENT_BASE);
+        Bag objBag = model.createBag(objPid.getRepositoryPath());
+        objBag.addProperty(RDF.type, Cdr.Work);
+        objBag.addProperty(CdrAspace.refId, "2817ec3c77e5ea9846d5c070d58d402b");
+
+        PID childPid = makePid(CONTENT_BASE);
+        Resource childResource = model.getResource(childPid.getRepositoryPath());
+        childResource.addProperty(RDF.type, Cdr.FileObject);
+        Resource origResource = DepositModelHelpers.addDatastream(childResource);
+        origResource.addLiteral(CdrDeposit.stagingLocation, "path");
+        objBag.add(childResource);
+
+        depBag.add(objBag);
+
+        job.closeModel();
+
+        job.run();
+    }
+
+    @Test
+    public void fileInvalidAspaceRefIdTest() {
+        Assertions.assertThrows(InvalidAssignmentException.class, () -> {
+            doThrow(new InvalidAssignmentException()).when(aclValidator).validate(any(Resource.class));
+
+            PID folderPid = makePid(CONTENT_BASE);
+            Bag folderBag = model.createBag(folderPid.getRepositoryPath());
+            folderBag.addProperty(RDF.type, Cdr.Folder);
+            folderBag.addProperty(CdrAspace.refId, "2817ec3c77e5ea9846d5c070d58d402b");
+
+            depBag.add(folderBag);
 
             job.closeModel();
 

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/validate/ValidateContentModelJobTest.java
@@ -588,10 +588,8 @@ public class ValidateContentModelJobTest extends AbstractDepositJobTest {
     }
 
     @Test
-    public void fileInvalidAspaceRefIdTest() {
-        Assertions.assertThrows(InvalidAssignmentException.class, () -> {
-            doThrow(new InvalidAssignmentException()).when(aclValidator).validate(any(Resource.class));
-
+    public void folderInvalidAspaceRefIdTest() {
+        Assertions.assertThrows(JobFailedException.class, () -> {
             PID folderPid = makePid(CONTENT_BASE);
             Bag folderBag = model.createBag(folderPid.getRepositoryPath());
             folderBag.addProperty(RDF.type, Cdr.Folder);


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4959](https://unclibrary.atlassian.net/browse/BXC-4959)

- update `populateAIPProperties` to add the `CdrAspace.RefId` property if it is present
- update `cdr-schema.ttl` to only allow the `CdrAspace.RefId` property to works