### PR TITLE
BXC-5761 - Remove extra solr lookup when getting thumbnails

### DIFF
--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DatastreamController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/DatastreamController.java
@@ -153,9 +153,11 @@ public class DatastreamController {
             throw new ResourceNotFoundException("The requested object either does not exist or is not accessible");
         }
 
+        var thumbObjRecord = objRecord;
         if (ResourceType.Work.name().equals(objRecord.getResourceType())) {
             var thumbRec = accessCopiesService.getThumbnailRecord(objRecord, principals, true);
             if (thumbRec != null) {
+                thumbObjRecord = thumbRec;
                 pid = thumbRec.getPid();
                 // check permissions for thumbnail file
                 accessControlService.assertHasAccess("Insufficient permissions to get thumbnail for " + pidString,
@@ -164,8 +166,6 @@ public class DatastreamController {
             }
         }
 
-        var thumbObjRequest = new SimpleIdRequest(pid, THUMB_QUERY_FIELDS, principals);
-        var thumbObjRecord = solrQueryLayerService.getObjectById(thumbObjRequest);
         var pixelSize = THUMB_SIZE_MAP.get(size).toString();
 
         try {

--- a/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DatastreamControllerTest.java
+++ b/web-services-app/src/test/java/edu/unc/lib/boxc/web/services/rest/DatastreamControllerTest.java
@@ -1,0 +1,106 @@
+package edu.unc.lib.boxc.web.services.rest;
+
+import edu.unc.lib.boxc.auth.api.services.AccessControlService;
+import edu.unc.lib.boxc.auth.fcrepo.models.AccessGroupSetImpl;
+import edu.unc.lib.boxc.auth.fcrepo.services.GroupsThreadStore;
+import edu.unc.lib.boxc.model.api.ResourceType;
+import edu.unc.lib.boxc.model.fcrepo.test.TestHelper;
+import edu.unc.lib.boxc.search.api.requests.SimpleIdRequest;
+import edu.unc.lib.boxc.search.solr.models.ContentObjectSolrRecord;
+import edu.unc.lib.boxc.search.solr.services.AccessCopiesService;
+import edu.unc.lib.boxc.web.common.services.SolrQueryLayerService;
+import edu.unc.lib.boxc.web.services.processing.DownloadImageService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+public class DatastreamControllerTest {
+    private static final String USERNAME = "test_user";
+    private static final AccessGroupSetImpl GROUPS = new AccessGroupSetImpl("adminGroup");
+
+    @InjectMocks
+    private DatastreamController controller;
+
+    @Mock
+    private SolrQueryLayerService solrQueryLayerService;
+    @Mock
+    private AccessControlService accessControlService;
+    @Mock
+    private AccessCopiesService accessCopiesService;
+    @Mock
+    private DownloadImageService downloadImageService;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    public void setup() {
+        closeable = openMocks(this);
+        GroupsThreadStore.storeUsername(USERNAME);
+        GroupsThreadStore.storeGroups(GROUPS);
+        TestHelper.setContentBase("http://localhost:48085/rest");
+    }
+
+    @AfterEach
+    void closeService() throws Exception {
+        GroupsThreadStore.clearStore();
+        closeable.close();
+    }
+
+    @Test
+    public void testGetThumbnailForFileReusesInitialSolrRecord() throws Exception {
+        var pid = TestHelper.makePid();
+        var fileRecord = new ContentObjectSolrRecord();
+        fileRecord.setId(pid.getId());
+        fileRecord.setResourceType(ResourceType.File.name());
+        ResponseEntity<Resource> response = ResponseEntity.ok(new ByteArrayResource(new byte[0]));
+
+        when(solrQueryLayerService.getObjectById(any(SimpleIdRequest.class))).thenReturn(fileRecord);
+        when(downloadImageService.streamThumbnail(fileRecord, "160")).thenReturn(response);
+
+        var result = controller.getThumbnail(pid.getId(), "small");
+
+        assertSame(response, result);
+        verify(solrQueryLayerService).getObjectById(any(SimpleIdRequest.class));
+        verify(accessCopiesService, never()).getThumbnailRecord(any(), any(), anyBoolean());
+        verify(downloadImageService).streamThumbnail(fileRecord, "160");
+    }
+
+    @Test
+    public void testGetThumbnailForWorkReusesThumbnailRecord() throws Exception {
+        var workPid = TestHelper.makePid();
+        var thumbPid = TestHelper.makePid();
+        var workRecord = new ContentObjectSolrRecord();
+        workRecord.setId(workPid.getId());
+        workRecord.setResourceType(ResourceType.Work.name());
+        var thumbRecord = new ContentObjectSolrRecord();
+        thumbRecord.setId(thumbPid.getId());
+        thumbRecord.setResourceType(ResourceType.File.name());
+        ResponseEntity<Resource> response = ResponseEntity.ok(new ByteArrayResource(new byte[0]));
+
+        when(solrQueryLayerService.getObjectById(any(SimpleIdRequest.class))).thenReturn(workRecord);
+        when(accessCopiesService.getThumbnailRecord(eq(workRecord), any(), eq(true))).thenReturn(thumbRecord);
+        when(downloadImageService.streamThumbnail(thumbRecord, "250")).thenReturn(response);
+
+        var result = controller.getThumbnail(workPid.getId(), "large");
+
+        assertSame(response, result);
+        verify(solrQueryLayerService).getObjectById(any(SimpleIdRequest.class));
+        verify(accessCopiesService).getThumbnailRecord(eq(workRecord), any(), eq(true));
+        verify(downloadImageService).streamThumbnail(thumbRecord, "250");
+    }
+}


### PR DESCRIPTION
Bonus fix that came up while looking at https://unclibrary.atlassian.net/browse/BXC-5761

For both file and work objects, the last solr lookup was unnecessary