### PR TITLE
BXC-4962 - PDF error handling and embedded jp2s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,10 @@ jobs:
         docker run -v /tmp/solr-config:/solr_config -d --rm -p 48983:8983 solr:9 solr-precreate access /solr_config/access
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
+        distribution: 'temurin'
 
     - name: Cache Maven packages
       uses: actions/cache@v4

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <iiif-apis.version>0.3.11</iiif-apis.version>
 
         <pdfbox.version>3.0.5</pdfbox.version>
+        <jai-imageio-jpeg2000.version>1.4.0</jai-imageio-jpeg2000.version>
         
         <jdom.version>2.0.6.1</jdom.version>
         <jaxen.version>1.2.0</jaxen.version>
@@ -611,6 +612,12 @@
                 <groupId>org.apache.pdfbox</groupId>
                 <artifactId>pdfbox</artifactId>
                 <version>${pdfbox.version}</version>
+            </dependency>
+            <!-- Required so that PDFbox can handle embedded jp2s -->
+            <dependency>
+                <groupId>com.github.jai-imageio</groupId>
+                <artifactId>jai-imageio-jpeg2000</artifactId>
+                <version>${jai-imageio-jpeg2000.version}</version>
             </dependency>
 
             <dependency>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -216,6 +216,10 @@
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
     </dependency>
+    <dependency>
+        <groupId>com.github.jai-imageio</groupId>
+        <artifactId>jai-imageio-jpeg2000</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessor.java
@@ -12,9 +12,12 @@ import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.rendering.PDFRenderer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -25,12 +28,14 @@ import java.nio.file.Paths;
  * @author bbpennel
  */
 public class PdfImageProcessor implements Processor {
+    private static final Logger log = LoggerFactory.getLogger(PdfImageProcessor.class);
     private String outputPath;
 
     @Override
     public void process(Exchange exchange) throws Exception {
         Message in = exchange.getIn();
         String binPath = (String) in.getHeader(CdrFcrepoHeaders.CdrBinaryPath);
+        log.debug("Processing PDF binary at path: {}", binPath);
 
         InputStream inputStream = null;
         PDDocument document = null;
@@ -53,6 +58,9 @@ public class PdfImageProcessor implements Processor {
             in.setHeader(CdrImagePath, outputImagePath.toString());
             in.setHeader(CdrBinaryMimeType, "image/tiff");
             in.setHeader(CdrImagePathCleanup, true);
+        } catch (IOException e) {
+            log.warn("Failed to process PDF binary at path {}: {}", binPath, e.getMessage());
+            log.debug("Stack trace:", e);
         } finally {
             if (document != null) {
                 document.close();

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessorTest.java
@@ -76,9 +76,10 @@ public class PdfImageProcessorTest {
         message.setHeader(CdrBinaryPath, "nonexistent.pdf");
         message.setHeader(CdrBinaryMimeType, "application/pdf");
 
-        // No exception should be thrown
+        // An IOException is thrown internally, but we are demonstrating that it does not bubble up
         processor.process(exchange);
 
+        // Since it failed to generate an image from the PDF no image path should be set, so camel will skip further processing
         assertNull(message.getHeader(CdrImagePath), "CdrImagePath should not be set when exception occurs");
         assertNull(message.getHeader(CdrImagePathCleanup));
         assertEquals("application/pdf", message.getHeader(CdrBinaryMimeType));

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/PdfImageProcessorTest.java
@@ -6,6 +6,8 @@ import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrImagePath
 import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrImagePathCleanup;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.camel.Exchange;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,6 +68,20 @@ public class PdfImageProcessorTest {
         var outputFile = Paths.get(outputPath);
         assertTrue(Files.exists(outputFile), "Generated TIFF file should exist");
         assertTrue(Files.size(outputFile) > 0, "Generated TIFF file should not be empty");
+    }
+
+    @Test
+    public void testLoadThrowsIOException() throws Exception {
+        // Set a non-existent PDF path
+        message.setHeader(CdrBinaryPath, "nonexistent.pdf");
+        message.setHeader(CdrBinaryMimeType, "application/pdf");
+
+        // No exception should be thrown
+        processor.process(exchange);
+
+        assertNull(message.getHeader(CdrImagePath), "CdrImagePath should not be set when exception occurs");
+        assertNull(message.getHeader(CdrImagePathCleanup));
+        assertEquals("application/pdf", message.getHeader(CdrBinaryMimeType));
     }
 
     @Test


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4962

* App jp2 library so that pdfs containing them will render. 
* Handle ioexceptions during PDF rendering to reduce verbosity and prevent retries. This is to deal with the other exceptions that occurred during PDF image generation
* Update setup-java gh action and specify a distribution, since GH actions was randomly failing to get a JDK