### PR TITLE
WIP: BXC-4952/4953 - Push digital objects to DOMino

### DIFF
--- a/operations/pom.xml
+++ b/operations/pom.xml
@@ -76,6 +76,10 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+        </dependency>
+        <dependency>
             <groupId>edu.unc.lib.cdr</groupId>
             <artifactId>common-utils</artifactId>
             <type>test-jar</type>

--- a/operations/src/main/java/edu/unc/lib/boxc/operations/impl/metadata/PushDominoMetadataService.java
+++ b/operations/src/main/java/edu/unc/lib/boxc/operations/impl/metadata/PushDominoMetadataService.java
@@ -1,0 +1,218 @@
+package edu.unc.lib.boxc.operations.impl.metadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import edu.unc.lib.boxc.common.util.URIUtil;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths;
+import edu.unc.lib.boxc.operations.impl.utils.EmailHandler;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * Service that pushes metadata for new digital objects to the Domino system.
+ * @author bbpennel
+ */
+@Component
+@EnableScheduling
+public class PushDominoMetadataService {
+    private static final Logger LOG = LoggerFactory.getLogger(PushDominoMetadataService.class);
+
+    private ExportDominoMetadataService exportDominoMetadataService;
+    private String dominoUrl;
+    private String dominoUsername;
+    private String dominoPassword;
+    private String runConfigPath;
+    private String adminEmailAddress;
+    private EmailHandler emailHandler;
+    private HttpClientConnectionManager connectionManager;
+    private CloseableHttpClient httpClient;
+    private ObjectWriter configWriter;
+    private ObjectReader configReader;
+
+    public PushDominoMetadataService() {
+        configWriter = new ObjectMapper().writerFor(DominoPushConfig.class);
+        configReader = new ObjectMapper().readerFor(DominoPushConfig.class);
+    }
+
+    /**
+     * Pushes works with ref ids that have been updated since the last run to DOMino for digital object creation.
+     */
+    @Scheduled(cron = "${domino.push.schedule}")
+    public void pushNewDigitalObjects() {
+        // Load previous run config
+        var config = loadConfig();
+
+        var endDate = ZonedDateTime.now(ZoneOffset.UTC).format(DateTimeFormatter.ISO_INSTANT);
+        Path csvPath = null;
+        try {
+            // Export the new objects to a CSV file
+            csvPath = exportNewObjectsCsv(config, endDate);
+
+            // Upload the CSV file to Domino
+            pushToDomino(csvPath);
+
+            // Update the last run timestamp in the config and persist it
+            config.setLastNewObjectsRunTimestamp(endDate);
+            persistConfig(config);
+        } catch (Exception e) {
+            LOG.error("Error pushing new digital objects to Domino", e);
+            // Send notification of failure to admin email address if there was an error
+            sendNotificationToAdmin(e);
+        } finally {
+            // Cleanup the CSV file
+            cleanupCsv(csvPath);
+        }
+    }
+
+    private void cleanupCsv(Path csvPath) {
+        if (csvPath == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(csvPath);
+        } catch (IOException e) {
+            LOG.error("Error deleting file {}", csvPath, e);
+        }
+    }
+
+    private Path exportNewObjectsCsv(DominoPushConfig config, String endDate) {
+        var pidList = List.of(RepositoryPaths.getContentRootPid());
+        var lastRunTimestamp = config.getLastNewObjectsRunTimestamp();
+        try {
+            return exportDominoMetadataService.exportCsv(pidList, null, lastRunTimestamp, endDate);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void pushToDomino(Path csvPath) {
+        var client = getHttpClient();
+        String requestUrl = URIUtil.join(dominoUrl, "manage?source=dcr&delete=none");
+        var postMethod = new HttpPost(requestUrl);
+        try {
+            InputStreamEntity bodyEntity = new InputStreamEntity(Files.newInputStream(csvPath));
+            postMethod.setEntity(bodyEntity);
+            try (var response = client.execute(postMethod)) {
+                if (response.getStatusLine().getStatusCode() >= 300) {
+                    throw new RepositoryException("Unexpected response from Domino: " + response.getStatusLine());
+                }
+            }
+        } catch (IOException e) {
+            throw new RepositoryException("Error reading response from Domino at " + requestUrl, e);
+        } finally {
+            postMethod.releaseConnection();
+        }
+    }
+
+    public CloseableHttpClient getHttpClient() {
+        if (httpClient == null) {
+            CredentialsProvider credsProvider = new BasicCredentialsProvider();
+            credsProvider.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(dominoUsername, dominoPassword)
+            );
+
+            httpClient = HttpClients.custom()
+                    .setDefaultCredentialsProvider(credsProvider)
+                    .setConnectionManager(connectionManager)
+                    .build();
+        }
+        return httpClient;
+    }
+
+    protected DominoPushConfig loadConfig() {
+        Path configPath = Path.of(runConfigPath);
+        try {
+            return configReader.readValue(configPath.toFile(), DominoPushConfig.class);
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to read Domino push config from " + runConfigPath, e);
+        }
+    }
+
+    protected synchronized void persistConfig(DominoPushConfig config) {
+        try {
+            Path configPath = Path.of(runConfigPath);
+            configWriter.writeValue(configPath.toFile(), config);
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to write Domino push config to " + runConfigPath, e);
+        }
+    }
+
+    private void sendNotificationToAdmin(Exception e) {
+        LOG.error("Sending notification to admin at {} about error: {}", adminEmailAddress, e.getMessage());
+        emailHandler.sendEmail(adminEmailAddress,
+                "Error pushing new digital objects to Domino",
+                "An error occurred while pushing digital objects to Domino: \n" + e.getMessage(),
+                null, null);
+    }
+
+    public void setExportDominoMetadataService(ExportDominoMetadataService exportDominoMetadataService) {
+        this.exportDominoMetadataService = exportDominoMetadataService;
+    }
+
+    public void setDominoUrl(String dominoUrl) {
+        this.dominoUrl = dominoUrl;
+    }
+
+    public void setDominoUsername(String dominoUsername) {
+        this.dominoUsername = dominoUsername;
+    }
+
+    public void setDominoPassword(String dominoPassword) {
+        this.dominoPassword = dominoPassword;
+    }
+
+    public void setRunConfigPath(String runConfigPath) {
+        this.runConfigPath = runConfigPath;
+    }
+
+    public void setConnectionManager(HttpClientConnectionManager connectionManager) {
+        this.connectionManager = connectionManager;
+    }
+
+    public void setAdminEmailAddress(String adminEmailAddress) {
+        this.adminEmailAddress = adminEmailAddress;
+    }
+
+    public void setHttpClient(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    public void setEmailHandler(EmailHandler emailHandler) {
+        this.emailHandler = emailHandler;
+    }
+
+    public static class DominoPushConfig {
+        private String lastNewObjectsRunTimestamp;
+
+        public String getLastNewObjectsRunTimestamp() {
+            return lastNewObjectsRunTimestamp;
+        }
+
+        public void setLastNewObjectsRunTimestamp(String lastNewObjectsRunTimestamp) {
+            this.lastNewObjectsRunTimestamp = lastNewObjectsRunTimestamp;
+        }
+    }
+}

--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/metadata/ExportDominoMetadataServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/metadata/ExportDominoMetadataServiceTest.java
@@ -142,9 +142,8 @@ public class ExportDominoMetadataServiceTest {
         mockParentResults(collectionRecord);
         when(solrSearchService.getSearchResults(any())).thenReturn(searchResultResponse);
 
-        var resultPath = csvService.exportCsv(asPidList(COLLECTION_UUID), agent, "*", "*");
-        var csvRecords = parseCsv(ExportDominoMetadataService.CSV_HEADERS, resultPath);
-        assertNumberOfEntries(0, csvRecords);
+        assertThrows(ExportDominoMetadataService.NoRecordsExportedException.class,
+                () -> csvService.exportCsv(asPidList(COLLECTION_UUID), agent, "*", "*"));
     }
 
     @Test

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -479,6 +479,7 @@
         <property name="dominoPassword" value="${domino.server.password}" />
         <property name="runConfigPath" value="${domino.runConfig.path}" />
         <property name="exportDominoMetadataService" ref="exportDominoMetadataService" />
+        <property name="accessGroups" ref="accessGroups" />
     </bean>
     
     <bean id="binaryCleanupProcessor" class="edu.unc.lib.boxc.services.camel.binaryCleanup.BinaryCleanupProcessor">

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -454,6 +454,7 @@
         <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
     </bean>
 
+    <!-- Service operates via spring scheduling -->
     <bean id="expireEmbargoService" class="edu.unc.lib.boxc.operations.impl.acl.ExpireEmbargoService">
         <property name="sparqlQueryService" ref="sparqlQueryService" />
         <property name="transactionManager" ref="transactionManager" />
@@ -461,6 +462,23 @@
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="premisLoggerFactory" ref="premisLoggerFactory" />
+    </bean>
+
+    <bean id="exportDominoMetadataService" class="edu.unc.lib.boxc.operations.impl.metadata.ExportDominoMetadataService">
+        <property name="aclService" ref="aclService" />
+        <property name="solrSearchService" ref="queryLayer" />
+    </bean>
+
+    <!-- Service operates via spring scheduling -->
+    <bean id="pushDominoMetadataService" class="edu.unc.lib.boxc.operations.impl.metadata.PushDominoMetadataService">
+        <property name="adminEmailAddress" ref="adminAddress" />
+        <property name="emailHandler" ref="emailHandler" />
+        <property name="connectionManager" ref="httpClientConnectionManager" />
+        <property name="dominoUrl" value="${domino.server.url}" />
+        <property name="dominoUsername" value="${domino.server.username}" />
+        <property name="dominoPassword" value="${domino.server.password}" />
+        <property name="runConfigPath" value="${domino.runConfig.path}" />
+        <property name="exportDominoMetadataService" ref="exportDominoMetadataService" />
     </bean>
     
     <bean id="binaryCleanupProcessor" class="edu.unc.lib.boxc.services.camel.binaryCleanup.BinaryCleanupProcessor">


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4953
https://unclibrary.atlassian.net/browse/BXC-4952

* Adds a service which runs on a configured schedule, pushing all appropriate works to domino as a CSV export
* BXC-4952 - Limit export to items with ref ids, return ref id field. Remove unused fields in test, more query verification. 
* Throw an exception when no records exported, so we can skip pushing to domino