### PR TITLE
BXC-4968 - Explicitly close randomAccessReadBuffer to prevent memory leaks

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessor.java
@@ -34,11 +34,12 @@ public class PdfImageProcessor implements Processor {
 
         InputStream inputStream = null;
         PDDocument document = null;
+        RandomAccessReadBuffer randomAccessReadBuffer = null;
 
         try {
             inputStream = Files.newInputStream(Paths.get(binPath));
 
-            RandomAccessReadBuffer randomAccessReadBuffer = new RandomAccessReadBuffer(inputStream);
+            randomAccessReadBuffer = new RandomAccessReadBuffer(inputStream);
 
             document = Loader.loadPDF(randomAccessReadBuffer);
             document.setResourceCache(null); // Reduce memory usage
@@ -58,6 +59,9 @@ public class PdfImageProcessor implements Processor {
             }
             if (inputStream != null) {
                 inputStream.close();
+            }
+            if (randomAccessReadBuffer != null) {
+                randomAccessReadBuffer.close();
             }
         }
     }


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4968

* Explicitly close randomAccessReadBuffer to prevent memory leaks. The inputstream that it wraps is being closed, but closing the buffer as well