### PR TITLE
BXC-4999 - Update to activemq 6

### DIFF
--- a/deposit-app/src/main/webapp/WEB-INF/web.xml
+++ b/deposit-app/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    metadata-complete="true"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
     
     <display-name>Deposit</display-name>
     

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -5,6 +5,7 @@ import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.integration.factories.FileFactory;
 import edu.unc.lib.boxc.integration.factories.WorkFactory;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -72,7 +74,7 @@ public class SearchEndpointIT extends EndpointIT {
                 "readGroup", "everyone");
         workFactory.createFileInWork(work, fileOptions);
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?titleIndex=text");
+        var getMethod = new HttpGet(SEARCH_URL + "?titleIndex=text");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -99,7 +101,7 @@ public class SearchEndpointIT extends EndpointIT {
                 "readGroup", "everyone");
         workFactory.createFileInWork(textWork, fileOptions);
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?anywhere=through");
+        var getMethod = new HttpGet(SEARCH_URL + "?anywhere=through");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -120,7 +122,7 @@ public class SearchEndpointIT extends EndpointIT {
     public void testSearchTypeParamWithOneType() throws Exception {
         createDefaultObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?types=Work");
+        var getMethod = new HttpGet(SEARCH_URL + "?types=Work");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -138,7 +140,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
 
         // rollup=false disables the FileObjects getting grouped into their associated Works
-        var getMethod = new HttpGet(SEARCH_URL + "/?types=Work,File&rollup=false");
+        var getMethod = new HttpGet(SEARCH_URL + "?types=Work,File&rollup=false");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -159,7 +161,7 @@ public class SearchEndpointIT extends EndpointIT {
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "A first collection", "readGroup", "everyone"));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,normal");
+        var getMethod = new HttpGet(SEARCH_URL + "?sort=title,normal");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -183,7 +185,7 @@ public class SearchEndpointIT extends EndpointIT {
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "A first collection", "readGroup", "everyone"));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?sort=title,reverse");
+        var getMethod = new HttpGet(SEARCH_URL + "?sort=title,reverse");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -209,7 +211,7 @@ public class SearchEndpointIT extends EndpointIT {
         folderFactory.createFolder(collection,
                 Map.of("title", "Folder Object 2", "readGroup", "everyone"));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?start=0&rows=5");
+        var getMethod = new HttpGet(SEARCH_URL + "?start=0&rows=5");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -226,7 +228,7 @@ public class SearchEndpointIT extends EndpointIT {
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "A first collection", "readGroup", "everyone"));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?start=3");
+        var getMethod = new HttpGet(SEARCH_URL + "?start=3");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -295,10 +297,10 @@ public class SearchEndpointIT extends EndpointIT {
     public void testDateDepositedInclusiveSearch() throws Exception {
         createDefaultObjects();
         var currentYear = Year.now().getValue();
-        assertResultCountEquals(SEARCH_URL + "/?added=" + currentYear + ",", 5);
-        assertResultCountEquals(SEARCH_URL + "/?added=" + currentYear + "," + currentYear, 5);
-        assertResultCountEquals(SEARCH_URL + "/?added=," + currentYear, 5);
-        assertResultCountEquals(SEARCH_URL + "/?added=" + (currentYear + 1) + ",", 0);
+        assertResultCountEquals(SEARCH_URL + "?added=" + currentYear + ",", 5);
+        assertResultCountEquals(SEARCH_URL + "?added=" + currentYear + "," + currentYear, 5);
+        assertResultCountEquals(SEARCH_URL + "?added=," + currentYear, 5);
+        assertResultCountEquals(SEARCH_URL + "?added=" + (currentYear + 1) + ",", 0);
     }
 
     @Test
@@ -307,7 +309,7 @@ public class SearchEndpointIT extends EndpointIT {
         var ids = createDatedObjects();
         var datedCollectionId = ids.get(1);
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=2022,2022");
+        var getMethod = new HttpGet(SEARCH_URL + "?createdYear=2022,2022");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -327,7 +329,7 @@ public class SearchEndpointIT extends EndpointIT {
         var datedAdminUnitId = ids.get(0);
         var datedCollectionId = ids.get(1);
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?createdYear=unknown");
+        var getMethod = new HttpGet(SEARCH_URL + "?createdYear=unknown");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -349,7 +351,7 @@ public class SearchEndpointIT extends EndpointIT {
         var firstFile = workFactory.createFileInWork(mWork, Map.of("title", "File A", FILE_FORMAT_OPTION, IMAGE_FORMAT));
         workFactory.createFileInWork(mWork, Map.of("title", "File D", FILE_FORMAT_OPTION, IMAGE_FORMAT));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?id=" + mWork.getPid().getId());
+        var getMethod = new HttpGet(SEARCH_URL + "?id=" + mWork.getPid().getId());
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);
@@ -368,7 +370,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language&language=English&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language&language=English&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -384,7 +386,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language&language=English&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language&language=English&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -403,7 +405,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language%2Csubject&subject=North%2520Carolina&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language%2Csubject&subject=North%2520Carolina&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -426,7 +428,7 @@ public class SearchEndpointIT extends EndpointIT {
         createDefaultObjects();
         createLanguageSubjectObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?getFacets=false");
+        var getMethod = new HttpGet(SEARCH_URL + "?getFacets=false");
 
         try (var resp = httpClient.execute(getMethod)) {
             var respJson = getResponseAsJson(resp);
@@ -439,7 +441,7 @@ public class SearchEndpointIT extends EndpointIT {
     @Test
     public void testGetFacetsTrueSearchReturnsDefaultFacets() throws Exception {
         createDefaultObjects();
-        var getMethod = new HttpGet(SEARCH_URL + "/?getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -458,7 +460,7 @@ public class SearchEndpointIT extends EndpointIT {
     @Test
     public void testSearchWithFacetSelectOnlyShowsThoseFacets() throws Exception {
         createDefaultObjects();
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language%2Csubject&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language%2Csubject&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -473,7 +475,7 @@ public class SearchEndpointIT extends EndpointIT {
     @Test
     public void testSearchWithFacetSelectCannotShowDisallowedFacets() throws Exception {
         createDefaultObjects();
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language,subject,contentStatus&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language,subject,contentStatus&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -495,7 +497,7 @@ public class SearchEndpointIT extends EndpointIT {
         collectionFactory.createCollection(adminUnit1,
                 Map.of("title", "Collection Object", "adminGroup", "adminGroup", "languageTerm", "por"));
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?facetSelect=language&getFacets=true");
+        var getMethod = new HttpGet(SEARCH_URL + "?facetSelect=language&getFacets=true");
 
         try (var resp = httpClient.execute(getMethod)) {
             var facetFields = getFacetsFromResponse(resp);
@@ -514,7 +516,7 @@ public class SearchEndpointIT extends EndpointIT {
     public void testSearchAllExpectedFieldsForRecordReturned() throws Exception {
         createWorkAndFileObjects();
 
-        var getMethod = new HttpGet(SEARCH_URL + "/?types=Work,File&rollup=false");
+        var getMethod = new HttpGet(SEARCH_URL + "?types=Work,File&rollup=false");
 
         try (var resp = httpClient.execute(getMethod)) {
             var metadata = getMetadataFromResponse(resp);

--- a/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
+++ b/integration/src/test/java/edu/unc/lib/boxc/integration/web/access/SearchEndpointIT.java
@@ -5,7 +5,6 @@ import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
 import edu.unc.lib.boxc.integration.factories.FileFactory;
 import edu.unc.lib.boxc.integration.factories.WorkFactory;
 import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,7 @@
         <commons-fileupload.version>1.5</commons-fileupload.version>
         <commons-collections.version>4.4</commons-collections.version>
 
-        <activemq.version>5.17.7</activemq.version>
-        <activemq-protobuf.version>1.1</activemq-protobuf.version>
+        <activemq.version>6.1.7</activemq.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <logback.version>1.2.13</logback.version>
@@ -121,7 +120,7 @@
         <jena.version>4.10.0</jena.version>
 
         <fcrepo-camel.version>6.0.0</fcrepo-camel.version>
-        <camel.version>3.22.3</camel.version>
+        <camel.version>4.13.0</camel.version>
         <tika.version>3.1.0</tika.version>
         <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
         
@@ -820,24 +819,6 @@
                 <artifactId>jedis</artifactId>
                 <version>${jedis.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-kahadb-store</artifactId>
-                <version>${activemq.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq.protobuf</groupId>
-                <artifactId>activemq-protobuf</artifactId>
-                <version>${activemq-protobuf.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq.tooling</groupId>
-                <artifactId>activemq-junit</artifactId>
-                <version>${activemq.version}</version>
-                <scope>test</scope>
-            </dependency> 
             
             <dependency>
                 <groupId>org.apache.solr</groupId>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -53,6 +53,11 @@
         <version>${camel.version}</version>
     </dependency>
     <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-direct</artifactId>
+        <version>${camel.version}</version>
+    </dependency>
+    <dependency>
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-broker</artifactId>
     </dependency>
@@ -202,12 +207,6 @@
     <!-- Testing -->
     <dependency>
         <groupId>org.apache.camel</groupId>
-        <artifactId>camel-test-spring</artifactId>
-        <version>${camel.version}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-spring-junit5</artifactId>
         <version>${camel.version}</version>
         <scope>test</scope>
@@ -276,16 +275,6 @@
     <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-core</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>activemq-kahadb-store</artifactId>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.activemq.protobuf</groupId>
-        <artifactId>activemq-protobuf</artifactId>
-        <scope>test</scope>
     </dependency>
     </dependencies>
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryEnhancementProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryEnhancementProcessor.java
@@ -33,10 +33,14 @@ public class BinaryEnhancementProcessor implements Processor {
     @Override
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
-        String fcrepoBinaryUri = (String) in.getHeader(FCREPO_URI);
+        String fcrepoBinaryUri = MessageUtil.getFcrepoUri(in);
 
         if (fcrepoBinaryUri == null) {
             Document msgBody = MessageUtil.getDocumentBody(in);
+            if (msgBody == null) {
+                log.debug("No body found in message, cannot set enhancement headers");
+                return;
+            }
             Element body = msgBody.getRootElement();
 
             Element enhancementsEl = body.getChild(RUN_ENHANCEMENTS.getName(), CDR_MESSAGE_NS);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/BinaryMetadataProcessor.java
@@ -3,7 +3,6 @@ package edu.unc.lib.boxc.services.camel;
 import static edu.unc.lib.boxc.model.api.rdf.Ebucore.hasMimeType;
 import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrBinaryMimeType;
 import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrBinaryPath;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -46,7 +46,7 @@ public class BinaryMetadataProcessor implements Processor {
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
 
-        String fcrepoBinaryUri = (String) in.getHeader(FCREPO_URI);
+        String fcrepoBinaryUri = MessageUtil.getFcrepoUri(in);
         PID binPid = PIDs.get(fcrepoBinaryUri);
         PID filePid = PIDs.get(binPid.getId());
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/fulltext/FulltextProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/fulltext/FulltextProcessor.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.services.camel.fulltext;
 
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -23,7 +24,6 @@ import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.HASHED_PATH
 import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
 import static edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders.CdrBinaryPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 /**
  * Extracts fulltext from documents and adds it as a derivative file on existing file object
@@ -73,7 +73,7 @@ public class FulltextProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
 
-        String fedoraUri = (String) in.getHeader(FCREPO_URI);
+        String fedoraUri = MessageUtil.getFcrepoUri(in);
         String binaryPath = (String) in.getHeader(CdrBinaryPath);
         String binaryId = PIDs.get(fedoraUri).getId();
         String binarySubPath = idToPath(binaryId, HASHED_PATH_DEPTH, HASHED_PATH_SIZE);

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/AddDerivativeProcessor.java
@@ -2,6 +2,7 @@ package edu.unc.lib.boxc.services.camel.images;
 
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.services.camel.util.CdrFcrepoHeaders;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -23,7 +24,6 @@ import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.HASHED_PATH
 import static edu.unc.lib.boxc.model.fcrepo.ids.RepositoryPaths.idToPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 /**
  * Adds a derivative file to an existing file object
@@ -51,7 +51,7 @@ public class AddDerivativeProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         Message in = exchange.getIn();
 
-        String binaryUri = (String) in.getHeader(FCREPO_URI);
+        String binaryUri = MessageUtil.getFcrepoUri(in);
         String binaryId = PIDs.get(binaryUri).getId();
         Path derivativeFinalPath = setDerivativeFinalPath(binaryId);
 
@@ -121,7 +121,7 @@ public class AddDerivativeProcessor implements Processor {
     public boolean needsRun(Exchange exchange) {
         Message in = exchange.getIn();
 
-        String binaryUri = (String) in.getHeader(FCREPO_URI);
+        String binaryUri = MessageUtil.getFcrepoUri(in);
         String binaryId = PIDs.get(binaryUri).getId();
         Path derivativeFinalPath = setDerivativeFinalPath(binaryId);
         if (Files.notExists(derivativeFinalPath)) {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageCacheInvalidationProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/images/ImageCacheInvalidationProcessor.java
@@ -5,6 +5,7 @@ import edu.unc.lib.boxc.common.util.URIUtil;
 import edu.unc.lib.boxc.model.api.ids.PID;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
 import edu.unc.lib.boxc.operations.api.images.ImageServerUtil;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -24,8 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
-
 /**
  * Processor which invalidates the image cache for a given object in the image server
  *
@@ -44,7 +43,7 @@ public class ImageCacheInvalidationProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
 
-        String fcrepoUri = (String) in.getHeader(FCREPO_URI);
+        String fcrepoUri = MessageUtil.getFcrepoUri(in);
         PID pid = PIDs.get(fcrepoUri);
         var client = getHttpClient();
         var imageId = ImageServerUtil.getImageServiceId(pid.getId());

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafAggregationStrategy.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafAggregationStrategy.java
@@ -1,12 +1,12 @@
 package edu.unc.lib.boxc.services.camel.longleaf;
 
 import static java.util.Collections.singletonList;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.AggregationStrategy;
 import org.apache.camel.Exchange;
 import org.slf4j.Logger;
@@ -23,7 +23,7 @@ public class LongleafAggregationStrategy implements AggregationStrategy {
     @SuppressWarnings("unchecked")
     @Override
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
-        String binaryUri = (String) newExchange.getIn().getHeader(FCREPO_URI);
+        String binaryUri = MessageUtil.getFcrepoUri(newExchange.getIn());
         List<String> incomingList ;
         if (binaryUri == null) {
             Object body = newExchange.getIn().getBody();

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/LongleafRouter.java
@@ -55,7 +55,7 @@ public class LongleafRouter extends RouteBuilder {
                 .redeliveryDelay(longleafRedeliveryDelay)
                 .onPrepareFailure(failedRouteProcessor));
 
-        from("direct-vm:filter.longleaf")
+        from("direct:filter.longleaf")
             .routeId("RegisterLongleafQueuing")
             .startupOrder(18)
             .filter().method(RegisterToLongleafProcessor.class, "registerableBinary")

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -2,7 +2,6 @@ package edu.unc.lib.boxc.services.camel.longleaf;
 
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.substringAfterLast;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.io.IOException;
 import java.net.URI;
@@ -14,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.ProducerTemplate;
@@ -264,11 +264,11 @@ public class RegisterToLongleafProcessor extends AbstractLongleafProcessor {
     }
 
     /**
-     * @param fcrepuUri uri of object
+     * @param exchange
      * @return true if the object is a binary that should be registered in longleaf.
      */
     public static boolean registerableBinary(Exchange exchange) {
-        String fcrepoUri = (String) exchange.getIn().getHeader(FCREPO_URI);
+        String fcrepoUri = MessageUtil.getFcrepoUri(exchange.getIn());
         String dsId = StringUtils.substringAfterLast(fcrepoUri, "/");
 
         if (dsId.equals("fcr:metadata")) {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraIdFilters.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraIdFilters.java
@@ -6,6 +6,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.regex.Pattern;
 
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.slf4j.Logger;
@@ -54,7 +55,7 @@ public class FedoraIdFilters {
     public static boolean allowedForLongleaf(Exchange exchange) {
         Message in = exchange.getIn();
         String resourceType = (String) in.getHeader(FcrepoJmsConstants.RESOURCE_TYPE);
-        String fcrepoUri = (String) exchange.getIn().getHeader(FCREPO_URI);
+        String fcrepoUri = MessageUtil.getFcrepoUri(in);
         if (!resourceType.contains(Binary.getURI()) || fcrepoUri.endsWith(RepositoryPathConstants.FCR_METADATA)) {
             return false;
         }
@@ -78,17 +79,16 @@ public class FedoraIdFilters {
             return false;
         }
 
-        String fcrepoId = (String) in.getHeader(FcrepoJmsConstants.IDENTIFIER);
-        String fcrepoBaseUrl = (String) in.getHeader(FcrepoJmsConstants.BASE_URL);
+        String fcrepoUri = MessageUtil.getFcrepoUri(in);
         PID pid;
         try {
-            pid = PIDs.get(fcrepoBaseUrl + fcrepoId);
+            pid = PIDs.get(fcrepoUri);
         } catch (Exception e) {
-            log.debug("Failed to parse fcrepo id {} as PID while filtering: {}", fcrepoId, e.getMessage());
+            log.debug("Failed to parse fcrepo id {} as PID while filtering: {}", fcrepoUri, e.getMessage());
             return false;
         }
         if (pid == null) {
-            log.error("Received null PID for object with fcrepo URI {}", fcrepoBaseUrl + fcrepoId);
+            log.error("Received null PID for object with fcrepo URI {}", fcrepoUri);
             return false;
         }
         // Filter out non-content objects

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
@@ -46,7 +46,7 @@ public class MetaServicesRouter extends RouteBuilder {
             .startupOrder(9)
             .filter().method(FedoraIdFilters.class, "allowedForTripleIndex")
             .doTry()
-                .to("direct-vm:index.start")
+                .to("direct:index.start")
             .endDoTry()
             .doCatch(FcrepoOperationFailedException.class)
                 .process(new Processor() {
@@ -66,7 +66,7 @@ public class MetaServicesRouter extends RouteBuilder {
             .end()
             .bean(cacheInvalidatingProcessor)
             .filter().method(FedoraIdFilters.class, "allowedForLongleaf")
-                .wireTap("direct-vm:filter.longleaf")
+                .wireTap("direct:filter.longleaf")
             .end().end() // ending the filter and the wiretap
             .filter().method(FedoraIdFilters.class, "allowedForEnhancements")
             .wireTap("direct:process.enhancement");

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
@@ -46,7 +46,7 @@ public class MetaServicesRouter extends RouteBuilder {
             .startupOrder(9)
             .filter().method(FedoraIdFilters.class, "allowedForTripleIndex")
             .doTry()
-                .to("direct:index.start")
+                .wireTap("direct:index.start")
             .endDoTry()
             .doCatch(FcrepoOperationFailedException.class)
                 .process(new Processor() {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/solr/SolrIngestProcessor.java
@@ -2,12 +2,12 @@ package edu.unc.lib.boxc.services.camel.solr;
 
 import static edu.unc.lib.boxc.common.metrics.TimerFactory.createTimerForClass;
 import static edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants.RESOURCE_TYPE;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import edu.unc.lib.boxc.operations.jms.MessageSender;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -58,7 +58,7 @@ public class SolrIngestProcessor implements Processor {
     public void process(Exchange exchange) throws Exception {
         try (Timer.Context context = timer.time()) {
             final Message in = exchange.getIn();
-            String fcrepoUri = (String) in.getHeader(FCREPO_URI);
+            String fcrepoUri = MessageUtil.getFcrepoUri(in);
 
             log.debug("Processing solr request for {}", fcrepoUri);
 

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/triplesReindexing/TriplesReindexingRouter.java
@@ -46,7 +46,7 @@ public class TriplesReindexingRouter extends RouteBuilder {
             .routeId("TripleIndexingRoute")
             .bean(indexingMessageProcessor)
             .log(INFO, log, "Received triple reindexing update message: ${headers[CamelFcrepoUri]}")
-            .inOnly(reindexingStream + "?disableTimeToLive=true");
+            .to(ExchangePattern.InOnly, reindexingStream + "?disableTimeToLive=true");
 
         // Route which recursively steps through fedora objects and submits them for indexing
         from(reindexingStream + "?asyncConsumer=true")
@@ -75,7 +75,7 @@ public class TriplesReindexingRouter extends RouteBuilder {
                     }
                 })
             .filter(header(FCREPO_URI).isNotNull())
-            .inOnly(reindexingStream + "?disableTimeToLive=true");
+            .to(ExchangePattern.InOnly, reindexingStream + "?disableTimeToLive=true");
     }
 
     @PropertyInject("error.retryDelay:500")

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/CacheInvalidatingProcessor.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.services.camel.util;
 
 import edu.unc.lib.boxc.auth.fcrepo.services.ObjectAclFactory;
-import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
 import edu.unc.lib.boxc.indexing.solr.utils.MemberOrderService;
 import edu.unc.lib.boxc.model.api.DatastreamType;
 import edu.unc.lib.boxc.model.api.ids.PID;
@@ -14,7 +13,6 @@ import edu.unc.lib.boxc.search.solr.services.TitleRetrievalService;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
-import org.fcrepo.camel.FcrepoHeaders;
 import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
@@ -42,12 +40,7 @@ public class CacheInvalidatingProcessor implements Processor {
             return;
         }
 
-        String fcrepoUri = (String) in.getHeader(FcrepoHeaders.FCREPO_URI);
-        if (fcrepoUri == null) {
-            String fcrepoId = (String) in.getHeader(FcrepoJmsConstants.IDENTIFIER);
-            String fcrepoBaseUrl = (String) in.getHeader(FcrepoJmsConstants.BASE_URL);
-            fcrepoUri = fcrepoBaseUrl + fcrepoId;
-        }
+        String fcrepoUri = MessageUtil.getFcrepoUri(in);
 
         PID pid;
         try {

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/MessageUtil.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/MessageUtil.java
@@ -2,13 +2,17 @@ package edu.unc.lib.boxc.services.camel.util;
 
 import static edu.unc.lib.boxc.common.xml.SecureXMLFactory.createSAXBuilder;
 
-import java.io.IOException;
-import java.io.InputStream;
-
+import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
 import org.apache.camel.Message;
+import org.fcrepo.camel.FcrepoHeaders;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
 import org.jdom2.Document;
 import org.jdom2.JDOMException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Utilities for working with event messages
@@ -17,6 +21,8 @@ import org.jdom2.JDOMException;
  *
  */
 public class MessageUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(MessageUtil.class);
 
     private MessageUtil() {
     }
@@ -32,17 +38,37 @@ public class MessageUtil {
     public static Document getDocumentBody(Message msg) throws JDOMException, IOException {
         Object body = msg.getBody();
 
-        if (body != null) {
-            if (body instanceof Document) {
-                return (Document) body;
-            } else if (body instanceof InputStream) {
-                return createSAXBuilder().build((InputStream) body);
-            } else if (body instanceof String) {
-                return createSAXBuilder().build(
-                        new ByteArrayInputStream(((String) body).getBytes()));
-            }
+        try {
+            return switch (body) {
+                case Document docBody -> docBody;
+                case InputStream streamBody -> createSAXBuilder().build(streamBody);
+                case String stringBody -> createSAXBuilder().build(new ByteArrayInputStream((stringBody).getBytes()));
+                default -> null;
+            };
+        } catch (JDOMException e) {
+            // Received messages may be json since that is the default format in activemq 6+, so we ignore those here
+            log.debug("Message body of type {} is not a valid XML document: {}", body.getClass(), e.getMessage());
+            return null;
         }
+    }
 
-        return null;
+    /**
+     * Returns the fcrepo URI for the given message, either from the FcrepoHeaders.FCREPO_URI header or by
+     * constructing it from the FcrepoJmsConstants.BASE_URL and FcrepoJmsConstants.IDENTIFIER headers.
+     *
+     * @param msg
+     * @return
+     */
+    public static String getFcrepoUri(Message msg) {
+        String fcrepoUri = (String) msg.getHeader(FcrepoHeaders.FCREPO_URI);
+        if (fcrepoUri == null) {
+            String fcrepoId = (String) msg.getHeader(FcrepoJmsConstants.IDENTIFIER);
+            String fcrepoBaseUrl = (String) msg.getHeader(FcrepoJmsConstants.BASE_URL);
+            if (fcrepoBaseUrl == null || fcrepoId == null) {
+                return null;
+            }
+            return fcrepoBaseUrl + fcrepoId;
+        }
+        return fcrepoUri;
     }
 }

--- a/services-camel-app/src/main/webapp/WEB-INF/activemq-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/activemq-context.xml
@@ -40,6 +40,9 @@
         <property name="configuration" ref="jmsConfig" />
         <property name="transacted" value="true" />
         <property name="lazyCreateTransactionManager" value="false" />
+        <property name="headerFilterStrategy">
+            <bean class="org.apache.camel.component.jms.ClassicJmsHeaderFilterStrategy"/>
+        </property>
     </bean>
     
     <bean class="org.springframework.jms.core.JmsTemplate">

--- a/services-camel-app/src/main/webapp/WEB-INF/web.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    metadata-complete="true"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
     
     <display-name>Services Camel</display-name>
     

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/audio/AudioEnhancementsRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/audio/AudioEnhancementsRouterTest.java
@@ -50,7 +50,7 @@ public class AudioEnhancementsRouterTest extends CamelSpringTestSupport {
     private final String audioAccessCopy = "AudioAccessCopy";
 
     @PropertyInject(value = "fcrepo.baseUrl")
-    private static String baseUri;
+    private String baseUri;
 
     @EndpointInject("mock:fcrepo")
     protected MockEndpoint resultEndpoint;
@@ -193,7 +193,7 @@ public class AudioEnhancementsRouterTest extends CamelSpringTestSupport {
         context.start();
     }
 
-    private static Map<String, Object> createEvent(final String identifier, final String eventTypes,
+    private Map<String, Object> createEvent(final String identifier, final String eventTypes,
                                                    final String force) {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(FCREPO_URI, identifier);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/destroyDerivatives/DestroyDerivativesRouterTest.java
@@ -51,9 +51,13 @@ public class DestroyDerivativesRouterTest extends CamelTestSupport {
     @TempDir
     public Path tmpFolder;
 
+    private Path jp2BasePath;
+
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
         destroyedMsgProcessor = new DestroyedMsgProcessor();
+        jp2BasePath = tmpFolder.resolve("jp2base");
+        destroyedMsgProcessor.setJp2BasePath(jp2BasePath.toString());
         var router = new DestroyDerivativesRouter();
         router.setDestroyedMsgProcessor(destroyedMsgProcessor);
         router.setDestroyAccessCopyProcessor(destroyAccessCopyProcessor);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/images/ImageEnhancementsRouterTest.java
@@ -61,7 +61,7 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
     private static final String derivTmpPath = "tmp/" + fileName;
 
     @PropertyInject(value = "fcrepo.baseUrl")
-    private static String baseUri;
+    private String baseUri;
 
     @EndpointInject("mock:fcrepo")
     protected MockEndpoint resultEndpoint;
@@ -262,7 +262,7 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
         context.start();
     }
 
-    private static Map<String, Object> createEvent(final String identifier, final String eventTypes,
+    private Map<String, Object> createEvent(final String identifier, final String eventTypes,
                                                    final String force) {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(FCREPO_URI, identifier);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/longleaf/RegisterLongleafRouteTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/longleaf/RegisterLongleafRouteTest.java
@@ -51,7 +51,7 @@ public class RegisterLongleafRouteTest extends AbstractLongleafRouteTest {
     private static final String TEXT1_BODY = "Some content";
     private static final String TEXT1_SHA1 = DigestUtils.sha1Hex(TEXT1_BODY);
 
-    @Produce("direct-vm:filter.longleaf")
+    @Produce("direct:filter.longleaf")
     private ProducerTemplate template;
 
     @EndpointInject("mock:direct:longleaf.dlq")

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouterTest.java
@@ -48,7 +48,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     private static final String PROCESS_ENHANCEMENT_ROUTE = "ProcessEnhancement";
 
     @PropertyInject(value = "fcrepo.baseUri")
-    private static String baseUri;
+    private String baseUri;
 
     @EndpointInject("mock:fcrepo")
     private MockEndpoint resultEndpoint;
@@ -345,7 +345,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
         context.start();
     }
 
-    private static Map<String, Object> createEvent(final String identifier, final String... type) {
+    private Map<String, Object> createEvent(final String identifier, final String... type) {
 
         final Map<String, Object> headers = new HashMap<>();
         headers.put(FCREPO_URI, baseUri + identifier);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouterTest.java
@@ -68,9 +68,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartContainer() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(1);
@@ -88,9 +88,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartTimemap() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(0);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -111,9 +111,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartDatafs() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -134,9 +134,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartDepositRecord() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -157,9 +157,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartNotAPid() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -180,9 +180,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartCollections() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(1);
@@ -202,9 +202,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartBinaryMetadata() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -229,9 +229,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartOriginalBinary() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(1);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(1);
@@ -250,9 +250,9 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testRouteStartPremisBinary() throws Exception {
-        var indexStartEndpoint = getMockEndpoint("mock:direct-vm:index.start");
+        var indexStartEndpoint = getMockEndpoint("mock:direct:index.start");
         indexStartEndpoint.expectedMessageCount(1);
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(1);
         var processEnhEndpoint = getMockEndpoint("mock:direct:process.enhancement");
         processEnhEndpoint.expectedMessageCount(0);
@@ -273,7 +273,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testEventTypeFilter() throws Exception {
-        var processCreationEndpoint = getMockEndpoint("mock:direct-vm:process.creation");
+        var processCreationEndpoint = getMockEndpoint("mock:direct:process.creation");
         processCreationEndpoint.expectedMessageCount(0);
 
         createContext(PROCESS_ENHANCEMENT_ROUTE);
@@ -305,7 +305,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testUpdateNonBinary() throws Exception {
-        var filterLongleafEndpoint = getMockEndpoint("mock:direct-vm:filter.longleaf");
+        var filterLongleafEndpoint = getMockEndpoint("mock:direct:filter.longleaf");
         filterLongleafEndpoint.expectedMessageCount(0);
         var processCreationEndpoint = getMockEndpoint("mock:direct:process.creation");
         processCreationEndpoint.expectedMessageCount(0);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrRouterTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/solr/SolrRouterTest.java
@@ -30,7 +30,7 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  */
 public class SolrRouterTest extends CamelSpringTestSupport {
     @PropertyInject(value = "fcrepo.baseUri")
-    private static String baseUri;
+    private String baseUri;
 
     @EndpointInject("mock:fcrepo")
     private MockEndpoint resultEndpoint;
@@ -63,7 +63,7 @@ public class SolrRouterTest extends CamelSpringTestSupport {
         context.start();
     }
 
-    private static Map<String, Object> createEvent() {
+    private Map<String, Object> createEvent() {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(EVENT_TYPE, "ResourceCreation");
         headers.put(IDENTIFIER, "original_file");

--- a/services-camel-app/src/test/resources/cdr-event-routing-it-config.properties
+++ b/services-camel-app/src/test/resources/cdr-event-routing-it-config.properties
@@ -29,10 +29,10 @@ solr.port=:8983
 solr.context=solr
 
 # The camel URI for the incoming message stream.
-fcrepo.stream=direct-vm:meta.start
+fcrepo.stream=direct:meta.start
 
 # Input stream to route to fcrepo-triplestore-router without having to override the fcrepo-camel-toolbox code
-input.stream=direct-vm:index.start
+input.stream=direct:index.start
 
 # The URI for the incoming CDR message stream
 cdr.stream=activemq:queue:repository.events

--- a/services-camel-app/src/test/resources/config.properties
+++ b/services-camel-app/src/test/resources/config.properties
@@ -30,32 +30,32 @@ solr.port=:8983
 solr.context=solr
 
 # The camel URI for the incoming message stream.
-fcrepo.stream=direct-vm:meta.start
+fcrepo.stream=direct:meta.start
 
 # Input stream to route to fcrepo-triplestore-router without having to override the fcrepo-camel-toolbox code
-input.stream=direct-vm:index.start
+input.stream=direct:index.start
 
 # The URI for the incoming CDR message stream
-cdr.stream=direct-vm:index.start
-cdr.stream.camel=direct-vm:index.start
+cdr.stream=direct:index.start
+cdr.stream.camel=direct:index.start
 
-cdr.solrupdate.stream=direct-vm:index.start
-cdr.solrupdate.stream.camel=direct-vm:index.start
+cdr.solrupdate.stream=direct:index.start
+cdr.solrupdate.stream.camel=direct:index.start
 
-cdr.triplesupdate.stream=direct-vm:index.start
-cdr.triplesupdate.stream.camel=direct-vm:index.start
+cdr.triplesupdate.stream=direct:index.start
+cdr.triplesupdate.stream.camel=direct:index.start
 
-cdr.destroy.stream=direct-vm:index.start
-cdr.destroy.stream.camel=direct-vm:index.start
+cdr.destroy.stream=direct:index.start
+cdr.destroy.stream.camel=direct:index.start
 
-cdr.destroy.post.stream=direct-vm:index.start.post
-cdr.destroy.post.stream.camel=direct-vm:index.start.post
+cdr.destroy.post.stream=direct:index.start.post
+cdr.destroy.post.stream.camel=direct:index.start.post
 
-cdr.destroy.derivatives.stream=direct-vm:index.start
-cdr.destroy.derivatives.stream.camel=direct-vm:index.start
+cdr.destroy.derivatives.stream=direct:index.start
+cdr.destroy.derivatives.stream.camel=direct:index.start
 
-cdr.enhancement.stream=direct-vm:repository.enhancements
-cdr.enhancement.stream.camel=direct-vm:repository.enhancements
+cdr.enhancement.stream=direct:repository.enhancements
+cdr.enhancement.stream.camel=direct:repository.enhancements
 
 cdr.ordermembers.stream=direct:ordermembers
 cdr.ordermembers.stream.camel=direct:ordermembers

--- a/services-camel-app/src/test/resources/enhancement-router-it-config.properties
+++ b/services-camel-app/src/test/resources/enhancement-router-it-config.properties
@@ -30,10 +30,10 @@ solr.port=:8983
 solr.context=solr
 
 # The camel URI for the incoming message stream.
-fcrepo.stream=direct-vm:meta.start
+fcrepo.stream=direct:meta.start
 
 # Input stream to route to fcrepo-triplestore-router without having to override the fcrepo-camel-toolbox code
-input.stream=direct-vm:index.start
+input.stream=direct:index.start
 
 # The URI for the incoming CDR message stream
 cdr.stream=activemq:queue:repository.events

--- a/services-camel-app/src/test/resources/spring-test/jms-context.xml
+++ b/services-camel-app/src/test/resources/spring-test/jms-context.xml
@@ -24,6 +24,9 @@
     <bean id="activemq"
         class="org.apache.camel.component.activemq.ActiveMQComponent">
         <property name="configuration" ref="jmsConfig" />
+        <property name="headerFilterStrategy">
+            <bean class="org.apache.camel.component.jms.ClassicJmsHeaderFilterStrategy"/>
+        </property>
     </bean>
 
     <!-- JMS ConnectionFactory to use, configuring the embedded broker using 

--- a/services-camel-app/src/test/resources/triples-reindexing-it-config.properties
+++ b/services-camel-app/src/test/resources/triples-reindexing-it-config.properties
@@ -8,7 +8,7 @@ error.backOffMultiplier=1
 
 indexing.predicate=false
 
-input.stream=direct-vm:index.start
+input.stream=direct:index.start
 
 cdr.triplesupdate.stream=activemq:queue:repository.triplesupdate?asyncConsumer=true
 cdr.triplesupdate.stream.camel=activemq://activemq:queue:repository.triplesupdate

--- a/spoof/src/main/webapp/WEB-INF/web.xml
+++ b/spoof/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    metadata-complete="true"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
     
     <display-name>Spoof</display-name>
     

--- a/static/js/vue-cdr-access/src/components/searchWrapper.vue
+++ b/static/js/vue-cdr-access/src/components/searchWrapper.vue
@@ -129,7 +129,7 @@ Top level component wrapper for search pages
                 let search_path = 'searchJson';
                 this.collection = this.routeHasPathId ? this.$route.path.split('/')[2] : '';
 
-                get(`api/${search_path}/${param_string}`).then((response) => {
+                get(`api/${search_path}${param_string}`).then((response) => {
                     this.emptyJsonResponseCheck(response);
                     this.records = response.data.metadata;
                     this.total_records = response.data.resultCount;

--- a/static/js/vue-cdr-access/src/mixins/displayUtils.js
+++ b/static/js/vue-cdr-access/src/mixins/displayUtils.js
@@ -15,7 +15,7 @@ export default {
                 }
             }
             if (browse_type) {
-                return `/record/${id}/?browse_type=${browse_type}`;
+                return `/record/${id}?browse_type=${browse_type}`;
             } else {
                 return `/record/${id}`;
             }

--- a/static/js/vue-cdr-access/tests/unit/browseSort.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/browseSort.spec.js
@@ -61,7 +61,7 @@ describe('browseSort.vue', () => {
     });
 
     it("updates the url when the dropdown changes for browsing", async () => {
-        await router.push('/record/d77fd8c9-744b-42ab-8e20-5ad9bdf8194e/?collection_name=testCollection&sort=title,normal');
+        await router.push('/record/d77fd8c9-744b-42ab-8e20-5ad9bdf8194e?collection_name=testCollection&sort=title,normal');
         wrapper.findAll('option')[2].setSelected();
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.sort).toEqual('title,reverse');

--- a/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/displayWrapper.spec.js
@@ -86,7 +86,7 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameter for non admin set browse works only browse", async () => {
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?works_only=true');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=true');
         mountApp();
 
         wrapper.vm.getBriefObject();
@@ -96,7 +96,7 @@ describe('displayWrapper.vue', () => {
     });
 
     it("uses the correct search parameters for non admin works only browse",  async () => {
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?works_only=false');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?works_only=false');
         mountApp();
 
         wrapper.vm.getBriefObject();
@@ -304,7 +304,7 @@ describe('displayWrapper.vue', () => {
                 'resourceType': 'AdminUnit',
                 'markedForDeletion': false
             });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?browse_type=list-display');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?browse_type=list-display');
         mountApp();
         await flushPromises();
 
@@ -324,7 +324,7 @@ describe('displayWrapper.vue', () => {
 
     it("shows a 'not found' message if no data is returned", async () => {
         stubQueryResponse(`/api/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/json`, '');
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a/?browse_type=list-display');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6a?browse_type=list-display');
         mountApp();
 
         await wrapper.vm.getBriefObject()
@@ -336,7 +336,7 @@ describe('displayWrapper.vue', () => {
             status: 404,
             response: JSON.stringify({ message: 'Nothing to see here' })
         });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6b/?browse_type=list-display');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6b?browse_type=list-display');
         mountApp();
 
         await wrapper.vm.getBriefObject()
@@ -348,7 +348,7 @@ describe('displayWrapper.vue', () => {
             status: 503,
             response: JSON.stringify({ message: 'bad stuff happened' })
         });
-        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6b/?browse_type=list-display');
+        await router.push('/record/73bc003c-9603-4cd9-8a65-93a22520ef6b?browse_type=list-display');
         mountApp();
         await wrapper.vm.getBriefObject();
         expect(wrapper.findComponent({ name: 'notAvailable' }).exists()).toBe(true);

--- a/static/js/vue-cdr-access/tests/unit/facetModal.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/facetModal.spec.js
@@ -87,7 +87,7 @@ describe('modalMetadata.vue', () => {
     });
 
     it("it appends some current url params, if present", async () => {
-        const route = '/search/?start=0&rows=20&sort=default,normal&' +
+        const route = '/search?start=0&rows=20&sort=default,normal&' +
             'facetSelect=createdYear,format,genre,language,subject,location,creatorContributor,publisher&' +
             'works_only=false&browse_type=gallery-display&types=Work,Folder,Collection,File';
         await router.push(route);

--- a/static/js/vue-cdr-access/tests/unit/facets.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/facets.spec.js
@@ -199,7 +199,7 @@ describe('facets.vue', () => {
     });
 
     it("does not display slider/form for 'Date Created' facet if unknown is set", async () => {
-        await router.push('/search/?createdYear=unknown');
+        await router.push('/search?createdYear=unknown');
 
         let facet_headers = wrapper.findAll('.facet-display h3');
 
@@ -364,7 +364,7 @@ describe('facets.vue', () => {
     });
 
     it("displays a listing of selected facets", async () => {
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         selected_facet.trigger('click');
         await flushPromises();
         let format_facets = listFacetEntries('format')
@@ -393,7 +393,7 @@ describe('facets.vue', () => {
     });
 
     it("clears a selected facet if it is unchecked", async () => {
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         // Add facet
         selected_facet.trigger('click');
         await flushPromises();
@@ -414,7 +414,7 @@ describe('facets.vue', () => {
         expect(wrapper.vm.$router.currentRoute.value.query.format).toBe(undefined);
 
         // Add facet
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         selected_facet.trigger('click');
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.format).toEqual('Image');
@@ -422,7 +422,7 @@ describe('facets.vue', () => {
 
     it("updates the query parameters if a facet is removed", async () => {
         // Add facet
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         selected_facet.trigger('click');
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.format).toEqual('Image');
@@ -437,12 +437,12 @@ describe('facets.vue', () => {
     });
 
     it("updates facet display for a collection", async () => {
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         expect(wrapper.vm.selected_facets).toEqual(['collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e']);
     });
 
     it("accepts multiple facets", async () => {
-        await router.push('/search/?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
+        await router.push('/search?collection=d77fd8c9-744b-42ab-8e20-5ad9bdf8194e');
         collection.trigger('click');
         await flushPromises();
         selected_facet.trigger('click');
@@ -462,7 +462,7 @@ describe('facets.vue', () => {
     });
 
     it("sets selected facets, including multiple from same facet, if the page is reloaded", async () => {
-        await router.push('/search/?format=Image%257C%257CText');
+        await router.push('/search?format=Image%257C%257CText');
         await flushPromises();
         expect(wrapper.vm.selected_facets).toEqual(['format=Image||Text']);
         let format_facets = listFacetEntries('format');
@@ -485,7 +485,7 @@ describe('facets.vue', () => {
     });
 
     it("sets the 'created date' picker values from the url", async () => {
-        await router.push('/search/?createdYear=2019,2021');
+        await router.push('/search?createdYear=2019,2021');
         await flushPromises();
 
         expect(wrapper.vm.selected_facets).toEqual(['createdYear=2019,2021']);
@@ -554,7 +554,7 @@ describe('facets.vue', () => {
         store = useAccessStore();
 
         moxios.wait(async () => {
-            await router.push('/search/?createdYear=unknown');
+            await router.push('/search?createdYear=unknown');
 
             let facet_headers = wrapper.findAll('.facet-display h3');
             expect(facet_headers[1].text()).toBe('Date Created');

--- a/static/js/vue-cdr-access/tests/unit/galleryDisplay.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/galleryDisplay.spec.js
@@ -53,14 +53,14 @@ describe('galleryDisplay.vue', () => {
         expect(first_cell.find('.record-title').text()).toEqual('Test Collection');
         let first_thumbnail = first_cell.find('thumbnail-stub');
         expect(first_thumbnail.exists()).toBe(true);
-        expect(first_thumbnail.attributes('linktourl')).toEqual('/record/dd8890d6-5756-4924-890c-48bc54e3edda/?browse_type=gallery-display');
+        expect(first_thumbnail.attributes('linktourl')).toEqual('/record/dd8890d6-5756-4924-890c-48bc54e3edda?browse_type=gallery-display');
         expect(first_thumbnail.attributes('size')).toEqual('large');
 
         let last_cell = cells[7];
         expect(last_cell.find('.record-title').text()).toEqual('Test Collection 2');
         let last_thumbnail = last_cell.find('thumbnail-stub');
         expect(last_thumbnail.exists()).toBe(true);
-        expect(last_thumbnail.attributes('linktourl')).toEqual('/record/87f54f12-5c50-4a14-bf8c-66cf64b00533/?browse_type=gallery-display');
+        expect(last_thumbnail.attributes('linktourl')).toEqual('/record/87f54f12-5c50-4a14-bf8c-66cf64b00533?browse_type=gallery-display');
         expect(last_thumbnail.attributes('size')).toEqual('large');
     });
 });

--- a/static/js/vue-cdr-access/tests/unit/searchWrapper.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/searchWrapper.spec.js
@@ -163,7 +163,7 @@ describe('searchWrapper.vue', () => {
     });
 
     it("displays facets if facets but no results", (done) => {
-        moxios.stubRequest(`api/searchJson/?anywhere=&getFacets=true`, {
+        moxios.stubRequest(`api/searchJson?anywhere=&getFacets=true`, {
             status: 200,
             response: JSON.stringify(facets_no_results)
         });
@@ -177,7 +177,7 @@ describe('searchWrapper.vue', () => {
 
     it("does not display facets if there are no facets and no results", (done) => {
         wrapper.vm.retrieveData();
-        moxios.stubRequest(`api/searchJson/?anywhere=&getFacets=true`, {
+        moxios.stubRequest(`api/searchJson?anywhere=&getFacets=true`, {
             status: 200,
             response: JSON.stringify(no_results)
         });
@@ -197,7 +197,7 @@ describe('searchWrapper.vue', () => {
     });
 
     it("displays a 'page not found' message if JSON response is an empty", (done) => {
-        moxios.stubRequest(`api/searchJson/?anywhere=&getFacets=true`, {
+        moxios.stubRequest(`api/searchJson?anywhere=&getFacets=true`, {
             status: 200,
             response: JSON.stringify('')
         });
@@ -210,7 +210,7 @@ describe('searchWrapper.vue', () => {
     });
 
     it("displays a '503 page' if JSON responds with an error", (done) => {
-        moxios.stubRequest(`api/searchJson/?anywhere=&getFacets=true`, {
+        moxios.stubRequest(`api/searchJson?anywhere=&getFacets=true`, {
             status: 503,
             response: JSON.stringify({ message: 'bad stuff happened' })
         });
@@ -230,7 +230,7 @@ describe('searchWrapper.vue', () => {
 });
 
 function loadFullData() {
-    moxios.stubRequest(`api/searchJson/?anywhere=&getFacets=true`, {
+    moxios.stubRequest(`api/searchJson?anywhere=&getFacets=true`, {
         status: 200,
         response: JSON.stringify(response)
     });

--- a/static/js/vue-cdr-access/tests/unit/viewType.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/viewType.spec.js
@@ -47,7 +47,7 @@ describe('viewType.vue', () => {
     });
 
     it("sets a browse type when clicked", async () => {
-        await router.push('/record/1234/?browse_type=list-display');
+        await router.push('/record/1234?browse_type=list-display');
         await btns[1].trigger('click');
         await flushPromises();
         expect(wrapper.vm.$router.currentRoute.value.query.browse_type).toEqual(encodeURIComponent('gallery-display'));
@@ -58,7 +58,7 @@ describe('viewType.vue', () => {
     });
 
     it("sets the browse type in sessionStorage when clicked", async () => {
-        await router.push('/record/1234/?browse_type=list-display');
+        await router.push('/record/1234?browse_type=list-display');
         const KEY = 'browse-type';
         await btns[1].trigger('click');
         await flushPromises();
@@ -83,10 +83,10 @@ describe('viewType.vue', () => {
     });
 
     it("sets browse_type from url, if present", async () => {
-        await router.push('/record/1234/?browse_type=list-display');
+        await router.push('/record/1234?browse_type=list-display');
         expect(wrapper.vm.browse_type).toEqual('list-display');
 
-        await router.push('/record/1234/?browse_type=gallery-display');
+        await router.push('/record/1234?browse_type=gallery-display');
         expect(wrapper.vm.browse_type).toEqual('gallery-display');
     });
 });

--- a/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
@@ -48,7 +48,7 @@ describe('worksOnly.vue', () => {
     });
 
     it("updates route to only show works if button is checked for a gallery view",  async () => {
-        await router.push('/record/1234/?browse_type=gallery-display');
+        await router.push('/record/1234?browse_type=gallery-display');
         await wrapper.setData({ works_only: false });
         await record_input.trigger('click');
         await flushPromises();
@@ -56,7 +56,7 @@ describe('worksOnly.vue', () => {
     });
 
     it("updates route to only show works and folders if button is unchecked for a gallery view", async  () => {
-        await router.push('/record/1234/?browse_type=gallery-display');
+        await router.push('/record/1234?browse_type=gallery-display');
         await wrapper.setData({ works_only: true });
         await record_input.trigger('click');
         await flushPromises();
@@ -65,7 +65,7 @@ describe('worksOnly.vue', () => {
     });
 
     it("updates route to only show works if button is checked for a list view", async() => {
-        await router.push('/record/1234/?browse_type=list-display');
+        await router.push('/record/1234?browse_type=list-display');
         await wrapper.setData({ works_only: false });
         await record_input.trigger('click');
         await flushPromises();
@@ -74,7 +74,7 @@ describe('worksOnly.vue', () => {
     });
 
     it("updates route to show works and folders if button is unchecked for a list view", async () => {
-        await router.push('/record/1234/?browse_type=list-display');
+        await router.push('/record/1234?browse_type=list-display');
         await wrapper.setData({ works_only: true });
         await record_input.trigger('click');
         await flushPromises();

--- a/web-access-app/src/main/webapp/WEB-INF/web.xml
+++ b/web-access-app/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    metadata-complete="true"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>DCR Access</display-name>
 

--- a/web-admin-app/src/main/webapp/WEB-INF/web.xml
+++ b/web-admin-app/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    metadata-complete="true"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 
     <display-name>DCR Administrative Interface</display-name>
 
@@ -39,6 +38,12 @@
             <param-name>contextConfigLocation</param-name>
             <param-value>/WEB-INF/uiapp-servlet.xml</param-value>
         </init-param>
+
+        <multipart-config>
+            <max-file-size>2000000000</max-file-size>
+            <max-request-size>2000000000</max-request-size>
+            <file-size-threshold>0</file-size-threshold>
+        </multipart-config>
     </servlet>
 
     <servlet-mapping>

--- a/web-services-app/pom.xml
+++ b/web-services-app/pom.xml
@@ -195,10 +195,6 @@
             <artifactId>solr-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq.tooling</groupId>
-            <artifactId>activemq-junit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DepositController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DepositController.java
@@ -271,7 +271,7 @@ public class DepositController {
 
     @RequestMapping(value = { "{stateOrUUID}", "/{stateOrUUID}" }, method = RequestMethod.GET)
     public @ResponseBody
-    Map<String, Object> get(@PathVariable String stateOrUUID) {
+    Map<String, Object> get(@PathVariable("stateOrUUID") String stateOrUUID) {
         DepositState depositState = null;
         try {
             depositState = DepositState.valueOf(stateOrUUID);
@@ -293,7 +293,7 @@ public class DepositController {
      * @param uuid
      */
     @RequestMapping(value = { "{uuid}", "/{uuid}" }, method = RequestMethod.DELETE)
-    public void destroy(@PathVariable String uuid) {
+    public void destroy(@PathVariable("uuid") String uuid) {
         // verify deposit is registered and not yet cleaned up
         // set deposit status to canceling
     }
@@ -310,7 +310,7 @@ public class DepositController {
      *           the action to take on the deposit (pause, resume, cancel, destroy)
      */
     @RequestMapping(value = { "{uuid}", "/{uuid}" }, method = RequestMethod.POST)
-    public void update(@PathVariable String uuid, @RequestParam(required = true) String action,
+    public void update(@PathVariable("uuid") String uuid, @RequestParam("action") String action,
             HttpServletResponse response) {
         DepositAction actionRequested = DepositAction.valueOf(action);
         if (actionRequested == null) {
@@ -373,7 +373,7 @@ public class DepositController {
 
     @RequestMapping(value = { "{uuid}/jobs", "/{uuid}/jobs" }, method = RequestMethod.GET)
     public @ResponseBody
-    Map<String, Map<String, String>> getJobs(@PathVariable String uuid) {
+    Map<String, Map<String, String>> getJobs(@PathVariable("uuid") String uuid) {
         LOG.debug("getJobs( {} )", uuid);
         try (Jedis jedis = getJedisPool().getResource()) {
             Map<String, Map<String, String>> jobs = new HashMap<>();
@@ -395,7 +395,7 @@ public class DepositController {
 
     @RequestMapping(value = { "{uuid}/events" }, method = RequestMethod.GET)
     public @ResponseBody
-    Document getEvents(@PathVariable String uuid) throws Exception {
+    Document getEvents(@PathVariable("uuid") String uuid) throws Exception {
         LOG.debug("getEvents( {} )", uuid);
         String bagDirectory;
         try (Jedis jedis = getJedisPool().getResource()) {

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DepositPipelineController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DepositPipelineController.java
@@ -77,7 +77,7 @@ public class DepositPipelineController {
      *      or an invalid action was requested
      */
     @PostMapping( path = { "{actionName}", "/{actionName}" }, produces = APPLICATION_JSON_VALUE )
-    public @ResponseBody ResponseEntity<Object> requestAction(@PathVariable String actionName) {
+    public @ResponseBody ResponseEntity<Object> requestAction(@PathVariable("actionName") String actionName) {
         AccessGroupSet principals = getAgentPrincipals().getPrincipals();
         if (!globalPermissionEvaluator.hasGlobalPermission(principals, Permission.createAdminUnit)) {
             return new ResponseEntity<>(singletonMap(ERROR_KEY, "Unauthorized"), HttpStatus.UNAUTHORIZED);

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvController.java
@@ -9,6 +9,7 @@ import edu.unc.lib.boxc.web.services.processing.ExportCsvService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.PathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -46,21 +47,22 @@ public class ExportCsvController extends AbstractSolrSearchController {
         var pids = getPids(pidList);
 
         try {
+
             String filename = "export.csv";
-            response.addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
-            response.addHeader("Content-Type", "text/csv");
-
-            exportCsvService.streamCsv(pids, getAgentPrincipals(), response.getOutputStream());
-
-            response.setStatus(HttpStatus.OK.value());
+            var csvPath = exportCsvService.exportCsv(pids, getAgentPrincipals());
+            PathResource pathResource = new PathResource(csvPath);
+            return ResponseEntity.ok()
+                    .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+                    .header("Content-Type", "text/csv")
+                    .body(pathResource);
         } catch (NotFoundException e) {
             log.warn("Object not found: {}", e.getMessage());
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (RepositoryException | IOException e) {
+        } catch (RepositoryException e) {
             log.error("Error exporting CSV: {}", e.getMessage());
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return null;
+
     }
 
     private List<PID> getPids(List<String> pidStrings){

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ViewSettingController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ViewSettingController.java
@@ -78,7 +78,7 @@ public class ViewSettingController {
 
     @PutMapping(value = "/edit/viewSettings", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity<Object> updateViewSetting(@RequestParam("allParams") Map<String,String> allParams) {
+    public ResponseEntity<Object> updateViewSetting(@RequestParam Map<String,String> allParams) {
         Map<String, Object> result = new HashMap<>();
 
         if (hasBadParams(allParams)) {

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ViewSettingController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/modify/ViewSettingController.java
@@ -78,7 +78,7 @@ public class ViewSettingController {
 
     @PutMapping(value = "/edit/viewSettings", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
-    public ResponseEntity<Object> updateViewSetting(@RequestParam Map<String,String> allParams) {
+    public ResponseEntity<Object> updateViewSetting(@RequestParam("allParams") Map<String,String> allParams) {
         Map<String, Object> result = new HashMap<>();
 
         if (hasBadParams(allParams)) {

--- a/web-services-app/src/main/webapp/WEB-INF/web.xml
+++ b/web-services-app/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_3_0.xsd"
-    version="3.0" xmlns="https://jakarta.ee/xml/ns/jakartaee">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
     <display-name>DCR Services Web Application</display-name>
 
     <listener>
@@ -25,6 +26,12 @@
             <param-name>contextConfigLocation</param-name>
             <param-value>/WEB-INF/rest-servlet.xml</param-value>
         </init-param>
+
+        <multipart-config>
+            <max-file-size>2000000000</max-file-size>
+            <max-request-size>2000000000</max-request-size>
+            <file-size-threshold>0</file-size-threshold>
+        </multipart-config>
     </servlet>
 
     <servlet-mapping>

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvIT.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/modify/ExportCsvIT.java
@@ -442,7 +442,7 @@ public class ExportCsvIT extends AbstractAPIIT {
 
         String id = collPid.getId();
 
-        MvcResult result = mvc.perform(get("/exportTree/csv/?ids=" + id))
+        MvcResult result = mvc.perform(get("/exportTree/csv?ids=" + id))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-4999

* Update to activemq 6, remove some unused activemq dependencies.
* "direct-vm:" doesn't exist for camel routing anymore, using "direct:" instead
* Spring is stricter about controller paths like `searchJson/?param=value` now, they will at least fail to be found in tests, maybe in live applications to. So switched most instances of "/?" to just "?"
* Explicitly set name of parameters in controller methods in the few places we weren't already, since assuming the names of parameters is not done by default anymore and would require additional build configuration
* Refactor ExportCsv service and controller to write csv to a file and then pass it back to the user as a Resource. This is because spring 6 appears to be stricter about setting http status after the response body has started to be written to, which caused tests to fail
* Set Classic header filter strategy, otherwise camel 4 removes all headers that begin with Camel*, which includes all fcrepo-camel headers. Hopefully this will get addressed in future versions of fcrepo-camel.

Note: this PR gets the build passing and web applications running at least to a minimally functional extent