### PR TITLE
BXC-5746 - Fix Longleaf deregistation path

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/DeregisterLongleafProcessor.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/longleaf/DeregisterLongleafProcessor.java
@@ -84,7 +84,7 @@ public class DeregisterLongleafProcessor extends AbstractLongleafProcessor {
     private void deregisterFiles(List<String> messages, String deregList, int entryCount) {
         batchSizeHistogram.update(entryCount);
 
-        String requestUrl = URIUtil.join(longleafBaseUri, "api/deregister");
+        String requestUrl = URIUtil.join(longleafBaseUri, "deregister");
         Map<String, Object> bodyMap = Map.of(
                 "from_list", "@-",
                 "body", deregList);

--- a/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel-app/src/test/java/edu/unc/lib/boxc/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @WireMockTest
 public class DeregisterLongleafRouteTest extends AbstractLongleafRouteTest {
     private static final String FILTER_DEREGISTER_ENDPOINT = "direct:filter.longleaf.deregister";
-    private static final String DEREGISTER_PATH = "/api/deregister";
+    private static final String DEREGISTER_PATH = "/deregister";
 
     @EndpointInject("mock:direct:longleaf.dlq")
     private MockEndpoint mockDlq;


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5746

Fix deregister path so that it assumes the same base path as the register path