### PR TITLE
BXC-4975 - Don't submit blank ref ids to domino

### DIFF
--- a/operations/src/test/java/edu/unc/lib/boxc/operations/impl/metadata/ExportDominoMetadataServiceTest.java
+++ b/operations/src/test/java/edu/unc/lib/boxc/operations/impl/metadata/ExportDominoMetadataServiceTest.java
@@ -108,7 +108,7 @@ public class ExportDominoMetadataServiceTest {
         var searchState = searchRequest.getValue().getSearchState();
         assertTrue(searchState.getRangeFields().containsKey(SearchFieldKey.DATE_UPDATED.name()));
         var refIdFilter = searchState.getFilters().get(0);
-        assertEquals(SearchFieldKey.ASPACE_REF_ID.getSolrField() + ":*", refIdFilter.toFilterString());
+        assertEquals(SearchFieldKey.ASPACE_REF_ID.getSolrField() + ":[\"\" TO *]", refIdFilter.toFilterString());
         assertIterableEquals(List.of(ResourceType.Work.name()), searchState.getResourceTypes());
     }
     
@@ -178,7 +178,7 @@ public class ExportDominoMetadataServiceTest {
         var searchState = searchRequest.getValue().getSearchState();
         assertTrue(searchState.getRangeFields().containsKey(SearchFieldKey.DATE_UPDATED.name()));
         var refIdFilter = searchState.getFilters().get(0);
-        assertEquals(SearchFieldKey.ASPACE_REF_ID.getSolrField() + ":*", refIdFilter.toFilterString());
+        assertEquals(SearchFieldKey.ASPACE_REF_ID.getSolrField() + ":[\"\" TO *]", refIdFilter.toFilterString());
         assertEquals("2020-00-00T00:00:00Z,*", searchState.getRangeFields()
                 .get(SearchFieldKey.DATE_UPDATED.name()).getParameterValue());
     }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/HasPopulatedFieldFilter.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/filters/HasPopulatedFieldFilter.java
@@ -17,7 +17,7 @@ public class HasPopulatedFieldFilter implements QueryFilter {
 
     @Override
     public String toFilterString() {
-        return getFieldKey().getSolrField() + ":*";
+        return getFieldKey().getSolrField() + ":[\"\" TO *]";
     }
 
     @Override

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactoryTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/filters/QueryFilterFactoryTest.java
@@ -56,6 +56,7 @@ public class QueryFilterFactoryTest {
     public void hasPopulatedFieldFilterTest() {
         var filter = QueryFilterFactory.createFilter(SearchFieldKey.STREAMING_TYPE);
         assertInstanceOf(HasPopulatedFieldFilter.class, filter);
+        assertEquals("streamingType:[\"\" TO *]", filter.toFilterString());
     }
 
     @Test


### PR DESCRIPTION
Part of https://unclibrary.atlassian.net/browse/BXC-4975

* HasPopulatedFieldFilter will now only match non-blank values. Not doing this was causing blank ref ids to get submitted to domino