### PR TITLE
BXC-5156 - Correct fedora headers when processing fedora stream

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraHeadersProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraHeadersProcessor.java
@@ -1,0 +1,43 @@
+package edu.unc.lib.boxc.services.camel.routing;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.fcrepo.camel.FcrepoHeaders;
+import org.slf4j.Logger;
+
+/**
+ * Processor which ensures fedora related headers are
+ *
+ * @author bbpennel
+ */
+public class FedoraHeadersProcessor implements Processor {
+    private static final Logger log = getLogger(FedoraHeadersProcessor.class);
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        var msg = exchange.getIn();
+        // Replace fedora:description with fcr:metadata if it appears in the identifier
+        String identifier = msg.getHeader(FcrepoJmsConstants.IDENTIFIER, String.class);
+        if (identifier != null && identifier.contains("fedora:description")) {
+            log.debug("Replacing fedora:description with fcr:metadata in identifier {}", identifier);
+            identifier = identifier.replace("fedora:description", RepositoryPathConstants.FCR_METADATA);
+            msg.setHeader(FcrepoJmsConstants.IDENTIFIER, identifier);
+        }
+        // Ensure that the CamelFcrepoUri header is set
+
+        String fcrepoUri = msg.getHeader(FcrepoHeaders.FCREPO_URI, String.class);
+        if (fcrepoUri == null) {
+            String fcrepoBaseUrl = msg.getHeader(FcrepoJmsConstants.BASE_URL, String.class);
+            if (fcrepoBaseUrl == null || identifier == null) {
+                return;
+            }
+            msg.setHeader(FCREPO_URI, fcrepoBaseUrl + identifier);
+        }
+    }
+}

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraIdFilters.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/FedoraIdFilters.java
@@ -1,7 +1,6 @@
 package edu.unc.lib.boxc.services.camel.routing;
 
 import static edu.unc.lib.boxc.model.api.rdf.Fcrepo4Repository.Binary;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.regex.Pattern;

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/routing/MetaServicesRouter.java
@@ -1,7 +1,11 @@
 package edu.unc.lib.boxc.services.camel.routing;
 
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.slf4j.LoggerFactory.getLogger;
 
+import edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants;
+import edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
 import org.apache.camel.BeanInject;
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
@@ -9,6 +13,7 @@ import org.apache.camel.Processor;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.http.HttpStatus;
+import org.apache.jena.sparql.function.library.leviathan.log;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.slf4j.Logger;
 
@@ -33,6 +38,8 @@ public class MetaServicesRouter extends RouteBuilder {
     @PropertyInject("cdr.enhancement.processingThreads")
     private Integer enhancementThreads;
 
+    private FedoraHeadersProcessor fedoraHeadersProcessor = new FedoraHeadersProcessor();
+
     @Override
     public void configure() throws Exception {
         onException(Exception.class)
@@ -44,23 +51,21 @@ public class MetaServicesRouter extends RouteBuilder {
         from("{{fcrepo.stream}}")
             .routeId("CdrMetaServicesRouter")
             .startupOrder(9)
+            .process(fedoraHeadersProcessor)
             .filter().method(FedoraIdFilters.class, "allowedForTripleIndex")
             .doTry()
                 .wireTap("direct:index.start")
             .endDoTry()
             .doCatch(FcrepoOperationFailedException.class)
-                .process(new Processor() {
-                    @Override
-                    public void process(Exchange exchange) throws Exception {
-                        FcrepoOperationFailedException ex = exchange.getProperty(Exchange.EXCEPTION_CAUGHT,
-                                FcrepoOperationFailedException.class);
-                        if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                            log.warn("Ignoring exception {} for {}", ex.getStatusText(),
-                                    exchange.getIn().getHeader("org.fcrepo.jms.identifier"));
-                            exchange.setProperty(Exchange.ROUTE_STOP, Boolean.TRUE);
-                        } else {
-                            throw ex;
-                        }
+                .process(exchange -> {
+                    FcrepoOperationFailedException ex = exchange.getProperty(Exchange.EXCEPTION_CAUGHT,
+                            FcrepoOperationFailedException.class);
+                    if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                        log.warn("Ignoring exception {} for {}", ex.getStatusText(),
+                                exchange.getIn().getHeader("org.fcrepo.jms.identifier"));
+                        exchange.setProperty(Exchange.ROUTE_STOP, Boolean.TRUE);
+                    } else {
+                        throw ex;
                     }
                 })
             .end()

--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/MessageUtil.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/util/MessageUtil.java
@@ -60,10 +60,10 @@ public class MessageUtil {
      * @return
      */
     public static String getFcrepoUri(Message msg) {
-        String fcrepoUri = (String) msg.getHeader(FcrepoHeaders.FCREPO_URI);
+        String fcrepoUri = msg.getHeader(FcrepoHeaders.FCREPO_URI, String.class);
         if (fcrepoUri == null) {
-            String fcrepoId = (String) msg.getHeader(FcrepoJmsConstants.IDENTIFIER);
-            String fcrepoBaseUrl = (String) msg.getHeader(FcrepoJmsConstants.BASE_URL);
+            String fcrepoId = msg.getHeader(FcrepoJmsConstants.IDENTIFIER, String.class);
+            String fcrepoBaseUrl = msg.getHeader(FcrepoJmsConstants.BASE_URL, String.class);
             if (fcrepoBaseUrl == null || fcrepoId == null) {
                 return null;
             }

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/FedoraHeadersProcessorTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/routing/FedoraHeadersProcessorTest.java
@@ -1,0 +1,98 @@
+package edu.unc.lib.boxc.services.camel.routing;
+
+import static edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants.BASE_URL;
+import static edu.unc.lib.boxc.fcrepo.FcrepoJmsConstants.IDENTIFIER;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants;
+import edu.unc.lib.boxc.services.camel.util.MessageUtil;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class FedoraHeadersProcessorTest {
+    private static final String TEST_BASE_URI = "http://example.com/rest";
+
+    @Mock
+    private Exchange exchange;
+
+    @Mock
+    private Message message;
+
+    private FedoraHeadersProcessor processor;
+
+    @BeforeEach
+    public void setUp() {
+        processor = new FedoraHeadersProcessor();
+        when(exchange.getIn()).thenReturn(message);
+    }
+
+    @Test
+    public void testProcessReplaceFedoraDescription() throws Exception {
+        String baseIdentifier = "/content/43/e2/27/ac/43e227ac-983a-4a18-94c9-c9cff8d28441/";
+        String originalIdentifier = baseIdentifier + "fedora:description";
+        String expectedIdentifier = baseIdentifier + RepositoryPathConstants.FCR_METADATA;
+        String fcrepoUri = TEST_BASE_URI + expectedIdentifier;
+
+        when(message.getHeader(FCREPO_URI, String.class)).thenReturn(null);
+        when(message.getHeader(IDENTIFIER, String.class)).thenReturn(originalIdentifier);
+        when(message.getHeader(BASE_URL, String.class)).thenReturn(TEST_BASE_URI);
+
+        processor.process(exchange);
+
+        verify(message).setHeader(IDENTIFIER, expectedIdentifier);
+        verify(message).setHeader(FCREPO_URI, fcrepoUri);
+    }
+
+    @Test
+    public void testProcessIdentifierWithoutFedoraDescription() throws Exception {
+        String identifier = "/content/43/e2/27/ac/43e227ac-983a-4a18-94c9-c9cff8d28441/original_file";
+        String fcrepoUri = TEST_BASE_URI + identifier;
+
+        when(message.getHeader(FCREPO_URI, String.class)).thenReturn(null);
+        when(message.getHeader(IDENTIFIER, String.class)).thenReturn(identifier);
+        when(message.getHeader(BASE_URL, String.class)).thenReturn(TEST_BASE_URI);
+
+        processor.process(exchange);
+
+        verify(message).setHeader(FCREPO_URI, fcrepoUri);
+    }
+
+    @Test
+    public void testProcessNullIdentifier() throws Exception {
+        when(message.getHeader(FCREPO_URI, String.class)).thenReturn(null);
+        when(message.getHeader(IDENTIFIER, String.class)).thenReturn(null);
+        when(message.getHeader(BASE_URL, String.class)).thenReturn(TEST_BASE_URI);
+
+        processor.process(exchange);
+
+        verify(message, never()).setHeader(eq(FCREPO_URI), anyString());
+    }
+
+    @Test
+    public void testProcessNullFcrepoUri() throws Exception {
+        String identifier = "/content/43/e2/27/ac/43e227ac-983a-4a18-94c9-c9cff8d28441/original_file";
+
+        when(message.getHeader(FCREPO_URI, String.class)).thenReturn(null);
+        when(message.getHeader(IDENTIFIER, String.class)).thenReturn(identifier);
+        when(message.getHeader(BASE_URL, String.class)).thenReturn(null);
+
+        processor.process(exchange);
+
+        verify(message, never()).setHeader(eq(FCREPO_URI), anyString());
+    }
+}


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5156

* Correct fedora:description in fedora uris in jms messages.
* Ensure that the fcrepo uri gets set on fedora messages